### PR TITLE
Add repo SUMMARY and AGENTS reference

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -180,5 +180,10 @@ See `TASK_TEMPLATE.md` for the canonical input format.
 
 > Task entries that do not follow the template must be flagged by the Maintainer agent.
 
+## 8. Project Map
+
+All agents must consult `docs/SUMMARY.md` before exploring the repository. The file provides a high-level directory overview, dependency graph and keyboard map so agents can quickly locate the relevant components.
+The Maintainer agent ensures this summary is kept in sync after structural changes.
+
 
 > “Modularity means putting every idea in the right place—no more, no less.”

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -1,0 +1,59 @@
+# Project Summary – Wrecept
+
+## 1. Modules Overview
+
+| Module | Purpose | Layer | Owned by |
+|-------|---------|-------|---------|
+| `src/ViewModels` | View-model logic, MVVM glue | MVVM | CodeGen-CSharp |
+| `src/Views` | XAML views and dialogs | UI | CodeGen-XAML |
+| `src/Infrastructure` | EF Core repositories, settings, helpers | Persistence | CodeGen-CSharp |
+| `src/Services` | Application services and navigation | Domain/Service | CodeGen-CSharp |
+| `src/Themes` | Resource dictionaries for light/dark themes | Styling | CodeGen-XAML |
+| `src/Resources` | Localisation strings (hu/en) | Shared | CodeGen-XAML |
+| `src/Wrecept.Core.CoreLib` | Entities and repository interfaces | Core Library | CodeGen-CSharp |
+| `src/Wrecept.Core` | Default service implementations | Core Services | CodeGen-CSharp |
+| `src/Wrecept.Plugin.Greeting` | Sample IMenuPlugin implementation | Plugin | CodeGen-CSharp |
+| `tests` | xUnit and UI tests | QA | TestWriter |
+
+## 2. View Hierarchy
+
+```
+MainWindow
+ └── InvoiceEditorWindow
+       ├── InvoiceSidebar
+       ├── InvoiceHeader
+       ├── InvoiceItemsGrid
+       └── InvoiceSummary
+```
+Additional windows: `SettingsWindow`, `HelpWindow`, `AboutWindow`, lookup dialogs and filter dialogs.
+
+## 3. Dependencies
+
+```mermaid
+graph TD
+    UI --> ViewModels
+    ViewModels --> Services
+    Services --> Repositories
+    Repositories --> Entities
+```
+
+## 4. Keyboard Input Routing
+
+| Key Combo | Function | Handled in |
+|-----------|----------|-----------|
+| Ctrl+S | Save current invoice | `InvoiceEditorViewModel` |
+| Esc | Cancel / exit | `InvoiceEditorViewModel` and dialogs |
+| F1 | Help overlay | `HelpWindow` |
+| Tab | Field navigation | All views |
+| F2 or Ctrl+L | Open lookup dialogs | `InvoiceItemRowViewModel` |
+
+## 5. Task Mapping
+
+| Area | Agent | Reference Files |
+|------|-------|----------------|
+| New XAML layout | CodeGen-XAML | `src/Views/**`, `docs/themes.md` |
+| New ViewModel logic | CodeGen-CSharp | `src/ViewModels/**` |
+| UX flow review | ux_agent | `docs/ui_flow.md` |
+| Error message updates | DocWriter | `docs/user_manual_hu.md` |
+| Keyboard handling | CodeGen-CSharp | `InvoiceEditorWindow.xaml.cs`, `*ViewModel.cs` |
+

--- a/docs/progress/2025-06-27_17-48-05_DocWriter.md
+++ b/docs/progress/2025-06-27_17-48-05_DocWriter.md
@@ -1,0 +1,7 @@
+### Documentation updates
+*Timestamp:* 2025-06-27T17:48:05Z
+*Files touched:* docs/SUMMARY.md, AGENTS.md
+*Summary:* Added project overview and reference section
+*Details:*
+- Created SUMMARY.md with module, view and keyboard map
+- Referenced the file in AGENTS.md under new 'Project Map' section


### PR DESCRIPTION
## Summary
- add a new `SUMMARY.md` documentation file
- reference SUMMARY.md in AGENTS.md
- log the documentation update

## Testing
- `./setup.sh` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ed8f7aae483228eefa0e6e6f17c33