### PR TITLE
Fix missing DI usings in NavigationService

### DIFF
--- a/docs/progress/2025-06-27_18-23-12_CodeGen-CSharp.md
+++ b/docs/progress/2025-06-27_18-23-12_CodeGen-CSharp.md
@@ -1,0 +1,8 @@
+### Fix NavigationService usings
+*Timestamp:* 2025-06-27T18:23:12Z
+*Files touched:* src/Services/NavigationService.cs
+*Summary:* added missing using directives for DI and infrastructure
+*Details:*
+- Removed duplicate using
+- Added `Microsoft.Extensions.DependencyInjection` and `Wrecept.Infrastructure`
+- Programmatic checks fail due to missing WindowsDesktop targets

--- a/src/Services/NavigationService.cs
+++ b/src/Services/NavigationService.cs
@@ -6,7 +6,8 @@ using Wrecept.Core.Domain;
 using Wrecept.Core.Services;
 using Wrecept.ViewModels;
 using Wrecept.Core.Repositories;
-using Wrecept.Core.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Wrecept.Infrastructure;
 
 namespace Wrecept.Services;
 


### PR DESCRIPTION
## Summary
- add using Microsoft.Extensions.DependencyInjection
- add using Wrecept.Infrastructure
- remove duplicate using
- log progress

## Testing
- `dotnet build Wrecept.sln -c Release` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*
- `./setup.sh` *(fails: tests fail because WindowsDesktop targets missing)*

------
https://chatgpt.com/codex/tasks/task_e_685ee0f999d4832282a976880bc4c940