### PR TITLE
Fix analyzers and update async test

### DIFF
--- a/docs/progress/2025-06-27_18-27-05_CodeGen-CSharp.md
+++ b/docs/progress/2025-06-27_18-27-05_CodeGen-CSharp.md
@@ -1,0 +1,9 @@
+### Fix warnings and unit test
+*Timestamp:* 2025-06-27T18:27:05Z
+*Files touched:* src/ViewModels/InvoiceSidebarViewModel.cs, src/Infrastructure/SeedDataService.cs, src/Services/FeedbackService.cs, tests/ui_tests/InvoiceEditorEscFlowTests.cs
+*Summary:* addressed analyzer warnings and updated async test
+*Details:*
+- Guarded null selections in InvoiceSidebarViewModel
+- Replaced null-forgiving with explicit checks in SeedDataService
+- Added OS checks in FeedbackService to satisfy CA1416
+- Converted CancelByEsc test to async/await

--- a/src/Infrastructure/SeedDataService.cs
+++ b/src/Infrastructure/SeedDataService.cs
@@ -60,9 +60,12 @@ public static class SeedDataService
             {
                 Id = productId,
                 Name = "Teszt termék",
-                Group = await db.ProductGroups.FindAsync(groupId)!,
-                TaxRate = await db.TaxRates.FindAsync(vatId)!,
-                DefaultUnit = await db.Units.FindAsync(unitId)!
+                Group = await db.ProductGroups.FindAsync(groupId)
+                    ?? throw new InvalidOperationException("Group missing"),
+                TaxRate = await db.TaxRates.FindAsync(vatId)
+                    ?? throw new InvalidOperationException("VAT missing"),
+                DefaultUnit = await db.Units.FindAsync(unitId)
+                    ?? throw new InvalidOperationException("Unit missing")
             });
         }
         else
@@ -92,9 +95,11 @@ public static class SeedDataService
                 SerialNumber = "INV-001",
                 TransactionNumber = "TXN-001",
                 IssueDate = DateOnly.FromDateTime(DateTime.Today),
-                Supplier = await db.Suppliers.FindAsync(supplierId)!,
+                Supplier = await db.Suppliers.FindAsync(supplierId)
+                    ?? throw new InvalidOperationException("Supplier missing"),
                 CalculationMode = CalculationMode.Net,
-                PaymentMethod = await db.PaymentMethods.FindAsync(payId)!,
+                PaymentMethod = await db.PaymentMethods.FindAsync(payId)
+                    ?? throw new InvalidOperationException("Payment method missing"),
                 Notes = string.Empty
             });
         }
@@ -108,13 +113,16 @@ public static class SeedDataService
             var item = new InvoiceItem
             {
                 Id = Guid.NewGuid(),
-                Product = await db.Products.FindAsync(productId)!,
+                Product = await db.Products.FindAsync(productId)
+                    ?? throw new InvalidOperationException("Product missing"),
                 Quantity = 1,
-                Unit = await db.Units.FindAsync(unitId)!,
+                Unit = await db.Units.FindAsync(unitId)
+                    ?? throw new InvalidOperationException("Unit missing"),
                 UnitPriceNet = 100,
                 VatRatePercent = 27
             };
-            var invoice = await db.Invoices.FindAsync(invoiceId)!;
+            var invoice = await db.Invoices.FindAsync(invoiceId)
+                ?? throw new InvalidOperationException("Invoice missing");
             invoice.Items.Add(item);
             db.InvoiceItems.Add(item);
         }

--- a/src/Services/FeedbackService.cs
+++ b/src/Services/FeedbackService.cs
@@ -6,7 +6,11 @@ public class FeedbackService : IFeedbackService
 {
     private readonly Action<int, int> _beep;
 
-    public FeedbackService() : this(Console.Beep) { }
+    public FeedbackService() : this((f, d) =>
+    {
+        if (OperatingSystem.IsWindows())
+            Console.Beep(f, d);
+    }) { }
 
     public FeedbackService(Action<int, int> beep)
     {
@@ -29,7 +33,8 @@ public class FeedbackService : IFeedbackService
             }
             catch
             {
-                System.Media.SystemSounds.Beep.Play();
+                if (OperatingSystem.IsWindows())
+                    System.Media.SystemSounds.Beep.Play();
             }
         }
     }

--- a/src/ViewModels/InvoiceSidebarViewModel.cs
+++ b/src/ViewModels/InvoiceSidebarViewModel.cs
@@ -65,7 +65,7 @@ public partial class InvoiceSidebarViewModel : ObservableObject
         if (SelectedSupplier != null)
             query = query.Where(i => i.Supplier.Id == SelectedSupplier.Id);
         Invoices = new ObservableCollection<Invoice>(query);
-        if (!Invoices.Contains(SelectedInvoice))
+        if (SelectedInvoice == null || !Invoices.Contains(SelectedInvoice))
             SelectedInvoice = Invoices.FirstOrDefault();
     }
 }

--- a/tests/ui_tests/InvoiceEditorEscFlowTests.cs
+++ b/tests/ui_tests/InvoiceEditorEscFlowTests.cs
@@ -19,7 +19,7 @@ public class InvoiceEditorEscFlowTests
         public bool ConfirmExit() => false;
     }
     [Fact]
-    public void CancelByEsc_ShouldSetFlags()
+    public async Task CancelByEsc_ShouldSetFlags()
     {
         var service = new DefaultInvoiceService(new InMemoryInvoiceRepository());
         var dialog = new StubDialog { Result = true };
@@ -46,7 +46,7 @@ public class InvoiceEditorEscFlowTests
             new NavigationService(),
             true);
 
-        vm.CancelByEscAsync().GetAwaiter().GetResult();
+        await vm.CancelByEscAsync();
 
         Assert.True(vm.ExitRequested);
     }


### PR DESCRIPTION
## Summary
- handle null selection in `InvoiceSidebarViewModel`
- ensure seed data lookups throw when not found
- add OS guards in `FeedbackService`
- make cancel flow test async
- log progress

## Testing
- `bash setup.sh` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ee1e963cc8322b877306575f8d5ad