### PR TITLE
Add focus and accesskey tweaks

### DIFF
--- a/docs/progress/2025-06-27_19-06-44_CodeGen-XAML.md
+++ b/docs/progress/2025-06-27_19-06-44_CodeGen-XAML.md
@@ -1,0 +1,8 @@
+### UI focus and access keys
+*Timestamp:* 2025-06-27T19:06:44Z
+*Files touched:* src/Views/InvoiceParts/InvoiceSidebar.xaml, src/Views/InvoiceParts/InvoiceSidebar.xaml.cs, src/Views/InvoiceParts/InvoiceHeader.xaml
+*Summary:* Added starting focus and access key bindings
+*Details:*
+- Set `FocusManager.FocusedElement` to SearchBox
+- Changed focus on load to SearchBox
+- Added `AccessKeyManager.AccessKey` labels for key fields

--- a/docs/progress/2025-06-27_19-06-44_DocWriter.md
+++ b/docs/progress/2025-06-27_19-06-44_DocWriter.md
@@ -1,0 +1,7 @@
+### ui_flow keyboard clarifications
+*Timestamp:* 2025-06-27T19:06:44Z
+*Files touched:* docs/ui_flow.md
+*Summary:* Documented focus start and access key mapping
+*Details:*
+- Mentioned SearchBox initial focus via FocusManager
+- Listed Alt+N/P/D/T shortcuts

--- a/docs/progress/2025-06-27_19-06-44_TestWriter.md
+++ b/docs/progress/2025-06-27_19-06-44_TestWriter.md
@@ -1,0 +1,8 @@
+### Added UI regression stubs
+*Timestamp:* 2025-06-27T19:06:44Z
+*Files touched:* tests/ui_tests/InvoiceSidebarNavigationTests.cs, tests/ui_tests/KeyboardShortcutRefactorTest.cs, tests/ui_tests/DialogEnterEscTest.cs
+*Summary:* Introduced tests for navigation and dialog shortcuts
+*Details:*
+- New test to verify Up arrow new-invoice prompt
+- Deprecated shortcut checks using XAML strings
+- Enter/Escape behavior assertions for confirm dialog

--- a/docs/ui_flow.md
+++ b/docs/ui_flow.md
@@ -35,9 +35,10 @@
 ## Keyboard & focus logic
 
 1. A Tab sorrend: Sidebar kereső → Header mezők → ItemsGrid → Summary → alsó eszköztár.
-2. Minden új nézetre lépéskor a logikus első mező kap fókuszt, a lista ablak már nem igényel kézi átméretezést.
+2. Minden új nézetre lépéskor a logikus első mező (Sidebar kereső) kap fókuszt. A fókusz a `FocusManager.FocusedElement` beállítással indul a SearchBoxon.
 3. Ctrl+S mentésre, Esc az aktuális sor vagy ablak bezárására szolgál; Esc-sorozat esetén először a szerkesztő, majd a főmenü aktiválódik.
 4. A menüsor Alt-tal, a gombok AccessKey jelöléssel érhetők el; az Enter és Esc útvonal minden dialógusban egységes.
+5. Fontos mezők gyorsbillentyűi: Alt+N – Szállító, Alt+P – Számlaszám, Alt+D – Dátum, Alt+T – Tranzakciószám.
 
 🧾 Exit & Save flow
 A szerkesztőből kilépés kizárólag az Esc megnyomásával történik.

--- a/src/Views/InvoiceParts/InvoiceHeader.xaml
+++ b/src/Views/InvoiceParts/InvoiceHeader.xaml
@@ -19,20 +19,20 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
-        <TextBlock Grid.Row="0" Grid.Column="0" Text="{DynamicResource Supplier_Label}" Margin="0,0,5,5"/>
+        <Label Grid.Row="0" Grid.Column="0" Content="{DynamicResource Supplier_Label}" Target="{Binding ElementName=SupplierNameBox}" AccessKeyManager.AccessKey="N" Margin="0,0,5,5"/>
         <lookup:LookupBox x:Name="SupplierNameBox" Grid.Row="0" Grid.Column="1" DataContext="{Binding SupplierLookup}" Margin="{DynamicResource MarginRightMediumBottomSmall}" TabIndex="0" />
-        <TextBlock Grid.Row="0" Grid.Column="2" Text="{DynamicResource Address_Label}" Margin="0,0,5,5"/>
-        <TextBox Grid.Row="0" Grid.Column="3" Text="{Binding Invoice.Supplier.Address}" Margin="{DynamicResource MarginBottomSmall}" TabIndex="1" />
-        <TextBlock Grid.Column="0" Grid.Row="1" Text="{DynamicResource TaxNumber_Label}" Margin="0,5,5,5"/>
-        <TextBox Grid.Column="1" Grid.Row="1" Text="{Binding Invoice.Supplier.TaxNumber}" TabIndex="2" />
-        <TextBlock Grid.Column="2" Grid.Row="1" Text="{DynamicResource InvoiceNumber_Header}" Margin="0,5,5,5"/>
-        <TextBox Grid.Column="3" Grid.Row="1" Text="{Binding Invoice.SerialNumber}" Margin="{DynamicResource MarginVerticalSmall}" TabIndex="3" />
-        <TextBlock Grid.Column="0" Grid.Row="2" Text="{DynamicResource Date_Label}" Margin="0,5,5,5"/>
-        <DatePicker Grid.Column="1" Grid.Row="2" SelectedDate="{Binding Invoice.IssueDate}" TabIndex="4" />
-        <TextBlock Grid.Column="2" Grid.Row="2" Text="{DynamicResource PaymentMethod_Label}" Margin="0,5,5,5"/>
-        <ComboBox Grid.Column="3" Grid.Row="2" ItemsSource="{Binding PaymentMethods}" SelectedItem="{Binding Invoice.PaymentMethod}" DisplayMemberPath="Label" Margin="0,5,0,5" TabIndex="5" />
-        <TextBlock Grid.Column="0" Grid.Row="3" Text="{DynamicResource TransactionNumber_Label}" Margin="0,5,5,5"/>
-        <TextBox Grid.Column="1" Grid.Row="3" Text="{Binding Invoice.TransactionNumber}" Margin="{DynamicResource MarginBottomSmall}" TabIndex="6" />
+        <Label Grid.Row="0" Grid.Column="2" Content="{DynamicResource Address_Label}" Target="{Binding ElementName=AddressBox}" AccessKeyManager.AccessKey="C" Margin="0,0,5,5"/>
+        <TextBox x:Name="AddressBox" Grid.Row="0" Grid.Column="3" Text="{Binding Invoice.Supplier.Address}" Margin="{DynamicResource MarginBottomSmall}" TabIndex="1" />
+        <Label Grid.Column="0" Grid.Row="1" Content="{DynamicResource TaxNumber_Label}" Target="{Binding ElementName=TaxNumberBox}" AccessKeyManager.AccessKey="A" Margin="0,5,5,5"/>
+        <TextBox x:Name="TaxNumberBox" Grid.Column="1" Grid.Row="1" Text="{Binding Invoice.Supplier.TaxNumber}" TabIndex="2" />
+        <Label Grid.Column="2" Grid.Row="1" Content="{DynamicResource InvoiceNumber_Header}" Target="{Binding ElementName=SerialBox}" AccessKeyManager.AccessKey="P" Margin="0,5,5,5"/>
+        <TextBox x:Name="SerialBox" Grid.Column="3" Grid.Row="1" Text="{Binding Invoice.SerialNumber}" Margin="{DynamicResource MarginVerticalSmall}" TabIndex="3" />
+        <Label Grid.Column="0" Grid.Row="2" Content="{DynamicResource Date_Label}" Target="{Binding ElementName=IssueDateBox}" AccessKeyManager.AccessKey="D" Margin="0,5,5,5"/>
+        <DatePicker x:Name="IssueDateBox" Grid.Column="1" Grid.Row="2" SelectedDate="{Binding Invoice.IssueDate}" TabIndex="4" />
+        <Label Grid.Column="2" Grid.Row="2" Content="{DynamicResource PaymentMethod_Label}" Target="{Binding ElementName=PaymentMethodBox}" AccessKeyManager.AccessKey="M" Margin="0,5,5,5"/>
+        <ComboBox x:Name="PaymentMethodBox" Grid.Column="3" Grid.Row="2" ItemsSource="{Binding PaymentMethods}" SelectedItem="{Binding Invoice.PaymentMethod}" DisplayMemberPath="Label" Margin="0,5,0,5" TabIndex="5" />
+        <Label Grid.Column="0" Grid.Row="3" Content="{DynamicResource TransactionNumber_Label}" Target="{Binding ElementName=TransactionBox}" AccessKeyManager.AccessKey="T" Margin="0,5,5,5"/>
+        <TextBox x:Name="TransactionBox" Grid.Column="1" Grid.Row="3" Text="{Binding Invoice.TransactionNumber}" Margin="{DynamicResource MarginBottomSmall}" TabIndex="6" />
         <TextBlock Grid.Column="0" Grid.Row="4" Text="{DynamicResource CalculationMode_Label}" Margin="0,5,5,0">
             <TextBlock.Style>
                 <Style TargetType="TextBlock">

--- a/src/Views/InvoiceParts/InvoiceSidebar.xaml
+++ b/src/Views/InvoiceParts/InvoiceSidebar.xaml
@@ -1,6 +1,7 @@
 <UserControl x:Class="Wrecept.Views.InvoiceParts.InvoiceSidebar"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             FocusManager.FocusedElement="{Binding ElementName=SearchBox}">
     <StackPanel Margin="{DynamicResource SpacingLarge}">
         <TextBox x:Uid="Search" x:Name="SearchBox" Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}" Margin="{DynamicResource MarginBottomLarge}" TabIndex="0" />
         <DatePicker x:Name="FromDate" SelectedDate="{Binding FromDate}" Margin="{DynamicResource MarginBottomSmall}" TabIndex="1" />

--- a/src/Views/InvoiceParts/InvoiceSidebar.xaml.cs
+++ b/src/Views/InvoiceParts/InvoiceSidebar.xaml.cs
@@ -13,7 +13,7 @@ public partial class InvoiceSidebar : UserControl
         {
             if (InvoiceList.Items.Count > 0)
                 InvoiceList.SelectedIndex = 0;
-            InvoiceList.Focus();
+            SearchBox.Focus();
         };
     }
 

--- a/tests/ui_tests/DialogEnterEscTest.cs
+++ b/tests/ui_tests/DialogEnterEscTest.cs
@@ -1,0 +1,39 @@
+using System.Reflection;
+using System.Windows;
+using System.Windows.Input;
+using System.Windows.Interop;
+using Wrecept.Views.Dialogs;
+using Xunit;
+
+namespace Wrecept.UiTests;
+
+public class DialogEnterEscTest
+{
+    [StaFact]
+    public void EnterKey_ShouldConfirm()
+    {
+        var dialog = new KeyboardConfirmDialog();
+        var window = new Window { Content = dialog };
+        window.Show();
+        var method = typeof(KeyboardConfirmDialog).GetMethod("OnPreviewKeyDown", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var source = new HwndSource(new HwndSourceParameters());
+        var args = new KeyEventArgs(Keyboard.PrimaryDevice, source, 0, Key.Enter) { RoutedEvent = Keyboard.PreviewKeyDownEvent };
+        method.Invoke(dialog, new object[] { args });
+        Assert.True(window.DialogResult);
+        window.Close();
+    }
+
+    [StaFact]
+    public void EscapeKey_ShouldCancel()
+    {
+        var dialog = new KeyboardConfirmDialog();
+        var window = new Window { Content = dialog };
+        window.Show();
+        var method = typeof(KeyboardConfirmDialog).GetMethod("OnPreviewKeyDown", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var source = new HwndSource(new HwndSourceParameters());
+        var args = new KeyEventArgs(Keyboard.PrimaryDevice, source, 0, Key.Escape) { RoutedEvent = Keyboard.PreviewKeyDownEvent };
+        method.Invoke(dialog, new object[] { args });
+        Assert.False(window.DialogResult);
+        window.Close();
+    }
+}

--- a/tests/ui_tests/InvoiceSidebarNavigationTests.cs
+++ b/tests/ui_tests/InvoiceSidebarNavigationTests.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.ObjectModel;
+using System.Reflection;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Interop;
+using Wrecept.Views.InvoiceParts;
+using Wrecept.ViewModels;
+using Wrecept.Core.Domain;
+using Wrecept.Services;
+using Xunit;
+
+namespace Wrecept.UiTests;
+
+public class InvoiceSidebarNavigationTests
+{
+    private class StubDialog : IKeyboardDialogService
+    {
+        public bool Result { get; set; }
+        public bool Confirm(string message) => Result;
+        public bool ConfirmNewInvoice() => Result;
+        public bool ConfirmExit() => false;
+    }
+
+    [StaFact]
+    public void UpArrowOnFirstItem_ShouldAskForNewInvoice()
+    {
+        var dialog = new StubDialog { Result = true };
+        App.Services = new ServiceCollection().AddSingleton<IKeyboardDialogService>(dialog).BuildServiceProvider();
+        var invoices = new ObservableCollection<Invoice>
+        {
+            new Invoice { SerialNumber = "1" },
+            new Invoice { SerialNumber = "2" }
+        };
+        var vm = new InvoiceSidebarViewModel(invoices, new DefaultSupplierService(new Core.Repositories.InMemorySupplierRepository()));
+        var sidebar = new InvoiceSidebar { DataContext = vm };
+        sidebar.Measure(new System.Windows.Size(100,100));
+        sidebar.Arrange(new System.Windows.Rect(0,0,100,100));
+        var method = typeof(InvoiceSidebar).GetMethod("InvoiceList_OnPreviewKeyDown", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var source = new HwndSource(new HwndSourceParameters());
+        var args = new KeyEventArgs(Keyboard.PrimaryDevice, source, 0, Key.Up) { RoutedEvent = Keyboard.PreviewKeyDownEvent };
+        method.Invoke(sidebar, new object[] { sidebar, args });
+        Assert.NotNull(vm.SelectedInvoice);
+        Assert.Null(vm.SelectedInvoice.Id);
+    }
+}

--- a/tests/ui_tests/KeyboardShortcutRefactorTest.cs
+++ b/tests/ui_tests/KeyboardShortcutRefactorTest.cs
@@ -1,0 +1,22 @@
+using System.IO;
+using Xunit;
+
+namespace Wrecept.UiTests;
+
+public class KeyboardShortcutRefactorTest
+{
+    [Fact]
+    public void InvoiceEditorWindow_HasDeprecatedCtrlS()
+    {
+        var xaml = File.ReadAllText("src/Views/InvoiceEditorWindow.xaml");
+        Assert.Contains("DEPRECATED: Ctrl+S", xaml);
+    }
+
+    [Fact]
+    public void InvoiceItemsGrid_HasDeprecatedShortcuts()
+    {
+        var xaml = File.ReadAllText("src/Views/InvoiceParts/InvoiceItemsGrid.xaml");
+        Assert.Contains("DEPRECATED: F2", xaml);
+        Assert.Contains("DEPRECATED: Ctrl+L", xaml);
+    }
+}


### PR DESCRIPTION
## Summary
- set initial focus on InvoiceSidebar SearchBox via FocusManager
- use labels with AccessKey for important invoice fields
- document search box focus and keyboard shortcuts in ui_flow
- add regression test stubs for navigation and dialogs

## Testing
- `dotnet build Wrecept.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_685eea1524888322a5b883c7ac9e2829