### PR TITLE
Fix XAML access key error

### DIFF
--- a/docs/progress/2025-06-27_19-15-08_CodeGen-CSharp.md
+++ b/docs/progress/2025-06-27_19-15-08_CodeGen-CSharp.md
@@ -1,0 +1,6 @@
+### Access key registration
+*Timestamp:* 2025-06-27T19:15:08Z
+*Files touched:* src/Views/InvoiceParts/InvoiceHeader.xaml.cs
+*Summary:* moved access key setup to code-behind
+*Details:*
+- Removed XAML property usage and registered keys programmatically

--- a/docs/progress/2025-06-27_19-15-12_CodeGen-XAML.md
+++ b/docs/progress/2025-06-27_19-15-12_CodeGen-XAML.md
@@ -1,0 +1,6 @@
+### Removed invalid access key properties
+*Timestamp:* 2025-06-27T19:15:12Z
+*Files touched:* src/Views/InvoiceParts/InvoiceHeader.xaml
+*Summary:* cleaned XAML to avoid MC3072 errors
+*Details:*
+- Dropped AccessKeyManager.AccessKey attributes from labels

--- a/src/Views/InvoiceParts/InvoiceHeader.xaml
+++ b/src/Views/InvoiceParts/InvoiceHeader.xaml
@@ -19,19 +19,19 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
-        <Label Grid.Row="0" Grid.Column="0" Content="{DynamicResource Supplier_Label}" Target="{Binding ElementName=SupplierNameBox}" AccessKeyManager.AccessKey="N" Margin="0,0,5,5"/>
+        <Label Grid.Row="0" Grid.Column="0" Content="{DynamicResource Supplier_Label}" Target="{Binding ElementName=SupplierNameBox}" Margin="0,0,5,5"/>
         <lookup:LookupBox x:Name="SupplierNameBox" Grid.Row="0" Grid.Column="1" DataContext="{Binding SupplierLookup}" Margin="{DynamicResource MarginRightMediumBottomSmall}" TabIndex="0" />
-        <Label Grid.Row="0" Grid.Column="2" Content="{DynamicResource Address_Label}" Target="{Binding ElementName=AddressBox}" AccessKeyManager.AccessKey="C" Margin="0,0,5,5"/>
+        <Label Grid.Row="0" Grid.Column="2" Content="{DynamicResource Address_Label}" Target="{Binding ElementName=AddressBox}" Margin="0,0,5,5"/>
         <TextBox x:Name="AddressBox" Grid.Row="0" Grid.Column="3" Text="{Binding Invoice.Supplier.Address}" Margin="{DynamicResource MarginBottomSmall}" TabIndex="1" />
-        <Label Grid.Column="0" Grid.Row="1" Content="{DynamicResource TaxNumber_Label}" Target="{Binding ElementName=TaxNumberBox}" AccessKeyManager.AccessKey="A" Margin="0,5,5,5"/>
+        <Label Grid.Column="0" Grid.Row="1" Content="{DynamicResource TaxNumber_Label}" Target="{Binding ElementName=TaxNumberBox}" Margin="0,5,5,5"/>
         <TextBox x:Name="TaxNumberBox" Grid.Column="1" Grid.Row="1" Text="{Binding Invoice.Supplier.TaxNumber}" TabIndex="2" />
-        <Label Grid.Column="2" Grid.Row="1" Content="{DynamicResource InvoiceNumber_Header}" Target="{Binding ElementName=SerialBox}" AccessKeyManager.AccessKey="P" Margin="0,5,5,5"/>
+        <Label Grid.Column="2" Grid.Row="1" Content="{DynamicResource InvoiceNumber_Header}" Target="{Binding ElementName=SerialBox}" Margin="0,5,5,5"/>
         <TextBox x:Name="SerialBox" Grid.Column="3" Grid.Row="1" Text="{Binding Invoice.SerialNumber}" Margin="{DynamicResource MarginVerticalSmall}" TabIndex="3" />
-        <Label Grid.Column="0" Grid.Row="2" Content="{DynamicResource Date_Label}" Target="{Binding ElementName=IssueDateBox}" AccessKeyManager.AccessKey="D" Margin="0,5,5,5"/>
+        <Label Grid.Column="0" Grid.Row="2" Content="{DynamicResource Date_Label}" Target="{Binding ElementName=IssueDateBox}" Margin="0,5,5,5"/>
         <DatePicker x:Name="IssueDateBox" Grid.Column="1" Grid.Row="2" SelectedDate="{Binding Invoice.IssueDate}" TabIndex="4" />
-        <Label Grid.Column="2" Grid.Row="2" Content="{DynamicResource PaymentMethod_Label}" Target="{Binding ElementName=PaymentMethodBox}" AccessKeyManager.AccessKey="M" Margin="0,5,5,5"/>
+        <Label Grid.Column="2" Grid.Row="2" Content="{DynamicResource PaymentMethod_Label}" Target="{Binding ElementName=PaymentMethodBox}" Margin="0,5,5,5"/>
         <ComboBox x:Name="PaymentMethodBox" Grid.Column="3" Grid.Row="2" ItemsSource="{Binding PaymentMethods}" SelectedItem="{Binding Invoice.PaymentMethod}" DisplayMemberPath="Label" Margin="0,5,0,5" TabIndex="5" />
-        <Label Grid.Column="0" Grid.Row="3" Content="{DynamicResource TransactionNumber_Label}" Target="{Binding ElementName=TransactionBox}" AccessKeyManager.AccessKey="T" Margin="0,5,5,5"/>
+        <Label Grid.Column="0" Grid.Row="3" Content="{DynamicResource TransactionNumber_Label}" Target="{Binding ElementName=TransactionBox}" Margin="0,5,5,5"/>
         <TextBox x:Name="TransactionBox" Grid.Column="1" Grid.Row="3" Text="{Binding Invoice.TransactionNumber}" Margin="{DynamicResource MarginBottomSmall}" TabIndex="6" />
         <TextBlock Grid.Column="0" Grid.Row="4" Text="{DynamicResource CalculationMode_Label}" Margin="0,5,5,0">
             <TextBlock.Style>

--- a/src/Views/InvoiceParts/InvoiceHeader.xaml.cs
+++ b/src/Views/InvoiceParts/InvoiceHeader.xaml.cs
@@ -1,4 +1,5 @@
 using System.Windows.Controls;
+using System.Windows.Input;
 using Wrecept.ViewModels;
 
 namespace Wrecept.Views.InvoiceParts;
@@ -8,6 +9,16 @@ public partial class InvoiceHeader : UserControl
     public InvoiceHeader()
     {
         InitializeComponent();
-        Loaded += (_, _) => SupplierNameBox.SearchBox.Focus();
+        Loaded += (_, _) =>
+        {
+            SupplierNameBox.SearchBox.Focus();
+            AccessKeyManager.Register("N", SupplierNameBox);
+            AccessKeyManager.Register("C", AddressBox);
+            AccessKeyManager.Register("A", TaxNumberBox);
+            AccessKeyManager.Register("P", SerialBox);
+            AccessKeyManager.Register("D", IssueDateBox);
+            AccessKeyManager.Register("M", PaymentMethodBox);
+            AccessKeyManager.Register("T", TransactionBox);
+        };
     }
 }


### PR DESCRIPTION
## Summary
- drop `AccessKeyManager.AccessKey` usage in InvoiceHeader
- register access keys programmatically on load
- log changes for CodeGen-XAML and CodeGen-CSharp agents

## Testing
- `./setup.sh` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_685eece84fa48322a60ddbb2805f1c6e