### PR TITLE
Fix focus management and navigation

### DIFF
--- a/docs/progress/2025-06-27_19-35-39_CodeGen-XAML.md
+++ b/docs/progress/2025-06-27_19-35-39_CodeGen-XAML.md
@@ -1,0 +1,7 @@
+### Focus fixes in dialogs
+*Timestamp:* 2025-06-27T19:35:39Z
+*Files touched:* src/Views/OnboardingOverlay.xaml, src/Views/Filters/DateFilterDialog.xaml, src/Views/Filters/ProductFilterDialog.xaml, src/Views/Filters/ProductGroupFilterDialog.xaml, src/Views/Filters/SupplierFilterDialog.xaml, src/Views/Settings/SettingsWindow.xaml
+*Summary:* Set FocusManager and names for initial focus
+*Details:*
+- Close button receives focus in OnboardingOverlay
+- Filter and settings dialogs now declare FocusManager.FocusedElement

--- a/docs/progress/2025-06-27_19-35-41_CodeGen-CSharp.md
+++ b/docs/progress/2025-06-27_19-35-41_CodeGen-CSharp.md
@@ -1,0 +1,9 @@
+### Navigation after saving
+*Timestamp:* 2025-06-27T19:35:41Z
+*Files touched:* src/ViewModels/InvoiceEditorViewModel.cs, src/Views/Filters/*.cs, src/Views/Settings/SettingsWindow.xaml.cs, tests/Wrecept.Tests/InvoiceEditorViewModelTests.cs, tests/ui_tests/InvoiceEditorEscFlowTests.cs
+*Summary:* Ensure invoice list shows after SaveAsync and removed manual focus calls
+*Details:*
+- SaveAsync now awaits NavigationService to restore invoice list
+- CancelByEscAsync no longer triggers navigation itself
+- Removed Keyboard.Focus from dialog code-behind
+- Updated unit tests with stub navigation service

--- a/docs/progress/2025-06-27_19-35-43_DocWriter.md
+++ b/docs/progress/2025-06-27_19-35-43_DocWriter.md
@@ -1,0 +1,7 @@
+### Updated focus documentation
+*Timestamp:* 2025-06-27T19:35:43Z
+*Files touched:* docs/ui_flow.md
+*Summary:* Documented overlay and dialog focus rules
+*Details:*
+- Added notes on OnboardingOverlay default focus
+- Mentioned FocusManager usage in dialogs

--- a/docs/ui_flow.md
+++ b/docs/ui_flow.md
@@ -39,6 +39,8 @@
 3. Ctrl+S mentésre, Esc az aktuális sor vagy ablak bezárására szolgál; Esc-sorozat esetén először a szerkesztő, majd a főmenü aktiválódik.
 4. A menüsor Alt-tal, a gombok AccessKey jelöléssel érhetők el; az Enter és Esc útvonal minden dialógusban egységes.
 5. Fontos mezők gyorsbillentyűi: Alt+N – Szállító, Alt+P – Számlaszám, Alt+D – Dátum, Alt+T – Tranzakciószám.
+6. Az OnboardingOverlay megnyitásakor a Bezár gombon van a fókusz.
+7. A szűrő- és beállítóablakok a `FocusManager.FocusedElement` tulajdonsággal jelölik ki az első mezőt.
 
 🧾 Exit & Save flow
 A szerkesztőből kilépés kizárólag az Esc megnyomásával történik.

--- a/src/ViewModels/InvoiceEditorViewModel.cs
+++ b/src/ViewModels/InvoiceEditorViewModel.cs
@@ -148,7 +148,6 @@ public partial class InvoiceEditorViewModel : ObservableObject
         {
             _navigationService.ShowSavingOverlay();
             await SaveAsync();
-            await _navigationService.ShowInvoiceListViewAsync();
         }
     }
 
@@ -185,6 +184,7 @@ public partial class InvoiceEditorViewModel : ObservableObject
         _feedbackService.Accept();
         ExitRequested = true;
         ExitedByEsc = false;
+        await _navigationService.ShowInvoiceListViewAsync();
     }
 
     private void PrintInvoice()

--- a/src/Views/Filters/DateFilterDialog.xaml
+++ b/src/Views/Filters/DateFilterDialog.xaml
@@ -1,7 +1,8 @@
 <UserControl x:Class="Wrecept.Views.Filters.DateFilterDialog"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        KeyDown="Window_KeyDown">
+        KeyDown="Window_KeyDown"
+        FocusManager.FocusedElement="{Binding ElementName=FromDatePicker}">
     <Grid Margin="{DynamicResource SpacingLarge}">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
@@ -13,7 +14,7 @@
             <ColumnDefinition Width="*"/>
         </Grid.ColumnDefinitions>
         <TextBlock x:Uid="StartDate_Label" Grid.Row="0" Grid.Column="0" Text="{DynamicResource StartDate_Label}" Margin="{DynamicResource MarginRightSmallBottomSmall}"/>
-        <DatePicker Grid.Row="0" Grid.Column="1" SelectedDate="{Binding FromDate}" TabIndex="0"/>
+        <DatePicker x:Name="FromDatePicker" Grid.Row="0" Grid.Column="1" SelectedDate="{Binding FromDate}" TabIndex="0"/>
         <TextBlock x:Uid="EndDate_Label" Grid.Row="1" Grid.Column="0" Text="{DynamicResource EndDate_Label}" Margin="{DynamicResource MarginTopSmallRightSmallBottomSmall}"/>
         <DatePicker Grid.Row="1" Grid.Column="1" SelectedDate="{Binding ToDate}" TabIndex="1"/>
         <StackPanel Grid.Row="2" Grid.ColumnSpan="2" Orientation="Horizontal" HorizontalAlignment="Right" Margin="{DynamicResource MarginTopLarge}">

--- a/src/Views/Filters/DateFilterDialog.xaml.cs
+++ b/src/Views/Filters/DateFilterDialog.xaml.cs
@@ -10,7 +10,6 @@ public partial class DateFilterDialog : UserControl
     public DateFilterDialog()
     {
         InitializeComponent();
-        Loaded += (_, _) => Keyboard.Focus(this);
     }
 
     private void Window_KeyDown(object sender, KeyEventArgs e)

--- a/src/Views/Filters/ProductFilterDialog.xaml
+++ b/src/Views/Filters/ProductFilterDialog.xaml
@@ -1,13 +1,14 @@
 <UserControl x:Class="Wrecept.Views.Filters.ProductFilterDialog"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        KeyDown="Window_KeyDown">
+        KeyDown="Window_KeyDown"
+        FocusManager.FocusedElement="{Binding ElementName=ProductList}">
     <Grid Margin="{DynamicResource SpacingLarge}">
         <Grid.RowDefinitions>
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
-        <ListBox ItemsSource="{Binding Products}" SelectedItem="{Binding SelectedProduct}" TabIndex="0">
+        <ListBox x:Name="ProductList" ItemsSource="{Binding Products}" SelectedItem="{Binding SelectedProduct}" TabIndex="0">
             <ListBox.ItemTemplate>
                 <DataTemplate>
                     <StackPanel Orientation="Horizontal" Margin="2">

--- a/src/Views/Filters/ProductFilterDialog.xaml.cs
+++ b/src/Views/Filters/ProductFilterDialog.xaml.cs
@@ -10,7 +10,6 @@ public partial class ProductFilterDialog : UserControl
     public ProductFilterDialog()
     {
         InitializeComponent();
-        Loaded += (_, _) => Keyboard.Focus(this);
     }
 
     private void Window_KeyDown(object sender, KeyEventArgs e)

--- a/src/Views/Filters/ProductGroupFilterDialog.xaml
+++ b/src/Views/Filters/ProductGroupFilterDialog.xaml
@@ -1,13 +1,14 @@
 <UserControl x:Class="Wrecept.Views.Filters.ProductGroupFilterDialog"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        KeyDown="Window_KeyDown">
+        KeyDown="Window_KeyDown"
+        FocusManager.FocusedElement="{Binding ElementName=GroupList}">
     <Grid Margin="{DynamicResource SpacingLarge}">
         <Grid.RowDefinitions>
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
-        <ListBox ItemsSource="{Binding Groups}" SelectedItem="{Binding SelectedGroup}" TabIndex="0" DisplayMemberPath="Name"/>
+        <ListBox x:Name="GroupList" ItemsSource="{Binding Groups}" SelectedItem="{Binding SelectedGroup}" TabIndex="0" DisplayMemberPath="Name"/>
         <StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Right" Margin="{DynamicResource MarginTopLarge}">
             <Button x:Uid="Filter_Button" Content="{DynamicResource Filter_Button}" Command="{Binding ApplyCommand}" CommandParameter="{Binding RelativeSource={RelativeSource AncestorType=UserControl}}" Margin="{DynamicResource SpacingSmall}" TabIndex="1" IsDefault="True" />
             <Button x:Uid="Cancel_Button" Content="{DynamicResource Cancel_Button}" Command="{Binding CancelCommand}" CommandParameter="{Binding RelativeSource={RelativeSource AncestorType=UserControl}}" TabIndex="2" IsCancel="True" />

--- a/src/Views/Filters/ProductGroupFilterDialog.xaml.cs
+++ b/src/Views/Filters/ProductGroupFilterDialog.xaml.cs
@@ -10,7 +10,6 @@ public partial class ProductGroupFilterDialog : UserControl
     public ProductGroupFilterDialog()
     {
         InitializeComponent();
-        Loaded += (_, _) => Keyboard.Focus(this);
     }
 
     private void Window_KeyDown(object sender, KeyEventArgs e)

--- a/src/Views/Filters/SupplierFilterDialog.xaml
+++ b/src/Views/Filters/SupplierFilterDialog.xaml
@@ -1,13 +1,14 @@
 <UserControl x:Class="Wrecept.Views.Filters.SupplierFilterDialog"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        KeyDown="Window_KeyDown">
+        KeyDown="Window_KeyDown"
+        FocusManager.FocusedElement="{Binding ElementName=SupplierList}">
     <Grid Margin="{DynamicResource SpacingLarge}">
         <Grid.RowDefinitions>
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
-        <ListBox ItemsSource="{Binding Suppliers}" SelectedItem="{Binding SelectedSupplier}" TabIndex="0">
+        <ListBox x:Name="SupplierList" ItemsSource="{Binding Suppliers}" SelectedItem="{Binding SelectedSupplier}" TabIndex="0">
             <ListBox.ItemTemplate>
                 <DataTemplate>
                     <StackPanel Orientation="Horizontal" Margin="2">

--- a/src/Views/Filters/SupplierFilterDialog.xaml.cs
+++ b/src/Views/Filters/SupplierFilterDialog.xaml.cs
@@ -10,7 +10,6 @@ public partial class SupplierFilterDialog : UserControl
     public SupplierFilterDialog()
     {
         InitializeComponent();
-        Loaded += (_, _) => Keyboard.Focus(this);
     }
 
     private void Window_KeyDown(object sender, KeyEventArgs e)

--- a/src/Views/OnboardingOverlay.xaml
+++ b/src/Views/OnboardingOverlay.xaml
@@ -1,7 +1,8 @@
 <UserControl x:Class="Wrecept.Views.OnboardingOverlay"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        KeyDown="Window_OnKeyDown">
+        KeyDown="Window_OnKeyDown"
+        FocusManager.FocusedElement="{Binding ElementName=CloseButton}">
     <Border Background="White" Opacity="0.9" Padding="{DynamicResource SpacingLarge}">
         <StackPanel>
             <TextBlock Text="{DynamicResource Shortcuts_Title}" FontWeight="Bold" Margin="{DynamicResource MarginBottomMedium}" FontSize="{DynamicResource BaseFontSize}" />
@@ -9,7 +10,7 @@
             <TextBlock Text="{DynamicResource Shortcut_Open}" FontSize="{DynamicResource BaseFontSize}" />
             <TextBlock Text="{DynamicResource Shortcut_Back}" FontSize="{DynamicResource BaseFontSize}" />
             <TextBlock Text="{DynamicResource Shortcut_Help}" FontSize="{DynamicResource BaseFontSize}" />
-            <Button x:Uid="CloseSimple_Button" Content="{DynamicResource CloseSimple_Button}" Click="OnClose" HorizontalAlignment="Right" Margin="{DynamicResource MarginTopLarge}" TabIndex="0" IsDefault="True" FontSize="{DynamicResource BaseFontSize}" />
+            <Button x:Name="CloseButton" x:Uid="CloseSimple_Button" Content="{DynamicResource CloseSimple_Button}" Click="OnClose" HorizontalAlignment="Right" Margin="{DynamicResource MarginTopLarge}" TabIndex="0" IsDefault="True" FontSize="{DynamicResource BaseFontSize}" />
         </StackPanel>
     </Border>
 </UserControl>

--- a/src/Views/Settings/SettingsWindow.xaml
+++ b/src/Views/Settings/SettingsWindow.xaml
@@ -1,10 +1,11 @@
 <UserControl x:Class="Wrecept.Views.Settings.SettingsWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        KeyDown="Window_KeyDown">
+        KeyDown="Window_KeyDown"
+        FocusManager.FocusedElement="{Binding ElementName=ThemeCombo}">
     <StackPanel Margin="{DynamicResource SpacingLarge}">
         <TextBlock x:Uid="Theme_Label" Text="{DynamicResource Theme_Label}" Margin="{DynamicResource MarginBottomSmall}" />
-        <ComboBox x:Uid="Theme_Combo" SelectedValue="{Binding Theme}" SelectedValuePath="Content" TabIndex="0">
+        <ComboBox x:Name="ThemeCombo" x:Uid="Theme_Combo" SelectedValue="{Binding Theme}" SelectedValuePath="Content" TabIndex="0">
             <ComboBoxItem Content="Light" />
             <ComboBoxItem Content="Dark" />
         </ComboBox>

--- a/src/Views/Settings/SettingsWindow.xaml.cs
+++ b/src/Views/Settings/SettingsWindow.xaml.cs
@@ -10,7 +10,6 @@ public partial class SettingsWindow : UserControl
     public SettingsWindow()
     {
         InitializeComponent();
-        Loaded += (_, _) => Keyboard.Focus(this);
     }
 
     private void Window_KeyDown(object sender, KeyEventArgs e)

--- a/tests/Wrecept.Tests/InvoiceEditorViewModelTests.cs
+++ b/tests/Wrecept.Tests/InvoiceEditorViewModelTests.cs
@@ -1,6 +1,7 @@
 using Wrecept.Core.Domain;
 using Wrecept.Core.Repositories;
 using Wrecept.Core.Services;
+using System.Threading.Tasks;
 using Wrecept.ViewModels;
 using Wrecept.Services;
 using Xunit;
@@ -89,6 +90,7 @@ public class InvoiceEditorViewModelTests
     {
         var repo = new InMemoryInvoiceRepository();
         var service = new DefaultInvoiceService(repo);
+        var nav = new StubNavigationService();
         var invoice = new Invoice { SerialNumber = "1", TransactionNumber = "T1" };
         var vm = new InvoiceEditorViewModel(
             invoice,
@@ -103,12 +105,41 @@ public class InvoiceEditorViewModelTests
             new JsonPriceHistoryService(),
             new FeedbackService(),
             new KeyboardDialogService(),
-            new NavigationService(),
+            nav,
             true);
 
         await vm.SaveAsync();
 
         Assert.True(vm.ExitRequested);
         Assert.Single(await repo.GetAllAsync());
+        Assert.Equal(1, nav.ShowCalls);
+    }
+
+    private class StubNavigationService : INavigationService
+    {
+        public int ShowCalls;
+        public Task ShowInvoiceListViewAsync()
+        {
+            ShowCalls++;
+            return Task.CompletedTask;
+        }
+
+        public void SetHost(MainWindowViewModel host) { }
+        public void ShowSupplierView() { }
+        public void ShowProductView() { }
+        public void ShowUnitView() { }
+        public void ShowProductGroupView() { }
+        public void ShowTaxRateView() { }
+        public void ShowSettingsView() { }
+        public void ShowFilterByDateView() { }
+        public void ShowFilterBySupplierView() { }
+        public void ShowFilterByProductGroupView() { }
+        public void ShowFilterByProductView() { }
+        public void ShowHelpView() { }
+        public void ShowAboutDialog() { }
+        public void ShowOnboardingOverlay() { }
+        public void ShowSavingOverlay() { }
+        public void CloseCurrentView() { }
+        public void ExitApplication() { }
     }
 }

--- a/tests/ui_tests/InvoiceEditorEscFlowTests.cs
+++ b/tests/ui_tests/InvoiceEditorEscFlowTests.cs
@@ -23,6 +23,7 @@ public class InvoiceEditorEscFlowTests
     {
         var service = new DefaultInvoiceService(new InMemoryInvoiceRepository());
         var dialog = new StubDialog { Result = true };
+        var nav = new StubNavigationService();
         var vm = new InvoiceEditorViewModel(
             new Invoice
             {
@@ -43,7 +44,7 @@ public class InvoiceEditorEscFlowTests
             new JsonPriceHistoryService(),
             new FeedbackService(),
             dialog,
-            new NavigationService(),
+            nav,
             true);
 
         await vm.CancelByEscAsync();
@@ -56,6 +57,7 @@ public class InvoiceEditorEscFlowTests
     {
         var repo = new InMemoryInvoiceRepository();
         var service = new DefaultInvoiceService(repo);
+        var nav = new StubNavigationService();
         var vm = new InvoiceEditorViewModel(
             new Invoice(),
             true,
@@ -69,11 +71,40 @@ public class InvoiceEditorEscFlowTests
             new JsonPriceHistoryService(),
             new FeedbackService(),
             new KeyboardDialogService(),
-            new NavigationService(),
+            nav,
             true);
 
         await vm.SaveAsync();
 
         Assert.False(vm.ExitedByEsc);
+        Assert.Equal(1, nav.ShowCalls);
+    }
+
+    private class StubNavigationService : INavigationService
+    {
+        public int ShowCalls;
+        public Task ShowInvoiceListViewAsync()
+        {
+            ShowCalls++;
+            return Task.CompletedTask;
+        }
+
+        public void SetHost(MainWindowViewModel host) { }
+        public void ShowSupplierView() { }
+        public void ShowProductView() { }
+        public void ShowUnitView() { }
+        public void ShowProductGroupView() { }
+        public void ShowTaxRateView() { }
+        public void ShowSettingsView() { }
+        public void ShowFilterByDateView() { }
+        public void ShowFilterBySupplierView() { }
+        public void ShowFilterByProductGroupView() { }
+        public void ShowFilterByProductView() { }
+        public void ShowHelpView() { }
+        public void ShowAboutDialog() { }
+        public void ShowOnboardingOverlay() { }
+        public void ShowSavingOverlay() { }
+        public void CloseCurrentView() { }
+        public void ExitApplication() { }
     }
 }


### PR DESCRIPTION
## Summary
- set default focus elements for overlay and dialogs
- focus restored to invoice list after SaveAsync
- update unit tests to stub navigation
- document new focus behaviour

## Testing
- `dotnet test Wrecept.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_685eefefba04832287669712a3bae0aa