### PR TITLE
Simplify InvoiceSidebar UI

### DIFF
--- a/docs/progress/2025-06-27_ui_agent.md
+++ b/docs/progress/2025-06-27_ui_agent.md
@@ -1,0 +1,9 @@
+### InvoiceSidebar simplification
+*Timestamp:* 2025-06-27T19:50:10Z
+*Files touched:* src/Views/InvoiceParts/InvoiceSidebar.xaml, src/Views/InvoiceParts/InvoiceSidebar.xaml.cs, tests/ui_tests/SidebarPanelRefactorTest.cs, docs/ui_flow.md
+*Summary:* Removed obsolete fields and centered invoice list
+*Details:*
+- Deleted search and filter controls from sidebar
+- Added "📄 Számlák" label and set focus to invoice list
+- Updated focus order in ui_flow.md
+- New UI test to verify cleaned markup

--- a/docs/ui_flow.md
+++ b/docs/ui_flow.md
@@ -9,6 +9,7 @@
 ## Invoice editor layout
 
 * A fő felület négy részre tagolt: InvoiceSidebar, InvoiceHeader, InvoiceItemsGrid és InvoiceSummary.
+* A bal panel tetején "📄 Számlák" felirat látható, alatta középre igazított számlalista kap helyet.
 * A fejléc bal oldala a szállító adatait, jobb oldala a számla jellemzőit tartalmazza.
 * A grid kiemelt vizuális elemmé válik: nagyobb betűméret, váltakozó sorszínek, a placeholder sor halványabban jelenik meg.
 * Fejlett mezők (pl. megjegyzés, számítás mód) alapból összehúzva, csak szerkesztés után nyílnak le.
@@ -34,8 +35,8 @@
 
 ## Keyboard & focus logic
 
-1. A Tab sorrend: Sidebar kereső → Header mezők → ItemsGrid → Summary → alsó eszköztár.
-2. Minden új nézetre lépéskor a logikus első mező (Sidebar kereső) kap fókuszt. A fókusz a `FocusManager.FocusedElement` beállítással indul a SearchBoxon.
+1. A Tab sorrend: Sidebar lista → Header mezők → ItemsGrid → Summary → alsó eszköztár.
+2. Minden új nézetre lépéskor a logikus első mező (Sidebar lista) kap fókuszt. A fókusz a `FocusManager.FocusedElement` beállítással indul az InvoiceList.
 3. Ctrl+S mentésre, Esc az aktuális sor vagy ablak bezárására szolgál; Esc-sorozat esetén először a szerkesztő, majd a főmenü aktiválódik.
 4. A menüsor Alt-tal, a gombok AccessKey jelöléssel érhetők el; az Enter és Esc útvonal minden dialógusban egységes.
 5. Fontos mezők gyorsbillentyűi: Alt+N – Szállító, Alt+P – Számlaszám, Alt+D – Dátum, Alt+T – Tranzakciószám.

--- a/src/Views/InvoiceParts/InvoiceSidebar.xaml
+++ b/src/Views/InvoiceParts/InvoiceSidebar.xaml
@@ -1,12 +1,9 @@
 <UserControl x:Class="Wrecept.Views.InvoiceParts.InvoiceSidebar"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             FocusManager.FocusedElement="{Binding ElementName=SearchBox}">
-    <StackPanel Margin="{DynamicResource SpacingLarge}">
-        <TextBox x:Uid="Search" x:Name="SearchBox" Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}" Margin="{DynamicResource MarginBottomLarge}" TabIndex="0" />
-        <DatePicker x:Name="FromDate" SelectedDate="{Binding FromDate}" Margin="{DynamicResource MarginBottomSmall}" TabIndex="1" />
-        <DatePicker x:Name="ToDate" SelectedDate="{Binding ToDate}" Margin="{DynamicResource MarginBottomLarge}" TabIndex="2" />
-        <ComboBox x:Name="SupplierFilter" ItemsSource="{Binding Suppliers}" SelectedItem="{Binding SelectedSupplier}" DisplayMemberPath="Name" Margin="{DynamicResource MarginBottomLarge}" TabIndex="3" />
+             FocusManager.FocusedElement="{Binding ElementName=InvoiceList}">
+    <StackPanel Margin="{DynamicResource SpacingLarge}" VerticalAlignment="Center">
+        <TextBlock Text="📄 Számlák" Margin="0,0,0,10" FontWeight="Bold" />
         <DataGrid x:Name="InvoiceList"
                   ItemsSource="{Binding Invoices}"
                   SelectedItem="{Binding SelectedInvoice, Mode=TwoWay}"
@@ -14,7 +11,8 @@
                   CanUserAddRows="False"
                   Height="300"
                   RowHeight="26"
-                  TabIndex="4"
+                  TabIndex="0"
+                  FocusVisualStyle="{x:Null}"
                   PreviewKeyDown="InvoiceList_OnPreviewKeyDown">
             <DataGrid.Columns>
                 <DataGridTextColumn Header="{DynamicResource InvoiceNumber_Header}" Binding="{Binding SerialNumber}" />

--- a/src/Views/InvoiceParts/InvoiceSidebar.xaml.cs
+++ b/src/Views/InvoiceParts/InvoiceSidebar.xaml.cs
@@ -13,7 +13,7 @@ public partial class InvoiceSidebar : UserControl
         {
             if (InvoiceList.Items.Count > 0)
                 InvoiceList.SelectedIndex = 0;
-            SearchBox.Focus();
+            InvoiceList.Focus();
         };
     }
 

--- a/tests/ui_tests/SidebarPanelRefactorTest.cs
+++ b/tests/ui_tests/SidebarPanelRefactorTest.cs
@@ -1,0 +1,18 @@
+using System.IO;
+using Xunit;
+
+namespace Wrecept.UiTests;
+
+public class SidebarPanelRefactorTest
+{
+    [Fact]
+    public void InvoiceSidebar_ShouldContainOnlyList()
+    {
+        var xaml = File.ReadAllText("src/Views/InvoiceParts/InvoiceSidebar.xaml");
+        Assert.DoesNotContain("<TextBox", xaml);
+        Assert.DoesNotContain("<DatePicker", xaml);
+        Assert.DoesNotContain("<ComboBox", xaml);
+        Assert.Contains("📄 Számlák", xaml);
+        Assert.Contains("InvoiceList", xaml);
+    }
+}


### PR DESCRIPTION
## Summary
- remove sidebar filters and add label
- center invoice list and autofocus on first item
- document updated focus order
- add UITest ensuring the sidebar markup only keeps the invoice list

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ef5aa2dd48322a9ca009999d22d76