### PR TITLE
Add docs_agent section and update docs authors

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -101,6 +101,16 @@ This document defines the agent-based development workflow for the **Wrecept** d
 
 ---
 
+## 📝 docs_agent
+
+**Role:** Maintains documentation and progress logs.
+
+* Owns `ARCHITECTURE.md`, `ERROR_HANDLING.md`, `TEST_STRATEGY.md`, `FAULT_INJECTION.md`, and `CODE_STANDARDS.md`.
+* Rögzíti a feladatok előrehaladását a `docs/progress/` könyvtárban.
+* Egyeztet a `root_agent`-tel, ha a dokumentáció a többi réteg felépítését is érinti.
+
+---
+
 ## ✨ Guidelines
 
 * **DO NOT** let agents cross layers without coordination.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 ---
 title: "Architecture Blueprint"
 purpose: "Overall module and data flow overview"
-author: "root_agent"
+author: "docs_agent"
 date: "2025-06-27"
 ---
 

--- a/docs/CODE_STANDARDS.md
+++ b/docs/CODE_STANDARDS.md
@@ -1,7 +1,7 @@
 ---
 title: "Code Standards"
 purpose: "Naming conventions and static analysis rules"
-author: "root_agent"
+author: "docs_agent"
 date: "2025-06-27"
 ---
 

--- a/docs/ERROR_HANDLING.md
+++ b/docs/ERROR_HANDLING.md
@@ -1,7 +1,7 @@
 ---
 title: "Error Handling"
 purpose: "Runtime and compile-time defense rules"
-author: "root_agent"
+author: "docs_agent"
 date: "2025-06-27"
 ---
 

--- a/docs/FAULT_INJECTION.md
+++ b/docs/FAULT_INJECTION.md
@@ -1,0 +1,23 @@
+---
+title: "Fault Injection"
+purpose: "Scenarios for reliability testing and expected mitigation"
+author: "docs_agent"
+date: "2025-06-27"
+---
+
+# 🐞 Fault Injection Scenarios
+
+Ez a dokumentum részletezi, hogyan teszteljük a Wrecept hibákkal szembeni ellenállását.
+
+## Szimulált helyzetek
+
+1. **Adatbázis elvesztése** – A SQLite fájl törlését vagy átnevezését követően a rendszernek biztonságosan alaphelyzetbe kell állnia, és a felhasználót tájékoztatnia kell a helyreállítás lépéseiről.
+2. **Sérült konfiguráció** – Hibás vagy hiányzó beállítófájl esetén az alkalmazás alapértelmezett konfigurációval indul, és figyelmeztetést jelenít meg.
+3. **Betelt háttértár** – Írási hibát szimulálunk, amikor nincs szabad hely. A tranzakcióknak megszakítás nélkül vissza kell gördülniük, a felhasználó pedig értesítést kap.
+
+## Elvárt viselkedés
+
+* Minden hibaeseményt naplózunk a `%AppData%/Wrecept/logs` könyvtárba.
+* A működésnek az adatbiztonság és a felhasználó tájékoztatása mellett kell folytatódnia, vagy szükség esetén biztonságosan leállnia.
+
+---

--- a/docs/TEST_STRATEGY.md
+++ b/docs/TEST_STRATEGY.md
@@ -1,7 +1,7 @@
 ---
 title: "Testing Strategy"
 purpose: "Unit, integration and UI testing principles"
-author: "root_agent"
+author: "docs_agent"
 date: "2025-06-27"
 ---
 

--- a/docs/progress/2025-06-27_22-13-50_docs_agent.md
+++ b/docs/progress/2025-06-27_22-13-50_docs_agent.md
@@ -1,0 +1,5 @@
+# Progress Log - 2025-06-27 22:13 UTC
+
+* Frissítettem a dokumentációk szerző mezőit a docs_agentre.
+* Létrehoztam a FAULT_INJECTION.md fájlt új hibaszcenáriókkal.
+* Bővítettem az AGENTS.md-t a docs_agent szerepkörével.


### PR DESCRIPTION
## Summary
- set docs_agent as author for main guidance docs
- create FAULT_INJECTION.md with reliability test scenarios
- document docs_agent duties in AGENTS.md
- log the documentation update in progress log

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_685f1736d734832285a84b686233feb4