### PR TITLE
Link docs & add onboarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,37 @@
+---
+title: "Changelog"
+purpose: "Aggregated changes from progress logs"
+author: "tools"
+date: "2025-06-27"
+---
+
+# 📝 Changelog
+
+## 2025-06-27
+- Added frontmatter to all documentation files.
+- Created missing Hungarian and English manual stubs.
+- Initialized progress logging directory.
+
+## 2025-06-27
+- Létrehoztam az architektúra, hibakezelés, tesztelés, fault injection és kódstandard dokumentumokat.
+- Ezek a hiányzó keretek a projekt működési elveit rögzítik.
+
+## 2025-06-27
+- Frissítettem a dokumentációk szerző mezőit a docs_agentre.
+- Létrehoztam a FAULT_INJECTION.md fájlt új hibaszcenáriókkal.
+- Bővítettem az AGENTS.md-t a docs_agent szerepkörével.
+
+## 2025-06-27
+- Kiegészítettem az ERROR_HANDLING.md-t konkrét hibaszcenáriókkal.
+- Részletesebbé tettem az adatáramlást az ARCHITECTURE.md-ben.
+- Pontosítottam a TEST_STRATEGY.md kódfedettségi és CI szabályait.
+- Bővítettem a FAULT_INJECTION.md-t új kockázatokkal.
+- Frissítettem a CODE_STANDARDS.md-t null-kezeléssel és naminggel.
+
+## 2025-06-27
+- Hivatkozásokat adtam a README.md aljára a fő dokumentumokra.
+- Szabályt rögzítettem az AGENTS.md-ben az InvoiceEditor indulásához.
+- Verziózási előírással bővítettem a CODE_STANDARDS.md-t.
+- Létrehoztam onboarding és Test Matrix dokumentumokat.
+- Automatikus changelog generáló script készült.
+

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -61,6 +61,8 @@ This document defines the agent-based development workflow for the **Wrecept** d
 * Prepares service interfaces for data access and UI logic.
 * Validates all operations before passing to persistence.
 * Coordinates with `storage_agent` and `logic_agent`.
+* `InvoiceEditor` fejlesztését csak akkor kezdheti meg, ha az
+  [ARCHITECTURE.md](ARCHITECTURE.md) alapján megértette az adatútvonalakat.
 
 ---
 

--- a/docs/CODE_STANDARDS.md
+++ b/docs/CODE_STANDARDS.md
@@ -32,4 +32,9 @@ A kód minden rétegében egységes konvenciókat követünk, hogy a projekt át
 * A CommunityToolkit.Mvvm `ObservableProperty` és `RelayCommand` attribútumait használjuk a ViewModelben.
 * Az automatikusan generált fájlokat a `Generated` mappában tartjuk, hogy elkülönüljenek a kézzel írt kódtól.
 
+## Verziózási szabályok
+
+* A `main` ágba kizárólag olyan commit kerülhet, amelyhez kódfedettségi jelentés tartozik.
+* A merge csak akkor engedélyezett, ha minden itt rögzített szabálynak megfelel a kód.
+
 ---

--- a/docs/README.md
+++ b/docs/README.md
@@ -86,3 +86,15 @@ Reconstruction by: \[ChatGPT-Dev Agent – 2025 Edition]
 ---
 
 *Work in Progress – Not intended for production use (yet).*
+
+---
+
+## 📚 Dokumentációk
+
+- [ARCHITECTURE.md](ARCHITECTURE.md) – Rétegek és adatútvonalak
+- [AGENTS.md](AGENTS.md) – Agent feladatkiosztás
+- [CODE_STANDARDS.md](CODE_STANDARDS.md) – Kódolási irányelvek
+- [DEV_SPECS.md](DEV_SPECS.md) – Fejlesztési specifikáció
+- [ERROR_HANDLING.md](ERROR_HANDLING.md) – Hibatűrés
+- [FAULT_PLAN.md](FAULT_PLAN.md) – Hibabefecskendezési terv
+- [TEST_STRATEGY.md](TEST_STRATEGY.md) – Tesztstratégia

--- a/docs/TEST_MATRIX.md
+++ b/docs/TEST_MATRIX.md
@@ -1,0 +1,14 @@
+---
+title: "Test Matrix"
+purpose: "Use-case coverage for reliability"
+author: "docs_agent"
+date: "2025-06-27"
+---
+
+# 🧪 Test Matrix
+
+| Szituáció        | Elvárt viselkedés                                                                 |
+|------------------|----------------------------------------------------------------------------------|
+| UI lock          | Az alkalmazás újra fókuszálja az aktív elemet vagy visszaáll alapállapotba.       |
+| Network loss     | A lokális műveletek zavartalanul folytatódnak, figyelmeztető üzenet jelenik meg. |
+| Corrupted invoice| A betöltés megszakad, a hibát naplózzuk és a felhasználót tájékoztatjuk.          |

--- a/docs/manuals/developer_onboarding_hu.md
+++ b/docs/manuals/developer_onboarding_hu.md
@@ -1,0 +1,15 @@
+---
+title: "Developer Onboarding"
+purpose: "Új fejlesztők belépési útmutatója"
+author: "docs_agent"
+date: "2025-06-27"
+---
+
+# 🚀 Developer Onboarding
+
+Az alábbi lépések segítenek a projekt gyors megismerésében:
+
+1. Olvasd el a [README.md](../README.md) és a [DEV_SPECS.md](../DEV_SPECS.md) fájlokat.
+2. Tanulmányozd át az [ARCHITECTURE.md](../ARCHITECTURE.md)-t a rétegek és adatútvonalak megértéséhez.
+3. Kövesd a [CODE_STANDARDS.md](../CODE_STANDARDS.md) ajánlásait.
+4. A haladásodat rögzítsd a `docs/progress` mappában a megfelelő formátumban.

--- a/docs/progress/2025-06-27_22-30-08_docs_agent.md
+++ b/docs/progress/2025-06-27_22-30-08_docs_agent.md
@@ -1,0 +1,7 @@
+# Progress Log - 2025-06-27 22:30 UTC
+
+* Hivatkozásokat adtam a README.md aljára a fő dokumentumokra.
+* Szabályt rögzítettem az AGENTS.md-ben az InvoiceEditor indulásához.
+* Verziózási előírással bővítettem a CODE_STANDARDS.md-t.
+* Létrehoztam onboarding és Test Matrix dokumentumokat.
+* Automatikus changelog generáló script készült.

--- a/tools/generate_changelog.py
+++ b/tools/generate_changelog.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+import pathlib
+import re
+
+progress_dir = pathlib.Path('docs/progress')
+changelog = pathlib.Path('CHANGELOG.md')
+
+entries = []
+for path in sorted(progress_dir.glob('*.md')):
+    stamp = path.stem.split('_')[0]
+    lines = path.read_text(encoding='utf-8').splitlines()
+    bullets = [re.sub(r'^\*\s+', '', l) for l in lines if l.startswith('*')]
+    if bullets:
+        entries.append((stamp, bullets))
+
+with changelog.open('w', encoding='utf-8') as f:
+    f.write('---\n')
+    f.write('title: "Changelog"\n')
+    f.write('purpose: "Aggregated changes from progress logs"\n')
+    f.write('author: "tools"\n')
+    f.write('date: "2025-06-27"\n')
+    f.write('---\n\n')
+    f.write('# 📝 Changelog\n\n')
+    for stamp, bullets in entries:
+        f.write(f'## {stamp}\n')
+        for b in bullets:
+            f.write(f'- {b}\n')
+        f.write('\n')


### PR DESCRIPTION
## Summary
- link all major docs at the end of `docs/README.md`
- require architecture understanding before starting `InvoiceEditor`
- set commit rules in `CODE_STANDARDS.md`
- add onboarding manual and test matrix docs
- add changelog generator script and run it

## Testing
- `tools/generate_changelog.py`


------
https://chatgpt.com/codex/tasks/task_e_685f1aadcc248322af1e0b6528e6da86