### PR TITLE
Add supplier lookup and bind editor view

### DIFF
--- a/Wrecept.Desktop/ViewModels/StageViewModel.cs
+++ b/Wrecept.Desktop/ViewModels/StageViewModel.cs
@@ -6,12 +6,20 @@ public partial class StageViewModel : ObservableObject
 {
     public MainMenuViewModel Menu { get; } = new();
     public InvoiceEditorViewModel Editor { get; } = new();
+    public SupplierLookupViewModel SupplierLookup { get; } = new();
 
     [ObservableProperty]
     private bool showEditor;
 
+    [ObservableProperty]
+    private bool showSupplierLookup;
+
     public StageViewModel()
     {
-        Menu.ItemActivated += idx => ShowEditor = idx == 0;
+        Menu.ItemActivated += idx =>
+        {
+            ShowEditor = idx == 0;
+            ShowSupplierLookup = idx == 2;
+        };
     }
 }

--- a/Wrecept.Desktop/ViewModels/SupplierLookupViewModel.cs
+++ b/Wrecept.Desktop/ViewModels/SupplierLookupViewModel.cs
@@ -1,0 +1,16 @@
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+using Wrecept.Core.Models;
+
+namespace Wrecept.Desktop.ViewModels;
+
+public partial class SupplierLookupViewModel : ObservableObject
+{
+    public ObservableCollection<Supplier> Suppliers { get; } = new();
+
+    public SupplierLookupViewModel()
+    {
+        Suppliers.Add(new Supplier { Id = 1, Name = "Teszt Kft." });
+        Suppliers.Add(new Supplier { Id = 2, Name = "Minta Bt." });
+    }
+}

--- a/Wrecept.Desktop/Views/StageView.xaml
+++ b/Wrecept.Desktop/Views/StageView.xaml
@@ -14,6 +14,14 @@
 
         <views:MainMenu x:Name="Menu" />
 
-        <views:InvoiceEditorView x:Name="Editor" Grid.Row="1" Visibility="{Binding ShowEditor, Converter={StaticResource BooleanToVisibilityConverter}}" />
+        <views:InvoiceEditorView x:Name="Editor"
+                                 DataContext="{Binding Editor}"
+                                 Grid.Row="1"
+                                 Visibility="{Binding ShowEditor, Converter={StaticResource BooleanToVisibilityConverter}}" />
+
+        <views:SupplierLookupView x:Name="SupplierLookup"
+                                  DataContext="{Binding SupplierLookup}"
+                                  Grid.Row="1"
+                                  Visibility="{Binding ShowSupplierLookup, Converter={StaticResource BooleanToVisibilityConverter}}" />
     </Grid>
 </UserControl>

--- a/Wrecept.Desktop/Views/SupplierLookupView.xaml
+++ b/Wrecept.Desktop/Views/SupplierLookupView.xaml
@@ -1,0 +1,20 @@
+<UserControl x:Class="Wrecept.Desktop.Views.SupplierLookupView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             d:DesignHeight="300" d:DesignWidth="800">
+    <Grid Background="{DynamicResource StageBackground}">
+        <StackPanel>
+            <TextBlock Text="Beszállítók" FontWeight="Bold" />
+            <ListBox ItemsSource="{Binding Suppliers}">
+                <ListBox.ItemTemplate>
+                    <DataTemplate>
+                        <TextBlock Text="{Binding Name}" />
+                    </DataTemplate>
+                </ListBox.ItemTemplate>
+            </ListBox>
+        </StackPanel>
+    </Grid>
+</UserControl>

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -37,4 +37,6 @@ A felhasználói események a ViewModelen keresztül jutnak el a Core-hoz, amely
 
 Az `DbContext` példányai a Storage rétegben élnek. A migrációk és a sémafrissítések parancssori eszközzel, CI környezetben futnak. A ViewModel soha nem fér közvetlenül az adatbázishoz.
 
+Az adatlekérést repositoryk végzik, amelyek `IInvoiceRepository`, `IProductRepository` és `ISupplierRepository` interfészeket valósítanak meg. Ezek felelősek a hibák naplózásáért és az üres listákkal való visszatérésért hiba esetén.
+
 ---

--- a/docs/progress/2025-06-27_22-54-24_root_agent.md
+++ b/docs/progress/2025-06-27_22-54-24_root_agent.md
@@ -1,0 +1,5 @@
+# Progress Log - 2025-06-27 22:54 UTC
+
+* Added SupplierLookupView and ViewModel with sample data.
+* Bound InvoiceEditor and Supplier views properly in StageView.
+* Extended StageViewModel to switch views based on menu selection.


### PR DESCRIPTION
## Summary
- introduce `SupplierLookupView` and ViewModel with sample suppliers
- show supplier list based on menu selection
- wire InvoiceEditorView and SupplierLookupView to StageViewModel
- document EF Core repository flow
- log progress for milestone 2 work

## Testing
- `dotnet test --no-build` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f20751a888322a54b6a1b61e14128