### PR TITLE
Implement EF Core invoice persistence

### DIFF
--- a/Wrecept.Core/Models/Invoice.cs
+++ b/Wrecept.Core/Models/Invoice.cs
@@ -3,7 +3,9 @@ namespace Wrecept.Core.Models;
 public class Invoice
 {
     public int Id { get; set; }
-    public string Name { get; set; } = string.Empty;
-    public decimal Net { get; set; }
-    public decimal Gross { get; set; }
+    public string Number { get; set; } = string.Empty;
+    public DateOnly Date { get; set; }
+    public int SupplierId { get; set; }
+    public Supplier? Supplier { get; set; }
+    public ICollection<InvoiceItem> Items { get; set; } = new List<InvoiceItem>();
 }

--- a/Wrecept.Core/Models/InvoiceItem.cs
+++ b/Wrecept.Core/Models/InvoiceItem.cs
@@ -1,0 +1,11 @@
+namespace Wrecept.Core.Models;
+
+public class InvoiceItem
+{
+    public int Id { get; set; }
+    public int InvoiceId { get; set; }
+    public Invoice? Invoice { get; set; }
+    public string Description { get; set; } = string.Empty;
+    public decimal Quantity { get; set; }
+    public decimal UnitPrice { get; set; }
+}

--- a/Wrecept.Core/Models/Supplier.cs
+++ b/Wrecept.Core/Models/Supplier.cs
@@ -4,6 +4,5 @@ public class Supplier
 {
     public int Id { get; set; }
     public string Name { get; set; } = string.Empty;
-    public decimal Net { get; set; }
-    public decimal Gross { get; set; }
+    public string? TaxId { get; set; }
 }

--- a/Wrecept.Core/Repositories/IInvoiceRepository.cs
+++ b/Wrecept.Core/Repositories/IInvoiceRepository.cs
@@ -1,0 +1,9 @@
+using Wrecept.Core.Models;
+
+namespace Wrecept.Core.Repositories;
+
+public interface IInvoiceRepository
+{
+    Task<int> AddAsync(Invoice invoice, CancellationToken ct = default);
+    Task<Invoice?> GetAsync(int id, CancellationToken ct = default);
+}

--- a/Wrecept.Core/Repositories/IProductRepository.cs
+++ b/Wrecept.Core/Repositories/IProductRepository.cs
@@ -1,0 +1,8 @@
+using Wrecept.Core.Models;
+
+namespace Wrecept.Core.Repositories;
+
+public interface IProductRepository
+{
+    Task<List<Product>> GetAllAsync(CancellationToken ct = default);
+}

--- a/Wrecept.Core/Repositories/ISupplierRepository.cs
+++ b/Wrecept.Core/Repositories/ISupplierRepository.cs
@@ -1,0 +1,8 @@
+using Wrecept.Core.Models;
+
+namespace Wrecept.Core.Repositories;
+
+public interface ISupplierRepository
+{
+    Task<List<Supplier>> GetAllAsync(CancellationToken ct = default);
+}

--- a/Wrecept.Core/Services/IInvoiceService.cs
+++ b/Wrecept.Core/Services/IInvoiceService.cs
@@ -1,0 +1,9 @@
+using Wrecept.Core.Models;
+
+namespace Wrecept.Core.Services;
+
+public interface IInvoiceService
+{
+    Task<bool> CreateAsync(Invoice invoice, CancellationToken ct = default);
+    Task<Invoice?> GetAsync(int id, CancellationToken ct = default);
+}

--- a/Wrecept.Core/Services/InvoiceService.cs
+++ b/Wrecept.Core/Services/InvoiceService.cs
@@ -1,0 +1,26 @@
+using Wrecept.Core.Models;
+using Wrecept.Core.Repositories;
+
+namespace Wrecept.Core.Services;
+
+public class InvoiceService : IInvoiceService
+{
+    private readonly IInvoiceRepository _invoices;
+
+    public InvoiceService(IInvoiceRepository invoices)
+    {
+        _invoices = invoices;
+    }
+
+    public async Task<bool> CreateAsync(Invoice invoice, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(invoice.Number)) return false;
+        if (invoice.Items.Count == 0) return false;
+        if (invoice.Items.Any(i => i.Quantity <= 0)) return false;
+        await _invoices.AddAsync(invoice, ct);
+        return true;
+    }
+
+    public Task<Invoice?> GetAsync(int id, CancellationToken ct = default)
+        => _invoices.GetAsync(id, ct);
+}

--- a/Wrecept.Desktop/ServiceLocator.cs
+++ b/Wrecept.Desktop/ServiceLocator.cs
@@ -1,0 +1,17 @@
+using Wrecept.Core.Services;
+using Wrecept.Storage.Data;
+using Wrecept.Storage.Repositories;
+
+namespace Wrecept.Desktop;
+
+public static class ServiceLocator
+{
+    public static IInvoiceService InvoiceService { get; }
+
+    static ServiceLocator()
+    {
+        var db = new AppDbContext("wrecept.db");
+        var invoiceRepo = new InvoiceRepository(db);
+        InvoiceService = new InvoiceService(invoiceRepo);
+    }
+}

--- a/Wrecept.Desktop/ViewModels/InvoiceEditorViewModel.cs
+++ b/Wrecept.Desktop/ViewModels/InvoiceEditorViewModel.cs
@@ -1,16 +1,65 @@
 using System.Collections.ObjectModel;
 using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Wrecept.Core.Models;
+using Wrecept.Core.Services;
 
 namespace Wrecept.Desktop.ViewModels;
 
 public partial class InvoiceEditorViewModel : ObservableObject
 {
+    private readonly IInvoiceService _service;
+
+    [ObservableProperty]
+    private string number = string.Empty;
+
+    [ObservableProperty]
+    private DateOnly date = DateOnly.FromDateTime(DateTime.Today);
+
+    [ObservableProperty]
+    private string supplierName = string.Empty;
+
     public ObservableCollection<ItemRow> Items { get; } = new();
 
-    public InvoiceEditorViewModel()
+    public IRelayCommand SaveCommand { get; }
+
+    public InvoiceEditorViewModel(IInvoiceService service)
     {
-        Items.Add(new ItemRow("Tétel 1", 100m, 127m));
+        _service = service;
+        SaveCommand = new RelayCommand(async () => await SaveAsync());
+        Items.Add(new ItemRow());
+    }
+
+    private async Task SaveAsync()
+    {
+        var invoice = new Invoice
+        {
+            Number = Number,
+            Date = Date,
+            Supplier = new Supplier { Name = SupplierName },
+            Items = Items.Select(i => new InvoiceItem
+            {
+                Description = i.Description,
+                Quantity = i.Quantity,
+                UnitPrice = i.UnitPrice
+            }).ToList()
+        };
+
+        var success = await _service.CreateAsync(invoice);
+        if (!success)
+        {
+            System.Diagnostics.Debug.WriteLine("Hibás számla adatok");
+        }
+        else
+        {
+            System.Diagnostics.Debug.WriteLine("Számla mentve");
+        }
     }
 }
 
-public record ItemRow(string Name, decimal Net, decimal Gross);
+public partial class ItemRow : ObservableObject
+{
+    [ObservableProperty] private string description = string.Empty;
+    [ObservableProperty] private decimal quantity = 1;
+    [ObservableProperty] private decimal unitPrice;
+}

--- a/Wrecept.Desktop/ViewModels/StageViewModel.cs
+++ b/Wrecept.Desktop/ViewModels/StageViewModel.cs
@@ -1,11 +1,12 @@
 using CommunityToolkit.Mvvm.ComponentModel;
+using Wrecept.Desktop;
 
 namespace Wrecept.Desktop.ViewModels;
 
 public partial class StageViewModel : ObservableObject
 {
     public MainMenuViewModel Menu { get; } = new();
-    public InvoiceEditorViewModel Editor { get; } = new();
+    public InvoiceEditorViewModel Editor { get; } = new(ServiceLocator.InvoiceService);
     public SupplierLookupViewModel SupplierLookup { get; } = new();
 
     [ObservableProperty]

--- a/Wrecept.Desktop/Views/InvoiceEditorView.xaml
+++ b/Wrecept.Desktop/Views/InvoiceEditorView.xaml
@@ -5,20 +5,32 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="d"
              d:DesignHeight="400" d:DesignWidth="800">
-    <Grid Background="{DynamicResource StageBackground}">
+    <Grid Background="{DynamicResource StageBackground}" Padding="10">
         <StackPanel>
-            <TextBlock Text="Invoice Items" FontWeight="Bold" />
-            <ListBox ItemsSource="{Binding Items}">
+            <StackPanel Orientation="Horizontal" Margin="0 0 0 5">
+                <TextBlock Text="Számlaszám:" Width="80" />
+                <TextBox Text="{Binding Number, UpdateSourceTrigger=PropertyChanged}" Width="120" />
+            </StackPanel>
+            <StackPanel Orientation="Horizontal" Margin="0 0 0 5">
+                <TextBlock Text="Beszállító:" Width="80" />
+                <TextBox Text="{Binding SupplierName, UpdateSourceTrigger=PropertyChanged}" Width="200" />
+            </StackPanel>
+            <StackPanel Orientation="Horizontal" Margin="0 0 0 10">
+                <TextBlock Text="Dátum:" Width="80" />
+                <DatePicker SelectedDate="{Binding Date}" />
+            </StackPanel>
+            <ListBox ItemsSource="{Binding Items}" Margin="0 0 0 10">
                 <ListBox.ItemTemplate>
                     <DataTemplate>
                         <StackPanel Orientation="Horizontal">
-                            <TextBlock Text="{Binding Name}" Width="200" />
-                            <TextBlock Text="{Binding Net}" Width="100" />
-                            <TextBlock Text="{Binding Gross}" Width="100" />
+                            <TextBox Text="{Binding Description, UpdateSourceTrigger=PropertyChanged}" Width="200" />
+                            <TextBox Text="{Binding Quantity, UpdateSourceTrigger=PropertyChanged}" Width="60" />
+                            <TextBox Text="{Binding UnitPrice, UpdateSourceTrigger=PropertyChanged}" Width="80" />
                         </StackPanel>
                     </DataTemplate>
                 </ListBox.ItemTemplate>
             </ListBox>
+            <Button Content="Mentés" Command="{Binding SaveCommand}" Width="100" />
         </StackPanel>
     </Grid>
 </UserControl>

--- a/Wrecept.Storage/Data/AppDbContext.cs
+++ b/Wrecept.Storage/Data/AppDbContext.cs
@@ -3,13 +3,26 @@ using Wrecept.Core.Models;
 
 namespace Wrecept.Storage.Data;
 
-// DbContext will be enabled in a later milestone
 public class AppDbContext : DbContext
 {
-    // public DbSet<Invoice> Invoices => Set<Invoice>();
-    // public DbSet<Product> Products => Set<Product>();
-    // public DbSet<Supplier> Suppliers => Set<Supplier>();
+    public DbSet<Invoice> Invoices => Set<Invoice>();
+    public DbSet<InvoiceItem> InvoiceItems => Set<InvoiceItem>();
+    public DbSet<Product> Products => Set<Product>();
+    public DbSet<Supplier> Suppliers => Set<Supplier>();
 
-    // protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-    //     => optionsBuilder.UseSqlite("Data Source=wrecept.db");
+    private readonly string _dbPath;
+
+    public AppDbContext(string dbPath)
+    {
+        _dbPath = dbPath;
+    }
+
+    public AppDbContext(DbContextOptions<AppDbContext> options, string dbPath)
+        : base(options)
+    {
+        _dbPath = dbPath;
+    }
+
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        => optionsBuilder.UseSqlite($"Data Source={_dbPath}");
 }

--- a/Wrecept.Storage/Repositories/InvoiceRepository.cs
+++ b/Wrecept.Storage/Repositories/InvoiceRepository.cs
@@ -1,4 +1,29 @@
+using Microsoft.EntityFrameworkCore;
+using Wrecept.Core.Models;
+using Wrecept.Core.Repositories;
+using Wrecept.Storage.Data;
+
 namespace Wrecept.Storage.Repositories;
 
-// Placeholder repository; real implementation will arrive in later milestones
-public class InvoiceRepository { }
+public class InvoiceRepository : IInvoiceRepository
+{
+    private readonly AppDbContext _db;
+
+    public InvoiceRepository(AppDbContext db)
+    {
+        _db = db;
+        _db.Database.EnsureCreated();
+    }
+
+    public async Task<int> AddAsync(Invoice invoice, CancellationToken ct = default)
+    {
+        _db.Invoices.Add(invoice);
+        await _db.SaveChangesAsync(ct);
+        return invoice.Id;
+    }
+
+    public Task<Invoice?> GetAsync(int id, CancellationToken ct = default)
+        => _db.Invoices
+            .Include(i => i.Items)
+            .FirstOrDefaultAsync(i => i.Id == id, ct);
+}

--- a/Wrecept.Storage/Repositories/ProductRepository.cs
+++ b/Wrecept.Storage/Repositories/ProductRepository.cs
@@ -1,3 +1,20 @@
+using Microsoft.EntityFrameworkCore;
+using Wrecept.Core.Models;
+using Wrecept.Core.Repositories;
+using Wrecept.Storage.Data;
+
 namespace Wrecept.Storage.Repositories;
 
-public class ProductRepository { }
+public class ProductRepository : IProductRepository
+{
+    private readonly AppDbContext _db;
+
+    public ProductRepository(AppDbContext db)
+    {
+        _db = db;
+        _db.Database.EnsureCreated();
+    }
+
+    public Task<List<Product>> GetAllAsync(CancellationToken ct = default)
+        => _db.Products.ToListAsync(ct);
+}

--- a/Wrecept.Storage/Repositories/SupplierRepository.cs
+++ b/Wrecept.Storage/Repositories/SupplierRepository.cs
@@ -1,3 +1,20 @@
+using Microsoft.EntityFrameworkCore;
+using Wrecept.Core.Models;
+using Wrecept.Core.Repositories;
+using Wrecept.Storage.Data;
+
 namespace Wrecept.Storage.Repositories;
 
-public class SupplierRepository { }
+public class SupplierRepository : ISupplierRepository
+{
+    private readonly AppDbContext _db;
+
+    public SupplierRepository(AppDbContext db)
+    {
+        _db = db;
+        _db.Database.EnsureCreated();
+    }
+
+    public Task<List<Supplier>> GetAllAsync(CancellationToken ct = default)
+        => _db.Suppliers.ToListAsync(ct);
+}

--- a/Wrecept.Tests/InvoiceServiceTests.cs
+++ b/Wrecept.Tests/InvoiceServiceTests.cs
@@ -1,0 +1,25 @@
+using Microsoft.EntityFrameworkCore;
+using Wrecept.Core.Models;
+using Wrecept.Core.Services;
+using Wrecept.Storage.Data;
+using Wrecept.Storage.Repositories;
+
+namespace Wrecept.Tests;
+
+public class InvoiceServiceTests
+{
+    [Fact]
+    public async Task CreateInvoice_WithoutItems_Fails()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase("test")
+            .Options;
+        await using var ctx = new AppDbContext(options, "test.db");
+        var repo = new InvoiceRepository(ctx);
+        var service = new InvoiceService(repo);
+
+        var invoice = new Invoice { Number = "A-1", Date = DateOnly.FromDateTime(DateTime.Today) };
+        var result = await service.CreateAsync(invoice);
+        Assert.False(result);
+    }
+}

--- a/Wrecept.Tests/Wrecept.Tests.csproj
+++ b/Wrecept.Tests/Wrecept.Tests.csproj
@@ -20,6 +20,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/docs/ERROR_HANDLING.md
+++ b/docs/ERROR_HANDLING.md
@@ -30,5 +30,6 @@ Ez a dokumentum összefoglalja a hibakezelési stratégiát. Cél, hogy az alkal
 1. **Adatbázis fájl hiánya** – Ha a `wrecept.db` nem található indításkor, a Storage réteg új üres adatbázist hoz létre, majd figyelmeztető üzenetet jelenítünk meg.
 2. **Sérült import fájl** – Hibás formátumú vagy hiányzó adatfájl betöltésekor megszakítjuk a folyamatot, naplózzuk a fájl nevét és a kiváltó hibát, és lehetőséget adunk új fájl kiválasztására.
 3. **Hálózati kimaradás** – Külső frissítések letöltése közben kapcsolatvesztés esetén újrapróbálkozunk, majd offline módra váltunk, miközben a felhasználót tájékoztatjuk.
+4. **Sikertelen adatbázis írás** – Ha a fájl zárolt vagy elfogy a tárhely, hibaüzenetet jelenítünk meg, a műveletet naplózzuk, majd biztonsági mentés után újrapróbáljuk.
 
 ---

--- a/docs/TEST_STRATEGY.md
+++ b/docs/TEST_STRATEGY.md
@@ -13,6 +13,7 @@ A Wrecept stabilitását több szinten biztosítjuk.
 
 1. **Unit tesztek** – A Core és ViewModel rétegek logikáját izoláltan ellenőrizzük.
 2. **Integration tesztek** – Adatbázis műveletek és szolgáltatások együttműködését vizsgáljuk SQLite in-memory módban.
+   * Egy külön teszt a fizikai `wrecept.db` fájlon fut, hogy ellenőrizzük a tényleges mentést és betöltést.
 3. **UI tesztek** – A WPF nézetek billentyű-kezelését automatizáltan teszteljük, például WinAppDriverrel.
 
 ## Hülyebiztos validáció

--- a/docs/progress/2025-06-27_23-03-31_core_agent.md
+++ b/docs/progress/2025-06-27_23-03-31_core_agent.md
@@ -1,0 +1,5 @@
+# Progress Log - 2025-06-27 23:03 UTC
+
+* Elkészítettem az első valódi domain modell struktúrákat (Invoice, InvoiceItem, Supplier).
+* Bevezettem EF Core alapú repositorykat és szolgáltatást.
+* Az InvoiceEditorViewModel immár menti az adatokat SQLite adatbázisba.


### PR DESCRIPTION
## Summary
- add invoice, invoice item and supplier domain models
- create EF Core repositories and invoice service
- implement invoice editor view model with Save command
- wire up ServiceLocator and StageViewModel
- expand error handling docs for DB write failures
- outline integration test case for persistence
- add a basic unit test
- log progress

## Testing
- `dotnet test` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f227ca070832288c9db6c27e616cd