### PR TITLE
Ensure WPF startup files present

### DIFF
--- a/Wrecept.Desktop/Program.cs
+++ b/Wrecept.Desktop/Program.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Windows;
+
+namespace Wrecept.Desktop;
+
+public static class Program
+{
+    [STAThread]
+    public static void Main()
+    {
+        var app = new App();
+        app.InitializeComponent();
+        app.Run();
+    }
+}

--- a/Wrecept.Desktop/Wrecept.Desktop.csproj
+++ b/Wrecept.Desktop/Wrecept.Desktop.csproj
@@ -5,6 +5,7 @@
     <Nullable>enable</Nullable>
     <OutputType>WinExe</OutputType>
     <UseWPF>true</UseWPF>
+    <StartupObject>Wrecept.Desktop.Program</StartupObject>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.0" />

--- a/Wrecept.Tests/MainWindowLaunchTests.cs
+++ b/Wrecept.Tests/MainWindowLaunchTests.cs
@@ -1,0 +1,24 @@
+using Xunit;
+using System.Threading;
+using Wrecept.Desktop;
+
+namespace Wrecept.Tests;
+
+public class MainWindowLaunchTests
+{
+    [StaFact]
+    public void MainWindow_Instantiates()
+    {
+        var t = new Thread(() =>
+        {
+            var app = new App();
+            app.InitializeComponent();
+            var window = new MainWindow();
+            // we don't show the window to avoid GUI requirement
+        });
+        t.SetApartmentState(ApartmentState.STA);
+        t.Start();
+        t.Join();
+        Assert.False(t.IsAlive);
+    }
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -75,6 +75,18 @@ Wrecept.Desktop/
 4. Discuss minimal database model based on real .dbf structure
 5. Kötelező induló tennivalók a [DEV_SPECS.md](DEV_SPECS.md) "Kick OFF" szakaszában
 
+## ✅ Kick OFF
+
+A WPF indító projekt helyes működéséhez a `Wrecept.Desktop` mappában az alábbi fájlok és beállítások szükségesek:
+
+* `App.xaml` benne `<Application StartupUri="MainWindow.xaml" />`
+* `App.xaml.cs` részleges osztály
+* `MainWindow.xaml` mint kezdő nézet
+* a projektfájlban `<OutputType>WinExe</OutputType>` és `<UseWPF>true</UseWPF>`
+* `[STAThread]` attribútummal ellátott `Main()` belépési pont (generált vagy `Program.cs`-ben)
+
+Ezen indító fájlok nélkül a build nem hoz létre futtatható `.exe` állományt.
+
 ---
 
 ## 🧾 Credits

--- a/docs/progress/2025-06-27_23-17-03_code_agent.md
+++ b/docs/progress/2025-06-27_23-17-03_code_agent.md
@@ -1,0 +1,6 @@
+# Progress Log - 2025-06-27 23:17 UTC
+
+* Ellenőriztem a Wrecept.Desktop projekt beállításait, minden szükséges WPF indítófájl meglévő.
+* Hozzáadtam explicit `Program.cs`-t STAThread Main metódussal és frissítettem a projektfájlt.
+* Létrehoztam `MainWindowLaunchTests` osztályt, ami ellenőrzi az ablak példányosítását.
+* Bővítettem a README Kick OFF szakaszát a szükséges indítófájlok listájával.


### PR DESCRIPTION
## Summary
- add explicit `Program` entry point for Wrecept.Desktop
- document required startup files in Kick OFF section
- add minimal MainWindow launch test
- log actions in progress log

## Testing
- `dotnet test Wrecept.Tests/Wrecept.Tests.csproj -c Release` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f25a9150883229cfd7b228a53f811