### PR TITLE
Fix InvoiceEditorView padding and update progress log

### DIFF
--- a/Wrecept.Desktop/Views/InvoiceEditorView.xaml
+++ b/Wrecept.Desktop/Views/InvoiceEditorView.xaml
@@ -5,8 +5,8 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="d"
              d:DesignHeight="400" d:DesignWidth="800">
-    <Grid Background="{DynamicResource StageBackground}" Padding="10">
-        <StackPanel>
+    <Border Background="{DynamicResource StageBackground}" Padding="10">
+        <Grid>
             <StackPanel Orientation="Horizontal" Margin="0 0 0 5">
                 <TextBlock Text="Számlaszám:" Width="80" />
                 <TextBox Text="{Binding Number, UpdateSourceTrigger=PropertyChanged}" Width="120" />
@@ -32,5 +32,6 @@
             </ListBox>
             <Button Content="Mentés" Command="{Binding SaveCommand}" Width="100" />
         </StackPanel>
-    </Grid>
+        </Grid>
+    </Border>
 </UserControl>

--- a/docs/progress/2025-06-27_23-21-43_CodeGen-XAML.md
+++ b/docs/progress/2025-06-27_23-21-43_CodeGen-XAML.md
@@ -1,0 +1,4 @@
+# Progress Log - 2025-06-27 23:21 UTC
+
+* Kijavítottam a `InvoiceEditorView` XAML hibáját: a Grid `Padding` tulajdonságát `Border` elemre cseréltem.
+* A módosítások után futtattam a `dotnet test` parancsot, de a környezet hiányzó Windows Desktop SDK miatt nem tudott buildelni.


### PR DESCRIPTION
## Summary
- fix build error by moving Padding to a Border in `InvoiceEditorView.xaml`
- add progress log for CodeGen-XAML agent

## Testing
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets missing)*

------
https://chatgpt.com/codex/tasks/task_e_685f270e76c08322907ee48c317de0cd