### PR TITLE
Fix InvoiceEditorView tag mismatch

### DIFF
--- a/Wrecept.Desktop/Views/InvoiceEditorView.xaml
+++ b/Wrecept.Desktop/Views/InvoiceEditorView.xaml
@@ -31,7 +31,6 @@
                 </ListBox.ItemTemplate>
             </ListBox>
             <Button Content="Mentés" Command="{Binding SaveCommand}" Width="100" />
-        </StackPanel>
         </Grid>
     </Border>
 </UserControl>

--- a/docs/progress/2025-06-27_23-26-05_root_agent.md
+++ b/docs/progress/2025-06-27_23-26-05_root_agent.md
@@ -1,0 +1,4 @@
+# Progress Log - 2025-06-27 23:26 UTC
+
+* Removed stray `</StackPanel>` from `InvoiceEditorView.xaml`.
+* Build attempted after installing .NET SDK 8, but failed due to missing Windows Desktop SDK.


### PR DESCRIPTION
## Summary
- correct closing tag in `InvoiceEditorView.xaml`
- log progress of fix

## Testing
- `dotnet build Wrecept.sln -c Debug` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*
- `dotnet test Wrecept.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f27fbc7908322924474d13a428f65