### PR TITLE
Fix project references and XAML padding

### DIFF
--- a/Wrecept.Desktop/Views/InvoiceEditorView.xaml
+++ b/Wrecept.Desktop/Views/InvoiceEditorView.xaml
@@ -5,7 +5,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="d"
              d:DesignHeight="400" d:DesignWidth="800">
-    <Border Background="{DynamicResource StageBackground}" Padding="10">
+    <Border Background="{DynamicResource StageBackground}" Margin="10">
         <Grid>
             <StackPanel Orientation="Horizontal" Margin="0 0 0 5">
                 <TextBlock Text="Számlaszám:" Width="80" />

--- a/Wrecept.Desktop/Wrecept.Desktop.csproj
+++ b/Wrecept.Desktop/Wrecept.Desktop.csproj
@@ -12,5 +12,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Wrecept.Core\Wrecept.Core.csproj" />
+    <ProjectReference Include="..\Wrecept.Storage\Wrecept.Storage.csproj" />
   </ItemGroup>
 </Project>

--- a/Wrecept.Tests/Wrecept.Tests.csproj
+++ b/Wrecept.Tests/Wrecept.Tests.csproj
@@ -25,6 +25,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Wrecept.Desktop\Wrecept.Desktop.csproj" />
+    <ProjectReference Include="..\Wrecept.Storage\Wrecept.Storage.csproj" />
   </ItemGroup>
 
 </Project>

--- a/docs/progress/2025-06-27_23-34-19_code_agent.md
+++ b/docs/progress/2025-06-27_23-34-19_code_agent.md
@@ -1,0 +1,4 @@
+- Verified build errors with dotnet SDK.
+- Added ProjectReference to Wrecept.Storage from Desktop and Tests.
+- Updated InvoiceEditorView to use Margin instead of Padding.
+- Build still fails due to missing Microsoft.NET.Sdk.WindowsDesktop on Linux.


### PR DESCRIPTION
## Summary
- use Margin instead of Padding in `InvoiceEditorView`
- reference `Wrecept.Storage` from desktop and test projects
- log build attempts

## Testing
- `dotnet build Wrecept.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f2970a18c8322a2a7a3a4a385dd03