### PR TITLE
Fix converter resource and StaFact package

### DIFF
--- a/Wrecept.Desktop/App.xaml
+++ b/Wrecept.Desktop/App.xaml
@@ -5,7 +5,6 @@
              StartupUri="MainWindow.xaml">
     <Application.Resources>
         <ResourceDictionary>
-            <local:EqualityConverter x:Key="EqualityConverter" />
             <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="Themes/RetroTheme.xaml" />

--- a/Wrecept.Desktop/Themes/RetroTheme.xaml
+++ b/Wrecept.Desktop/Themes/RetroTheme.xaml
@@ -1,5 +1,7 @@
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:local="clr-namespace:Wrecept.Desktop">
+    <local:EqualityConverter x:Key="EqualityConverter" />
     <Color x:Key="BackgroundColor">#202020</Color>
     <Color x:Key="ForegroundColor">#E0E0E0</Color>
     <SolidColorBrush x:Key="StageBackground" Color="{StaticResource BackgroundColor}"/>

--- a/Wrecept.Tests/Wrecept.Tests.csproj
+++ b/Wrecept.Tests/Wrecept.Tests.csproj
@@ -20,6 +20,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Xunit.StaFact" Version="1.1.11" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.4" />
   </ItemGroup>
 

--- a/docs/progress/2025-06-27_23-46-32_root_agent.md
+++ b/docs/progress/2025-06-27_23-46-32_root_agent.md
@@ -1,0 +1,3 @@
+- fix build errors by adding Xunit.StaFact package
+- moved EqualityConverter resource into RetroTheme
+- attempted dotnet build but windows desktop SDK missing


### PR DESCRIPTION
## Summary
- add `Xunit.StaFact` package for WPF test support
- move `EqualityConverter` resource to `RetroTheme` for XAML lookup
- log build fixes

## Testing
- `dotnet restore`
- `dotnet build Wrecept.Core/Wrecept.Core.csproj --no-restore`
- `dotnet build Wrecept.Storage/Wrecept.Storage.csproj --no-restore`
- `dotnet build Wrecept.Tests/Wrecept.Tests.csproj --no-restore` *(fails: Microsoft.NET.Sdk.WindowsDesktop missing)*

------
https://chatgpt.com/codex/tasks/task_e_685f2c5e22bc83228778f99940baa9fd