### PR TITLE
Fix Foreground brush for RetroTheme

### DIFF
--- a/Wrecept.Desktop/Themes/RetroTheme.xaml
+++ b/Wrecept.Desktop/Themes/RetroTheme.xaml
@@ -4,10 +4,11 @@
     <local:EqualityConverter x:Key="EqualityConverter" />
     <Color x:Key="BackgroundColor">#202020</Color>
     <Color x:Key="ForegroundColor">#E0E0E0</Color>
+    <SolidColorBrush x:Key="ForegroundBrush" Color="{StaticResource ForegroundColor}"/>
     <SolidColorBrush x:Key="StageBackground" Color="{StaticResource BackgroundColor}"/>
     <SolidColorBrush x:Key="MenuBackground" Color="#303030"/>
     <Style x:Key="MenuItemStyle" TargetType="Button">
-        <Setter Property="Foreground" Value="{StaticResource ForegroundColor}"/>
+        <Setter Property="Foreground" Value="{StaticResource ForegroundBrush}"/>
         <Setter Property="Background" Value="{StaticResource MenuBackground}"/>
         <Setter Property="Margin" Value="2"/>
         <Setter Property="Template">

--- a/docs/progress/2025-06-27_23-54-35_CodeGen-XAML.md
+++ b/docs/progress/2025-06-27_23-54-35_CodeGen-XAML.md
@@ -1,0 +1,5 @@
+# Progress Log - 2025-06-27 23:54 UTC
+
+* A `RetroTheme.xaml` fájlban a `ForegroundColor` erőforrás színként szerepelt, ami `InvalidOperationException`-t okozott a `Foreground` tulajdonsághoz kötve.
+* Létrehoztam `ForegroundBrush` néven ecset erőforrást és átállítottam a `MenuItemStyle` beállítást.
+* A `dotnet test` parancs futtatása hiányzó `dotnet` környezet miatt nem sikerült.


### PR DESCRIPTION
## Summary
- fix invalid Foreground binding by providing a SolidColorBrush resource
- log the change

## Testing
- `dotnet test Wrecept.sln -v minimal` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f2edf37e88322882c2785ebd4816c