### PR TITLE
Fix Viewbox spelling in StageView

### DIFF
--- a/Wrecept.Desktop/Views/StageView.xaml
+++ b/Wrecept.Desktop/Views/StageView.xaml
@@ -21,7 +21,7 @@
             </Grid.ColumnDefinitions>
 
             <!-- Instrument positions placeholder -->
-            <ViewBox Margin="10" Stretch="Fill">
+            <Viewbox Margin="10" Stretch="Fill">
                 <Canvas Width="400" Height="300">
                     <!-- Temporary visual layout -->
                     <Rectangle Width="80" Height="80"
@@ -29,10 +29,10 @@
                                Stroke="{DynamicResource BorderBrushColor}"
                                StrokeThickness="1" />
                 </Canvas>
-            </ViewBox>
+            </Viewbox>
 
             <!-- Amplifier positions placeholder -->
-            <ViewBox Grid.Column="1" Margin="10" Stretch="Fill">
+            <Viewbox Grid.Column="1" Margin="10" Stretch="Fill">
                 <Canvas Width="400" Height="300">
                     <!-- Temporary visual layout -->
                     <Rectangle Width="80" Height="80"
@@ -40,7 +40,7 @@
                                Stroke="{DynamicResource BorderBrushColor}"
                                StrokeThickness="1" />
                 </Canvas>
-            </ViewBox>
+            </Viewbox>
 
             <views:InvoiceEditorView x:Name="Editor"
                                      DataContext="{Binding Editor}"

--- a/docs/progress/2025-06-28_00-46-10_ui_agent.md
+++ b/docs/progress/2025-06-28_00-46-10_ui_agent.md
@@ -1,0 +1,4 @@
+# Progress Log - 2025-06-28 00:46 UTC
+
+* Kijavítottam a StageView XAML hibáját: a `ViewBox` elem helyesen `Viewbox` lett.
+* A build még mindig hiányolja a Windows Desktop SDK-t az aktuális környezetben.


### PR DESCRIPTION
## Summary
- correct `<Viewbox>` tag in StageView to fix MC3074 error
- log fix in progress notes

## Testing
- `dotnet build Wrecept.sln -consoleloggerparameters:Summary -nologo` *(fails: Microsoft.NET.Sdk.WindowsDesktop missing)*
- `dotnet test Wrecept.sln --no-build -v minimal` *(fails: Microsoft.NET.Sdk.WindowsDesktop missing)*

------
https://chatgpt.com/codex/tasks/task_e_685f3af7a0d88322a7a68dd3f53a6534