### PR TITLE
Implement tabbed menu and new domain entities

### DIFF
--- a/Wrecept.Core/Entities/PaymentMethod.cs
+++ b/Wrecept.Core/Entities/PaymentMethod.cs
@@ -1,0 +1,9 @@
+namespace Wrecept.Core.Entities;
+
+public class PaymentMethod
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+}

--- a/Wrecept.Core/Entities/ProductGroup.cs
+++ b/Wrecept.Core/Entities/ProductGroup.cs
@@ -1,0 +1,9 @@
+namespace Wrecept.Core.Entities;
+
+public class ProductGroup
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+}

--- a/Wrecept.Core/Entities/TaxRate.cs
+++ b/Wrecept.Core/Entities/TaxRate.cs
@@ -1,0 +1,9 @@
+namespace Wrecept.Core.Entities;
+
+public class TaxRate
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+}

--- a/Wrecept.Core/Models/InvoiceItem.cs
+++ b/Wrecept.Core/Models/InvoiceItem.cs
@@ -5,6 +5,8 @@ public class InvoiceItem
     public int Id { get; set; }
     public int InvoiceId { get; set; }
     public Invoice? Invoice { get; set; }
+    public int ProductId { get; set; }
+    public Product? Product { get; set; }
     public string Description { get; set; } = string.Empty;
     public decimal Quantity { get; set; }
     public decimal UnitPrice { get; set; }

--- a/Wrecept.Core/Repositories/IPaymentMethodRepository.cs
+++ b/Wrecept.Core/Repositories/IPaymentMethodRepository.cs
@@ -1,0 +1,8 @@
+using Wrecept.Core.Entities;
+
+namespace Wrecept.Core.Repositories;
+
+public interface IPaymentMethodRepository
+{
+    Task<List<PaymentMethod>> GetAllAsync(CancellationToken ct = default);
+}

--- a/Wrecept.Core/Repositories/IProductGroupRepository.cs
+++ b/Wrecept.Core/Repositories/IProductGroupRepository.cs
@@ -1,0 +1,8 @@
+using Wrecept.Core.Entities;
+
+namespace Wrecept.Core.Repositories;
+
+public interface IProductGroupRepository
+{
+    Task<List<ProductGroup>> GetAllAsync(CancellationToken ct = default);
+}

--- a/Wrecept.Core/Repositories/ITaxRateRepository.cs
+++ b/Wrecept.Core/Repositories/ITaxRateRepository.cs
@@ -1,0 +1,8 @@
+using Wrecept.Core.Entities;
+
+namespace Wrecept.Core.Repositories;
+
+public interface ITaxRateRepository
+{
+    Task<List<TaxRate>> GetAllAsync(CancellationToken ct = default);
+}

--- a/Wrecept.Core/Services/InvoiceService.cs
+++ b/Wrecept.Core/Services/InvoiceService.cs
@@ -17,6 +17,7 @@ public class InvoiceService : IInvoiceService
         if (string.IsNullOrWhiteSpace(invoice.Number)) return false;
         if (invoice.Items.Count == 0) return false;
         if (invoice.Items.Any(i => i.Quantity <= 0)) return false;
+        if (invoice.Items.Any(i => i.ProductId <= 0)) return false;
         await _invoices.AddAsync(invoice, ct);
         return true;
     }

--- a/Wrecept.Desktop/MainWindow.xaml
+++ b/Wrecept.Desktop/MainWindow.xaml
@@ -4,5 +4,5 @@
         xmlns:views="clr-namespace:Wrecept.Desktop.Views"
         Title="Wrecept" Height="450" Width="800"
         KeyDown="Window_KeyDown">
-    <views:StageView />
+    <views:StageView x:Name="Stage" />
 </Window>

--- a/Wrecept.Desktop/MainWindow.xaml.cs
+++ b/Wrecept.Desktop/MainWindow.xaml.cs
@@ -4,32 +4,28 @@ namespace Wrecept.Desktop;
 
 public partial class MainWindow : Window
 {
+    public ViewModels.MainWindowViewModel ViewModel { get; }
+
     public MainWindow()
     {
         InitializeComponent();
+        ViewModel = new ViewModels.MainWindowViewModel();
+        DataContext = ViewModel;
     }
 
     private void Window_KeyDown(object sender, System.Windows.Input.KeyEventArgs e)
     {
-        try
+        switch (e.Key)
         {
-            switch (e.Key)
-            {
-                case System.Windows.Input.Key.Up:
-                    ((Views.StageView)Content).Menu.ViewModel.MoveUpCommand.Execute(null);
-                    break;
-                case System.Windows.Input.Key.Down:
-                    ((Views.StageView)Content).Menu.ViewModel.MoveDownCommand.Execute(null);
-                    break;
-                case System.Windows.Input.Key.Enter:
-                    ((Views.StageView)Content).Menu.ViewModel.EnterCommand.Execute(null);
-                    System.Console.Beep();
-                    break;
-            }
-        }
-        catch
-        {
-            // suppress all runtime exceptions during prototype stage
+            case System.Windows.Input.Key.Left:
+                ViewModel.MoveLeftCommand.Execute(null);
+                break;
+            case System.Windows.Input.Key.Right:
+                ViewModel.MoveRightCommand.Execute(null);
+                break;
+            case System.Windows.Input.Key.Enter:
+                ViewModel.EnterCommand.Execute(null);
+                break;
         }
     }
 }

--- a/Wrecept.Desktop/ServiceLocator.cs
+++ b/Wrecept.Desktop/ServiceLocator.cs
@@ -1,17 +1,24 @@
 using Wrecept.Core.Services;
 using Wrecept.Storage.Data;
 using Wrecept.Storage.Repositories;
+using Wrecept.Core.Repositories;
 
 namespace Wrecept.Desktop;
 
 public static class ServiceLocator
 {
     public static IInvoiceService InvoiceService { get; }
+    public static IProductGroupRepository ProductGroupRepository { get; }
+    public static ITaxRateRepository TaxRateRepository { get; }
+    public static IPaymentMethodRepository PaymentMethodRepository { get; }
 
     static ServiceLocator()
     {
         var db = new AppDbContext("wrecept.db");
         var invoiceRepo = new InvoiceRepository(db);
         InvoiceService = new InvoiceService(invoiceRepo);
+        ProductGroupRepository = new ProductGroupRepository(db);
+        TaxRateRepository = new TaxRateRepository(db);
+        PaymentMethodRepository = new PaymentMethodRepository(db);
     }
 }

--- a/Wrecept.Desktop/ViewModels/InvoiceEditorViewModel.cs
+++ b/Wrecept.Desktop/ViewModels/InvoiceEditorViewModel.cs
@@ -39,6 +39,7 @@ public partial class InvoiceEditorViewModel : ObservableObject
             Supplier = new Supplier { Name = SupplierName },
             Items = Items.Select(i => new InvoiceItem
             {
+                ProductId = i.ProductId,
                 Description = i.Description,
                 Quantity = i.Quantity,
                 UnitPrice = i.UnitPrice
@@ -59,6 +60,7 @@ public partial class InvoiceEditorViewModel : ObservableObject
 
 public partial class ItemRow : ObservableObject
 {
+    [ObservableProperty] private int productId;
     [ObservableProperty] private string description = string.Empty;
     [ObservableProperty] private decimal quantity = 1;
     [ObservableProperty] private decimal unitPrice;

--- a/Wrecept.Desktop/ViewModels/MainWindowViewModel.cs
+++ b/Wrecept.Desktop/ViewModels/MainWindowViewModel.cs
@@ -1,0 +1,29 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+
+namespace Wrecept.Desktop.ViewModels;
+
+public partial class MainWindowViewModel : ObservableObject
+{
+    [ObservableProperty]
+    private int selectedTab;
+
+    public IRelayCommand MoveLeftCommand { get; }
+    public IRelayCommand MoveRightCommand { get; }
+    public IRelayCommand EnterCommand { get; }
+
+    public MainWindowViewModel()
+    {
+        MoveLeftCommand = new RelayCommand(() => ChangeTab(-1));
+        MoveRightCommand = new RelayCommand(() => ChangeTab(1));
+        EnterCommand = new RelayCommand(() => { });
+    }
+
+    private void ChangeTab(int delta)
+    {
+        var newIndex = SelectedTab + delta;
+        if (newIndex < 0) newIndex = 0;
+        if (newIndex > 5) newIndex = 5;
+        SelectedTab = newIndex;
+    }
+}

--- a/Wrecept.Desktop/ViewModels/PaymentMethodViewModel.cs
+++ b/Wrecept.Desktop/ViewModels/PaymentMethodViewModel.cs
@@ -1,0 +1,7 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace Wrecept.Desktop.ViewModels;
+
+public partial class PaymentMethodViewModel : ObservableObject
+{
+}

--- a/Wrecept.Desktop/ViewModels/ProductGroupViewModel.cs
+++ b/Wrecept.Desktop/ViewModels/ProductGroupViewModel.cs
@@ -1,0 +1,7 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace Wrecept.Desktop.ViewModels;
+
+public partial class ProductGroupViewModel : ObservableObject
+{
+}

--- a/Wrecept.Desktop/ViewModels/StageViewModel.cs
+++ b/Wrecept.Desktop/ViewModels/StageViewModel.cs
@@ -5,7 +5,6 @@ namespace Wrecept.Desktop.ViewModels;
 
 public partial class StageViewModel : ObservableObject
 {
-    public MainMenuViewModel Menu { get; } = new();
     public InvoiceEditorViewModel Editor { get; } = new(ServiceLocator.InvoiceService);
     public SupplierLookupViewModel SupplierLookup { get; } = new();
 
@@ -17,10 +16,5 @@ public partial class StageViewModel : ObservableObject
 
     public StageViewModel()
     {
-        Menu.ItemActivated += idx =>
-        {
-            ShowEditor = idx == 0;
-            ShowSupplierLookup = idx == 2;
-        };
     }
 }

--- a/Wrecept.Desktop/ViewModels/TaxRateViewModel.cs
+++ b/Wrecept.Desktop/ViewModels/TaxRateViewModel.cs
@@ -1,0 +1,7 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace Wrecept.Desktop.ViewModels;
+
+public partial class TaxRateViewModel : ObservableObject
+{
+}

--- a/Wrecept.Desktop/Views/InvoiceEditorView.xaml
+++ b/Wrecept.Desktop/Views/InvoiceEditorView.xaml
@@ -23,7 +23,8 @@
                 <ListBox.ItemTemplate>
                     <DataTemplate>
                         <StackPanel Orientation="Horizontal">
-                            <TextBox Text="{Binding Description, UpdateSourceTrigger=PropertyChanged}" Width="200" />
+                            <TextBox Text="{Binding ProductId, UpdateSourceTrigger=PropertyChanged}" Width="40" />
+                            <TextBox Text="{Binding Description, UpdateSourceTrigger=PropertyChanged}" Width="160" />
                             <TextBox Text="{Binding Quantity, UpdateSourceTrigger=PropertyChanged}" Width="60" />
                             <TextBox Text="{Binding UnitPrice, UpdateSourceTrigger=PropertyChanged}" Width="80" />
                         </StackPanel>

--- a/Wrecept.Desktop/Views/PaymentMethodView.xaml
+++ b/Wrecept.Desktop/Views/PaymentMethodView.xaml
@@ -1,0 +1,11 @@
+<UserControl x:Class="Wrecept.Desktop.Views.PaymentMethodView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             d:DesignHeight="300" d:DesignWidth="400">
+    <Border Background="{DynamicResource StageBackground}" Padding="10">
+        <TextBlock Text="PaymentMethod View" />
+    </Border>
+</UserControl>

--- a/Wrecept.Desktop/Views/ProductGroupView.xaml
+++ b/Wrecept.Desktop/Views/ProductGroupView.xaml
@@ -1,0 +1,11 @@
+<UserControl x:Class="Wrecept.Desktop.Views.ProductGroupView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             d:DesignHeight="300" d:DesignWidth="400">
+    <Border Background="{DynamicResource StageBackground}" Padding="10">
+        <TextBlock Text="ProductGroup View" />
+    </Border>
+</UserControl>

--- a/Wrecept.Desktop/Views/StageView.xaml
+++ b/Wrecept.Desktop/Views/StageView.xaml
@@ -12,7 +12,49 @@
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
 
-        <views:MainMenu x:Name="Menu" />
+        <TabControl x:Name="MenuTabs" SelectedIndex="{Binding SelectedTab, RelativeSource={RelativeSource AncestorType=Window}}">
+            <TabItem Header="Számlák">
+                <StackPanel>
+                    <Button Content="Bejövő szállítólevelek" Margin="2" />
+                    <Button Content="Bejövő számlák aktualizálása" Margin="2" />
+                </StackPanel>
+            </TabItem>
+            <TabItem Header="Törzsek">
+                <StackPanel>
+                    <Button Content="Termékek" Margin="2" />
+                    <Button Content="Termékcsoportok" Margin="2" />
+                    <Button Content="Szállítók" Margin="2" />
+                    <Button Content="ÁFA-kulcsok" Margin="2" />
+                    <Button Content="Fizetési módok" Margin="2" />
+                </StackPanel>
+            </TabItem>
+            <TabItem Header="Listák">
+                <StackPanel>
+                    <Button Content="Terméklista" Margin="2" />
+                    <Button Content="Szállítók listája" Margin="2" />
+                    <Button Content="Számlák listája" Margin="2" />
+                    <Button Content="Készletkarton" Margin="2" />
+                </StackPanel>
+            </TabItem>
+            <TabItem Header="Szerviz">
+                <StackPanel>
+                    <Button Content="Állományok ellenőrzése" Margin="2" />
+                    <Button Content="Áramszünet után" Margin="2" />
+                    <Button Content="Képernyő beállítása" Margin="2" />
+                    <Button Content="Nyomtató beállítás" Margin="2" />
+                </StackPanel>
+            </TabItem>
+            <TabItem Header="Névjegy">
+                <StackPanel>
+                    <Button Content="A program felhasználójának adatai" Margin="2" />
+                </StackPanel>
+            </TabItem>
+            <TabItem Header="Vége">
+                <StackPanel>
+                    <Button Content="Kilépés" Margin="2" />
+                </StackPanel>
+            </TabItem>
+        </TabControl>
 
         <Grid Grid.Row="1">
             <Grid.ColumnDefinitions>

--- a/Wrecept.Desktop/Views/StageView.xaml.cs
+++ b/Wrecept.Desktop/Views/StageView.xaml.cs
@@ -7,7 +7,6 @@ public partial class StageView : UserControl
 {
     public StageViewModel ViewModel { get; }
 
-    public MainMenuViewModel MenuViewModel => ViewModel.Menu;
 
     public StageView()
     {

--- a/Wrecept.Desktop/Views/TaxRateView.xaml
+++ b/Wrecept.Desktop/Views/TaxRateView.xaml
@@ -1,0 +1,11 @@
+<UserControl x:Class="Wrecept.Desktop.Views.TaxRateView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             d:DesignHeight="300" d:DesignWidth="400">
+    <Border Background="{DynamicResource StageBackground}" Padding="10">
+        <TextBlock Text="TaxRate View" />
+    </Border>
+</UserControl>

--- a/Wrecept.Storage/Data/AppDbContext.cs
+++ b/Wrecept.Storage/Data/AppDbContext.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using Wrecept.Core.Models;
+using Wrecept.Core.Entities;
 
 namespace Wrecept.Storage.Data;
 
@@ -9,6 +10,9 @@ public class AppDbContext : DbContext
     public DbSet<InvoiceItem> InvoiceItems => Set<InvoiceItem>();
     public DbSet<Product> Products => Set<Product>();
     public DbSet<Supplier> Suppliers => Set<Supplier>();
+    public DbSet<ProductGroup> ProductGroups => Set<ProductGroup>();
+    public DbSet<TaxRate> TaxRates => Set<TaxRate>();
+    public DbSet<PaymentMethod> PaymentMethods => Set<PaymentMethod>();
 
     private readonly string _dbPath;
 

--- a/Wrecept.Storage/Repositories/PaymentMethodRepository.cs
+++ b/Wrecept.Storage/Repositories/PaymentMethodRepository.cs
@@ -1,0 +1,20 @@
+using Microsoft.EntityFrameworkCore;
+using Wrecept.Core.Entities;
+using Wrecept.Core.Repositories;
+using Wrecept.Storage.Data;
+
+namespace Wrecept.Storage.Repositories;
+
+public class PaymentMethodRepository : IPaymentMethodRepository
+{
+    private readonly AppDbContext _db;
+
+    public PaymentMethodRepository(AppDbContext db)
+    {
+        _db = db;
+        _db.Database.EnsureCreated();
+    }
+
+    public Task<List<PaymentMethod>> GetAllAsync(CancellationToken ct = default)
+        => _db.Set<PaymentMethod>().ToListAsync(ct);
+}

--- a/Wrecept.Storage/Repositories/ProductGroupRepository.cs
+++ b/Wrecept.Storage/Repositories/ProductGroupRepository.cs
@@ -1,0 +1,20 @@
+using Microsoft.EntityFrameworkCore;
+using Wrecept.Core.Entities;
+using Wrecept.Core.Repositories;
+using Wrecept.Storage.Data;
+
+namespace Wrecept.Storage.Repositories;
+
+public class ProductGroupRepository : IProductGroupRepository
+{
+    private readonly AppDbContext _db;
+
+    public ProductGroupRepository(AppDbContext db)
+    {
+        _db = db;
+        _db.Database.EnsureCreated();
+    }
+
+    public Task<List<ProductGroup>> GetAllAsync(CancellationToken ct = default)
+        => _db.Set<ProductGroup>().ToListAsync(ct);
+}

--- a/Wrecept.Storage/Repositories/TaxRateRepository.cs
+++ b/Wrecept.Storage/Repositories/TaxRateRepository.cs
@@ -1,0 +1,20 @@
+using Microsoft.EntityFrameworkCore;
+using Wrecept.Core.Entities;
+using Wrecept.Core.Repositories;
+using Wrecept.Storage.Data;
+
+namespace Wrecept.Storage.Repositories;
+
+public class TaxRateRepository : ITaxRateRepository
+{
+    private readonly AppDbContext _db;
+
+    public TaxRateRepository(AppDbContext db)
+    {
+        _db = db;
+        _db.Database.EnsureCreated();
+    }
+
+    public Task<List<TaxRate>> GetAllAsync(CancellationToken ct = default)
+        => _db.Set<TaxRate>().ToListAsync(ct);
+}

--- a/docs/progress/2025-06-28_01-18-04_root_agent.md
+++ b/docs/progress/2025-06-28_01-18-04_root_agent.md
@@ -1,0 +1,8 @@
+# Progress Log - 2025-06-28 01:18 UTC
+
+* Hozzáadtam ProductGroup, TaxRate és PaymentMethod entitás osztályokat.
+* Kiterjesztettem az AppDbContextet és a ServiceLocatort az új repository-kel.
+* Átalakítottam a StageView menüt TabControl alapúra, egyszerűbb billentyűkezeléssel.
+* Bevezettem a MainWindowViewModelt a menüvezérléshez.
+* Az InvoiceItem modell most ProductId mezőt is tartalmaz, a szerkesztő nézet ennek megfelelően frissült.
+* A dotnet tesztek futtatása a környezet hiánya miatt ismételten meghiúsult.


### PR DESCRIPTION
## Summary
- convert `StageView` to a simple tab-based menu
- introduce `ProductGroup`, `TaxRate` and `PaymentMethod` entities
- extend `ServiceLocator` and `AppDbContext` with new repositories
- link `InvoiceItem` to `Product`
- add stub views and viewmodels for new entities
- create `MainWindowViewModel` to handle tab navigation
- record progress log

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f41600d648322b52cd45ed2ba678a