### PR TITLE
Fix resource order causing XamlParseException

### DIFF
--- a/Wrecept.Desktop/Themes/RetroTheme.xaml
+++ b/Wrecept.Desktop/Themes/RetroTheme.xaml
@@ -47,20 +47,6 @@
         </Setter>
     </Style>
 
-    <!-- Sub Menu Item Buttons -->
-    <Style x:Key="SubMenuItemStyle" TargetType="Button" BasedOn="{StaticResource MenuItemStyle}">
-        <Style.Triggers>
-            <DataTrigger Value="True">
-                <DataTrigger.Binding>
-                    <MultiBinding Converter="{StaticResource EqualityConverter}">
-                        <Binding Path="Tag" RelativeSource="{RelativeSource Self}" />
-                        <Binding Path="SelectedSubIndex" RelativeSource="{RelativeSource AncestorType=UserControl}" />
-                    </MultiBinding>
-                </DataTrigger.Binding>
-                <Setter Property="Background" Value="{StaticResource HighlightBrush}" />
-            </DataTrigger>
-        </Style.Triggers>
-    </Style>
 
     <!-- Default text styles -->
     <Style TargetType="TextBlock">
@@ -176,6 +162,20 @@
         </Setter>
     </Style>
 
+    <!-- Sub Menu Item Buttons -->
+    <Style x:Key="SubMenuItemStyle" TargetType="Button" BasedOn="{StaticResource MenuItemStyle}">
+        <Style.Triggers>
+            <DataTrigger Value="True">
+                <DataTrigger.Binding>
+                    <MultiBinding Converter="{StaticResource EqualityConverter}">
+                        <Binding Path="Tag" RelativeSource="{RelativeSource Self}" />
+                        <Binding Path="SelectedSubIndex" RelativeSource="{RelativeSource AncestorType=UserControl}" />
+                    </MultiBinding>
+                </DataTrigger.Binding>
+                <Setter Property="Background" Value="{StaticResource HighlightBrush}" />
+            </DataTrigger>
+        </Style.Triggers>
+    </Style>
     <!-- Named Buttons -->
     <Style x:Key="AddRowButtonStyle" BasedOn="{StaticResource BaseButtonStyle}" TargetType="Button">
         <Setter Property="Background" Value="#FFA726" />

--- a/docs/progress/2025-06-28_01-50-10_root_agent.md
+++ b/docs/progress/2025-06-28_01-50-10_root_agent.md
@@ -1,0 +1,4 @@
+# Progress Log - 2025-06-28 01:50 UTC
+
+* Átrendeztem a RetroTheme.xaml erőforrást, hogy a `MenuItemStyle` megelőzze a `SubMenuItemStyle` definícióját.
+* Ez megakadályozza a `XamlParseException`-t a program indulásakor.


### PR DESCRIPTION
## Summary
- reorder style definitions so `MenuItemStyle` comes before `SubMenuItemStyle`
- log progress

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f498354fc8322b168be8784f5cbbc