### PR TITLE
Fix StageView compile error

### DIFF
--- a/Wrecept.Desktop/Views/StageView.xaml.cs
+++ b/Wrecept.Desktop/Views/StageView.xaml.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using System.Windows.Controls;
+using System.Windows;
 using Wrecept.Desktop.ViewModels;
 
 namespace Wrecept.Desktop.Views;

--- a/docs/progress/2025-06-28_02-17-35_code_agent.md
+++ b/docs/progress/2025-06-28_02-17-35_code_agent.md
@@ -1,0 +1,4 @@
+# Progress Log - 2025-06-28 02:17 UTC
+
+* A StageView.xaml.cs fájl elejére felvettem a `System.Windows` using-et.
+* Ez megszünteti a `FrameworkElement` hiányát jelző CS0246 fordítási hibát.


### PR DESCRIPTION
## Summary
- add System.Windows import to StageView
- log progress for compile fix

## Testing
- `dotnet build Wrecept.sln -v minimal` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*
- `dotnet test Wrecept.sln -v minimal` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f504e4c3c8322894dcc08625888b7