### PR TITLE
Fix submenu display by wiring menu Click events

### DIFF
--- a/Wrecept.Desktop/Views/StageView.xaml
+++ b/Wrecept.Desktop/Views/StageView.xaml
@@ -16,12 +16,18 @@
 
         <!-- Horizontal menu bar -->
         <StackPanel x:Name="MainMenuPanel" Orientation="Horizontal" Background="{DynamicResource MenuBackground}">
-            <Button x:Name="MainMenuFirstButton" Content="Számlák" Style="{StaticResource MenuItemStyle}" Tag="0" />
-            <Button x:Name="MainMenuButton1" Content="Törzsek" Style="{StaticResource MenuItemStyle}" Tag="1" />
-            <Button x:Name="MainMenuButton2" Content="Listák" Style="{StaticResource MenuItemStyle}" Tag="2" />
-            <Button x:Name="MainMenuButton3" Content="Szerviz" Style="{StaticResource MenuItemStyle}" Tag="3" />
-            <Button x:Name="MainMenuButton4" Content="Névjegy" Style="{StaticResource MenuItemStyle}" Tag="4" />
-            <Button x:Name="MainMenuButton5" Content="Vége" Style="{StaticResource MenuItemStyle}" Tag="5" />
+            <Button x:Name="MainMenuFirstButton" Content="Számlák" Style="{StaticResource MenuItemStyle}" Tag="0"
+                    Click="MainMenuButton_Click" />
+            <Button x:Name="MainMenuButton1" Content="Törzsek" Style="{StaticResource MenuItemStyle}" Tag="1"
+                    Click="MainMenuButton_Click" />
+            <Button x:Name="MainMenuButton2" Content="Listák" Style="{StaticResource MenuItemStyle}" Tag="2"
+                    Click="MainMenuButton_Click" />
+            <Button x:Name="MainMenuButton3" Content="Szerviz" Style="{StaticResource MenuItemStyle}" Tag="3"
+                    Click="MainMenuButton_Click" />
+            <Button x:Name="MainMenuButton4" Content="Névjegy" Style="{StaticResource MenuItemStyle}" Tag="4"
+                    Click="MainMenuButton_Click" />
+            <Button x:Name="MainMenuButton5" Content="Vége" Style="{StaticResource MenuItemStyle}" Tag="5"
+                    Click="MainMenuButton_Click" />
         </StackPanel>
 
         <!-- Dynamic submenu -->
@@ -38,7 +44,8 @@
                 <DataTemplate>
                     <Button Content="{Binding Label}"
                             Style="{StaticResource SubMenuItemStyle}"
-                            Tag="{Binding Index}" />
+                            Tag="{Binding Index}"
+                            Click="SubmenuButton_Click" />
                 </DataTemplate>
             </ItemsControl.ItemTemplate>
         </ItemsControl>

--- a/Wrecept.Desktop/Views/StageView.xaml.cs
+++ b/Wrecept.Desktop/Views/StageView.xaml.cs
@@ -1,3 +1,4 @@
+using System;
 using System.ComponentModel;
 using System.Windows.Controls;
 using System.Windows;
@@ -40,6 +41,26 @@ public partial class StageView : UserControl
                 if (MainMenuPanel.Children[ViewModel.SelectedIndex] is Control btn)
                     btn.Focus();
             }
+        }
+    }
+
+    private void MainMenuButton_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is Button btn)
+        {
+            ViewModel.SelectedIndex = Convert.ToInt32(btn.Tag);
+            ViewModel.IsSubMenuOpen = true;
+            ViewModel.SelectedSubmenuIndex = 0;
+        }
+    }
+
+    private void SubmenuButton_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is Button btn)
+        {
+            ViewModel.SelectedSubmenuIndex = Convert.ToInt32(btn.Tag);
+            ViewModel.ExecuteCurrentSubmenu();
+            ViewModel.IsSubMenuOpen = false;
         }
     }
 }

--- a/docs/progress/2025-06-28_02-29-41_ui_agent.md
+++ b/docs/progress/2025-06-28_02-29-41_ui_agent.md
@@ -1,0 +1,4 @@
+- Almenü megjelenítés nem működött, mert a főmenü gombok nem frissítették a StageViewModel állapotát.
+- Hozzáadtam Click eseménykezelőket a főmenü és almenü gombokhoz.
+- StageView.xaml.cs-ben új metódusok frissítik a SelectedIndex-et és végrehajtják az almenü akciókat.
+- Az `SubmenuList` immár látható, amikor a felhasználó Entert üt vagy rákattint a menügombra.


### PR DESCRIPTION
## Summary
- wire `MainMenu` buttons to a shared Click handler
- add handler for submenu buttons
- update `StageView.xaml.cs` to open and execute submenu entries on click
- log progress

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f52f82ef483228a1f60d16f1f46df