### PR TITLE
Restore vertical menu with about info

### DIFF
--- a/Wrecept.Desktop/BuildInfo.cs
+++ b/Wrecept.Desktop/BuildInfo.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Diagnostics;
+using System.Reflection;
+
+namespace Wrecept.Desktop;
+
+public static class BuildInfo
+{
+    public static string CommitHash { get; }
+    public static string BuildTimestamp { get; } = DateTime.UtcNow.ToString("u");
+    public static string Version { get; }
+
+    static BuildInfo()
+    {
+        CommitHash = GetCommitHash();
+        Version = Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "N/A";
+    }
+
+    private static string GetCommitHash()
+    {
+        try
+        {
+            var psi = new ProcessStartInfo("git", "rev-parse HEAD")
+            {
+                RedirectStandardOutput = true,
+                UseShellExecute = false
+            };
+            using var p = Process.Start(psi);
+            if (p == null) return "N/A";
+            var hash = p.StandardOutput.ReadLine();
+            p.WaitForExit(1000);
+            return hash ?? "N/A";
+        }
+        catch
+        {
+            return "N/A";
+        }
+    }
+
+    public static string GetInfo() => $"Commit: {CommitHash}\nBuilt: {BuildTimestamp}\nVersion: {Version}";
+}

--- a/Wrecept.Desktop/ViewModels/MainWindowViewModel.cs
+++ b/Wrecept.Desktop/ViewModels/MainWindowViewModel.cs
@@ -35,10 +35,22 @@ public partial class MainWindowViewModel : ObservableObject
     public MainWindowViewModel(StageViewModel stage)
     {
         _stage = stage;
-        MoveLeftCommand = new RelayCommand(() => { if(!IsSubMenuOpen) ChangeMain(-1); });
-        MoveRightCommand = new RelayCommand(() => { if(!IsSubMenuOpen) ChangeMain(1); });
-        MoveUpCommand = new RelayCommand(() => { if(IsSubMenuOpen) SelectNextSubmenu(-1); });
-        MoveDownCommand = new RelayCommand(() => { if(IsSubMenuOpen) SelectNextSubmenu(1); });
+        MoveLeftCommand = new RelayCommand(() => { if(IsSubMenuOpen) IsSubMenuOpen = false; });
+        MoveRightCommand = new RelayCommand(() => { if(!IsSubMenuOpen) { IsSubMenuOpen = true; SelectedSubmenuIndex = 0; } });
+        MoveUpCommand = new RelayCommand(() =>
+        {
+            if (IsSubMenuOpen)
+                SelectNextSubmenu(-1);
+            else
+                ChangeMain(-1);
+        });
+        MoveDownCommand = new RelayCommand(() =>
+        {
+            if (IsSubMenuOpen)
+                SelectNextSubmenu(1);
+            else
+                ChangeMain(1);
+        });
         EnterCommand = new RelayCommand(ExecuteSubmenuItem);
         EscapeCommand = new RelayCommand(ReturnToMainTabs);
     }

--- a/Wrecept.Desktop/ViewModels/StageViewModel.cs
+++ b/Wrecept.Desktop/ViewModels/StageViewModel.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.ObjectModel;
 using CommunityToolkit.Mvvm.ComponentModel;
 using Wrecept.Desktop;
@@ -42,6 +43,8 @@ public partial class StageViewModel : ObservableObject
 
     private readonly Dictionary<int, List<SubmenuItem>> _submenuMap;
 
+    public event Action<string>? ShowMessageRequested;
+
     public StageViewModel()
     {
         _submenuMap = new()
@@ -75,7 +78,7 @@ public partial class StageViewModel : ObservableObject
             },
             [4] = new()
             {
-                new SubmenuItem(0, "A program felhasználójának adatai", () => { })
+                new SubmenuItem(0, "A program felhasználójának adatai", ShowAbout)
             },
             [5] = new()
             {
@@ -83,6 +86,11 @@ public partial class StageViewModel : ObservableObject
             }
         };
         LoadSubmenu(0);
+    }
+
+    private void ShowAbout()
+    {
+        ShowMessageRequested?.Invoke(BuildInfo.GetInfo());
     }
 
     private void LoadSubmenu(int mainIndex)

--- a/Wrecept.Desktop/Views/MainMenu.xaml
+++ b/Wrecept.Desktop/Views/MainMenu.xaml
@@ -6,9 +6,11 @@
              mc:Ignorable="d"
              d:DesignHeight="100" d:DesignWidth="800">
     <StackPanel Orientation="Vertical" Background="{DynamicResource MenuBackground}">
-        <Button Content="Számla rögzítés" Style="{StaticResource MenuItemStyle}" Tag="0"/>
-        <Button Content="Termékek" Style="{StaticResource MenuItemStyle}" Tag="1"/>
-        <Button Content="Beszállítók" Style="{StaticResource MenuItemStyle}" Tag="2"/>
-        <Button Content="Kilépés" Style="{StaticResource MenuItemStyle}" Tag="3"/>
+        <Button x:Name="FirstButtonElement" Content="Számlák" Style="{StaticResource MenuItemStyle}" Tag="0"/>
+        <Button Content="Törzsek" Style="{StaticResource MenuItemStyle}" Tag="1"/>
+        <Button Content="Listák" Style="{StaticResource MenuItemStyle}" Tag="2"/>
+        <Button Content="Szerviz" Style="{StaticResource MenuItemStyle}" Tag="3"/>
+        <Button Content="Névjegy" Style="{StaticResource MenuItemStyle}" Tag="4"/>
+        <Button Content="Vége" Style="{StaticResource MenuItemStyle}" Tag="5"/>
     </StackPanel>
 </UserControl>

--- a/Wrecept.Desktop/Views/MainMenu.xaml.cs
+++ b/Wrecept.Desktop/Views/MainMenu.xaml.cs
@@ -1,16 +1,12 @@
 using System.Windows.Controls;
-using Wrecept.Desktop.ViewModels;
-
 namespace Wrecept.Desktop.Views;
 
 public partial class MainMenu : UserControl
 {
-    public MainMenuViewModel ViewModel { get; }
+    public Button FirstButton => FirstButtonElement;
 
     public MainMenu()
     {
         InitializeComponent();
-        ViewModel = new MainMenuViewModel();
-        DataContext = ViewModel;
     }
 }

--- a/Wrecept.Desktop/Views/StageView.xaml
+++ b/Wrecept.Desktop/Views/StageView.xaml
@@ -14,21 +14,8 @@
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
 
-        <!-- Horizontal menu bar -->
-        <StackPanel x:Name="MainMenuPanel" Orientation="Horizontal" Background="{DynamicResource MenuBackground}">
-            <Button x:Name="MainMenuFirstButton" Content="Számlák" Style="{StaticResource MenuItemStyle}" Tag="0"
-                    Click="MainMenuButton_Click" />
-            <Button x:Name="MainMenuButton1" Content="Törzsek" Style="{StaticResource MenuItemStyle}" Tag="1"
-                    Click="MainMenuButton_Click" />
-            <Button x:Name="MainMenuButton2" Content="Listák" Style="{StaticResource MenuItemStyle}" Tag="2"
-                    Click="MainMenuButton_Click" />
-            <Button x:Name="MainMenuButton3" Content="Szerviz" Style="{StaticResource MenuItemStyle}" Tag="3"
-                    Click="MainMenuButton_Click" />
-            <Button x:Name="MainMenuButton4" Content="Névjegy" Style="{StaticResource MenuItemStyle}" Tag="4"
-                    Click="MainMenuButton_Click" />
-            <Button x:Name="MainMenuButton5" Content="Vége" Style="{StaticResource MenuItemStyle}" Tag="5"
-                    Click="MainMenuButton_Click" />
-        </StackPanel>
+        <!-- Vertical main menu -->
+        <views:MainMenu x:Name="MainMenu" />
 
         <!-- Dynamic submenu -->
         <ItemsControl x:Name="SubmenuList"

--- a/Wrecept.Desktop/Views/StageView.xaml.cs
+++ b/Wrecept.Desktop/Views/StageView.xaml.cs
@@ -16,12 +16,13 @@ public partial class StageView : UserControl
         InitializeComponent();
         ViewModel = new StageViewModel();
         ViewModel.PropertyChanged += ViewModel_PropertyChanged;
+        ViewModel.ShowMessageRequested += msg => MessageBox.Show(msg, "Névjegy");
         DataContext = ViewModel;
     }
 
     private void UserControl_Loaded(object sender, System.Windows.RoutedEventArgs e)
     {
-        MainMenuFirstButton.Focus();
+        MainMenu.FirstButton.Focus();
     }
 
     private void ViewModel_PropertyChanged(object? sender, PropertyChangedEventArgs e)
@@ -38,19 +39,8 @@ public partial class StageView : UserControl
             }
             else
             {
-                if (MainMenuPanel.Children[ViewModel.SelectedIndex] is Control btn)
-                    btn.Focus();
+                MainMenu.FirstButton.Focus();
             }
-        }
-    }
-
-    private void MainMenuButton_Click(object sender, RoutedEventArgs e)
-    {
-        if (sender is Button btn)
-        {
-            ViewModel.SelectedIndex = Convert.ToInt32(btn.Tag);
-            ViewModel.IsSubMenuOpen = true;
-            ViewModel.SelectedSubmenuIndex = 0;
         }
     }
 

--- a/docs/progress/2025-06-28_02-41-56_ui_agent.md
+++ b/docs/progress/2025-06-28_02-41-56_ui_agent.md
@@ -1,0 +1,4 @@
+- Visszaállítottam a StageView eredeti vertikális menüjét a MainMenu vezérlő használatával.
+- Új BuildInfo osztály adja vissza a commit hash-t, build időt és verziót.
+- Névjegy almenü megjeleníti ezt az információt egy MessageBox ablakban.
+- Frissítettem a ViewModel-eket, hogy a fel/le nyilakkal lehessen navigálni a menüpontok között.


### PR DESCRIPTION
## Summary
- switch StageView back to vertical `MainMenu`
- add new `BuildInfo` helper to show git hash, build time and version
- display build details via `Névjegy` menu
- adjust navigation commands for Up/Down based menu
- log progress

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f5513dc68832288ace71a13dfe68b