### PR TITLE
Fix Int32 markup in menu xaml

### DIFF
--- a/Wrecept.Desktop/Views/MainMenu.xaml
+++ b/Wrecept.Desktop/Views/MainMenu.xaml
@@ -6,9 +6,9 @@
              mc:Ignorable="d"
              d:DesignHeight="100" d:DesignWidth="800">
     <StackPanel Orientation="Vertical" Background="{DynamicResource MenuBackground}">
-        <Button Content="Számla rögzítés" Style="{StaticResource MenuItemStyle}" Tag="{x:Int32 0}"/>
-        <Button Content="Termékek" Style="{StaticResource MenuItemStyle}" Tag="{x:Int32 1}"/>
-        <Button Content="Beszállítók" Style="{StaticResource MenuItemStyle}" Tag="{x:Int32 2}"/>
-        <Button Content="Kilépés" Style="{StaticResource MenuItemStyle}" Tag="{x:Int32 3}"/>
+        <Button Content="Számla rögzítés" Style="{StaticResource MenuItemStyle}" Tag="0"/>
+        <Button Content="Termékek" Style="{StaticResource MenuItemStyle}" Tag="1"/>
+        <Button Content="Beszállítók" Style="{StaticResource MenuItemStyle}" Tag="2"/>
+        <Button Content="Kilépés" Style="{StaticResource MenuItemStyle}" Tag="3"/>
     </StackPanel>
 </UserControl>

--- a/Wrecept.Desktop/Views/StageView.xaml
+++ b/Wrecept.Desktop/Views/StageView.xaml
@@ -16,80 +16,80 @@
 
         <!-- Horizontal menu bar -->
         <StackPanel Orientation="Horizontal" Background="{DynamicResource MenuBackground}">
-            <Button x:Name="MainMenuFirstButton" Content="Számlák" Style="{StaticResource MenuItemStyle}" Tag="{x:Int32 0}" />
-            <Button Content="Törzsek" Style="{StaticResource MenuItemStyle}" Tag="{x:Int32 1}" />
-            <Button Content="Listák" Style="{StaticResource MenuItemStyle}" Tag="{x:Int32 2}" />
-            <Button Content="Szerviz" Style="{StaticResource MenuItemStyle}" Tag="{x:Int32 3}" />
-            <Button Content="Névjegy" Style="{StaticResource MenuItemStyle}" Tag="{x:Int32 4}" />
-            <Button Content="Vége" Style="{StaticResource MenuItemStyle}" Tag="{x:Int32 5}" />
+            <Button x:Name="MainMenuFirstButton" Content="Számlák" Style="{StaticResource MenuItemStyle}" Tag="0" />
+            <Button Content="Törzsek" Style="{StaticResource MenuItemStyle}" Tag="1" />
+            <Button Content="Listák" Style="{StaticResource MenuItemStyle}" Tag="2" />
+            <Button Content="Szerviz" Style="{StaticResource MenuItemStyle}" Tag="3" />
+            <Button Content="Névjegy" Style="{StaticResource MenuItemStyle}" Tag="4" />
+            <Button Content="Vége" Style="{StaticResource MenuItemStyle}" Tag="5" />
         </StackPanel>
 
         <!-- Vertical sub menu panels -->
         <StackPanel Grid.Row="1" Orientation="Vertical" Background="{DynamicResource MenuBackground}" Visibility="{Binding IsSubMenuOpen, Converter={StaticResource BooleanToVisibilityConverter}}">
-        <StackPanel Tag="{x:Int32 0}">
+        <StackPanel Tag="0">
                 <StackPanel.Visibility>
                     <MultiBinding Converter="{StaticResource EqualityToVisibilityConverter}">
                         <Binding Path="Tag" RelativeSource="{RelativeSource Self}" />
                         <Binding Path="SelectedIndex" />
                     </MultiBinding>
                 </StackPanel.Visibility>
-                <Button Content="Bejövő szállítólevelek" Style="{StaticResource SubMenuItemStyle}" Tag="{x:Int32 0}" />
-                <Button Content="Bejövő számlák aktualizálása" Style="{StaticResource SubMenuItemStyle}" Tag="{x:Int32 1}" />
+                <Button Content="Bejövő szállítólevelek" Style="{StaticResource SubMenuItemStyle}" Tag="0" />
+                <Button Content="Bejövő számlák aktualizálása" Style="{StaticResource SubMenuItemStyle}" Tag="1" />
             </StackPanel>
-        <StackPanel Tag="{x:Int32 1}">
+        <StackPanel Tag="1">
                 <StackPanel.Visibility>
                     <MultiBinding Converter="{StaticResource EqualityToVisibilityConverter}">
                         <Binding Path="Tag" RelativeSource="{RelativeSource Self}" />
                         <Binding Path="SelectedIndex" />
                     </MultiBinding>
                 </StackPanel.Visibility>
-                <Button Content="Termékek" Style="{StaticResource SubMenuItemStyle}" Tag="{x:Int32 0}" />
-                <Button Content="Termékcsoportok" Style="{StaticResource SubMenuItemStyle}" Tag="{x:Int32 1}" />
-                <Button Content="Szállítók" Style="{StaticResource SubMenuItemStyle}" Tag="{x:Int32 2}" />
-                <Button Content="ÁFA-kulcsok" Style="{StaticResource SubMenuItemStyle}" Tag="{x:Int32 3}" />
-                <Button Content="Fizetési módok" Style="{StaticResource SubMenuItemStyle}" Tag="{x:Int32 4}" />
+                <Button Content="Termékek" Style="{StaticResource SubMenuItemStyle}" Tag="0" />
+                <Button Content="Termékcsoportok" Style="{StaticResource SubMenuItemStyle}" Tag="1" />
+                <Button Content="Szállítók" Style="{StaticResource SubMenuItemStyle}" Tag="2" />
+                <Button Content="ÁFA-kulcsok" Style="{StaticResource SubMenuItemStyle}" Tag="3" />
+                <Button Content="Fizetési módok" Style="{StaticResource SubMenuItemStyle}" Tag="4" />
             </StackPanel>
-        <StackPanel Tag="{x:Int32 2}">
+        <StackPanel Tag="2">
                 <StackPanel.Visibility>
                     <MultiBinding Converter="{StaticResource EqualityToVisibilityConverter}">
                         <Binding Path="Tag" RelativeSource="{RelativeSource Self}" />
                         <Binding Path="SelectedIndex" />
                     </MultiBinding>
                 </StackPanel.Visibility>
-                <Button Content="Terméklista" Style="{StaticResource SubMenuItemStyle}" Tag="{x:Int32 0}" />
-                <Button Content="Szállítók listája" Style="{StaticResource SubMenuItemStyle}" Tag="{x:Int32 1}" />
-                <Button Content="Számlák listája" Style="{StaticResource SubMenuItemStyle}" Tag="{x:Int32 2}" />
-                <Button Content="Készletkarton" Style="{StaticResource SubMenuItemStyle}" Tag="{x:Int32 3}" />
+                <Button Content="Terméklista" Style="{StaticResource SubMenuItemStyle}" Tag="0" />
+                <Button Content="Szállítók listája" Style="{StaticResource SubMenuItemStyle}" Tag="1" />
+                <Button Content="Számlák listája" Style="{StaticResource SubMenuItemStyle}" Tag="2" />
+                <Button Content="Készletkarton" Style="{StaticResource SubMenuItemStyle}" Tag="3" />
             </StackPanel>
-        <StackPanel Tag="{x:Int32 3}">
+        <StackPanel Tag="3">
                 <StackPanel.Visibility>
                     <MultiBinding Converter="{StaticResource EqualityToVisibilityConverter}">
                         <Binding Path="Tag" RelativeSource="{RelativeSource Self}" />
                         <Binding Path="SelectedIndex" />
                     </MultiBinding>
                 </StackPanel.Visibility>
-                <Button Content="Állományok ellenőrzése" Style="{StaticResource SubMenuItemStyle}" Tag="{x:Int32 0}" />
-                <Button Content="Áramszünet után" Style="{StaticResource SubMenuItemStyle}" Tag="{x:Int32 1}" />
-                <Button Content="Képernyő beállítása" Style="{StaticResource SubMenuItemStyle}" Tag="{x:Int32 2}" />
-                <Button Content="Nyomtató beállítás" Style="{StaticResource SubMenuItemStyle}" Tag="{x:Int32 3}" />
+                <Button Content="Állományok ellenőrzése" Style="{StaticResource SubMenuItemStyle}" Tag="0" />
+                <Button Content="Áramszünet után" Style="{StaticResource SubMenuItemStyle}" Tag="1" />
+                <Button Content="Képernyő beállítása" Style="{StaticResource SubMenuItemStyle}" Tag="2" />
+                <Button Content="Nyomtató beállítás" Style="{StaticResource SubMenuItemStyle}" Tag="3" />
             </StackPanel>
-        <StackPanel Tag="{x:Int32 4}">
+        <StackPanel Tag="4">
                 <StackPanel.Visibility>
                     <MultiBinding Converter="{StaticResource EqualityToVisibilityConverter}">
                         <Binding Path="Tag" RelativeSource="{RelativeSource Self}" />
                         <Binding Path="SelectedIndex" />
                     </MultiBinding>
                 </StackPanel.Visibility>
-                <Button Content="A program felhasználójának adatai" Style="{StaticResource SubMenuItemStyle}" Tag="{x:Int32 0}" />
+                <Button Content="A program felhasználójának adatai" Style="{StaticResource SubMenuItemStyle}" Tag="0" />
             </StackPanel>
-        <StackPanel Tag="{x:Int32 5}">
+        <StackPanel Tag="5">
                 <StackPanel.Visibility>
                     <MultiBinding Converter="{StaticResource EqualityToVisibilityConverter}">
                         <Binding Path="Tag" RelativeSource="{RelativeSource Self}" />
                         <Binding Path="SelectedIndex" />
                     </MultiBinding>
                 </StackPanel.Visibility>
-                <Button Content="Kilépés" Style="{StaticResource SubMenuItemStyle}" Tag="{x:Int32 0}" />
+                <Button Content="Kilépés" Style="{StaticResource SubMenuItemStyle}" Tag="0" />
             </StackPanel>
         </StackPanel>
 

--- a/docs/progress/2025-06-28_23-38-31_ui_agent.md
+++ b/docs/progress/2025-06-28_23-38-31_ui_agent.md
@@ -1,0 +1,2 @@
+- StageView.xaml és MainMenu.xaml fájlban újra eltávolítottam a `{x:Int32}` jelölést.
+- Minden Tag attribútumot egyszerű számértékkel adtam meg.


### PR DESCRIPTION
## Summary
- correct invalid `x:Int32` usage in MainMenu.xaml and StageView.xaml
- log progress

## Testing
- `dotnet test --no-build` *(fails: The argument Wrecept.Tests.dll is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_68607c17fdd48322841adb45b29a91ff