### PR TITLE
Implement InputBindings for keyboard navigation

### DIFF
--- a/Wrecept.Desktop/MainWindow.xaml
+++ b/Wrecept.Desktop/MainWindow.xaml
@@ -2,7 +2,14 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:views="clr-namespace:Wrecept.Desktop.Views"
-        Title="Wrecept" Height="450" Width="800"
-        KeyDown="Window_KeyDown">
+        Title="Wrecept" Height="450" Width="800">
+    <Window.InputBindings>
+        <KeyBinding Key="Enter" Command="{Binding EnterCommand}" />
+        <KeyBinding Key="Escape" Command="{Binding EscapeCommand}" />
+        <KeyBinding Key="Left" Command="{Binding MoveLeftCommand}" />
+        <KeyBinding Key="Right" Command="{Binding MoveRightCommand}" />
+        <KeyBinding Key="Up" Command="{Binding MoveUpCommand}" />
+        <KeyBinding Key="Down" Command="{Binding MoveDownCommand}" />
+    </Window.InputBindings>
     <views:StageView x:Name="Stage" />
 </Window>

--- a/Wrecept.Desktop/MainWindow.xaml.cs
+++ b/Wrecept.Desktop/MainWindow.xaml.cs
@@ -13,6 +13,9 @@ public partial class MainWindow : Window
         DataContext = ViewModel;
     }
 
+    // InputBindings a MainWindow.xaml-ben gondoskodik a billentyűkezelésről,
+    // ezért a korábbi Window_KeyDown kezelő inaktiválva marad.
+    /*
     private void Window_KeyDown(object sender, System.Windows.Input.KeyEventArgs e)
     {
         switch (e.Key)
@@ -37,4 +40,5 @@ public partial class MainWindow : Window
                 break;
         }
     }
+    */
 }

--- a/docs/progress/2025-06-29_01-01-28_ui_agent.md
+++ b/docs/progress/2025-06-29_01-01-28_ui_agent.md
@@ -1,0 +1,5 @@
+# Progress Log - 2025-06-29 01:01 UTC
+
+- Global InputBindings került a MainWindow.xaml-be a navigációs parancsokhoz.
+- A korábbi `Window_KeyDown` metódus kommentálva lett, a XAML esemény törölve.
+- `dotnet test` futtatva, de a Windows Desktop SDK hiányzott, ezért nem sikerült a build.


### PR DESCRIPTION
## Summary
- add global InputBindings in `MainWindow.xaml`
- comment legacy `Window_KeyDown` handler
- document progress

## Testing
- `dotnet test` *(fails: Windows Desktop SDK missing)*

------
https://chatgpt.com/codex/tasks/task_e_68608b55890c83228c154dd12a65cb12