### PR TITLE
Restore Window_KeyDown in MainWindow

### DIFF
--- a/Wrecept.Desktop/MainWindow.xaml.cs
+++ b/Wrecept.Desktop/MainWindow.xaml.cs
@@ -1,4 +1,5 @@
 using System.Windows;
+using System.Windows.Input;
 
 namespace Wrecept.Desktop;
 
@@ -9,13 +10,11 @@ public partial class MainWindow : Window
     public MainWindow()
     {
         InitializeComponent();
+        this.AddHandler(Keyboard.KeyDownEvent, new KeyEventHandler(Window_KeyDown), true);
         ViewModel = new ViewModels.MainWindowViewModel(Stage.ViewModel);
         DataContext = ViewModel;
     }
 
-    // InputBindings a MainWindow.xaml-ben gondoskodik a billentyűkezelésről,
-    // ezért a korábbi Window_KeyDown kezelő inaktiválva marad.
-    /*
     private void Window_KeyDown(object sender, System.Windows.Input.KeyEventArgs e)
     {
         switch (e.Key)
@@ -40,5 +39,4 @@ public partial class MainWindow : Window
                 break;
         }
     }
-    */
 }

--- a/docs/progress/2025-06-29_01-20-04_logic_agent.md
+++ b/docs/progress/2025-06-29_01-20-04_logic_agent.md
@@ -1,0 +1,3 @@
+- Window_KeyDown metódus visszaállítva a MainWindow.xaml.cs fájlban.
+- A konstruktorban AddHandler hívás csatlakoztatja a billentyűkezelőt.
+- A tesztfuttatás a Windows Desktop SDK hiánya miatt sikertelen.


### PR DESCRIPTION
## Summary
- reintroduce the `Window_KeyDown` handler in `MainWindow.xaml.cs`
- attach the handler with `AddHandler` in the constructor
- log progress

## Testing
- `dotnet test Wrecept.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_68609420e2988322ad136fa0e11622b5