### PR TITLE
Implement WPF Menu

### DIFF
--- a/Wrecept.Desktop/MainWindow.xaml
+++ b/Wrecept.Desktop/MainWindow.xaml
@@ -2,7 +2,8 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:views="clr-namespace:Wrecept.Desktop.Views"
-        Title="Wrecept" Height="450" Width="800">
+        Title="Wrecept" Height="450" Width="800"
+        Loaded="Window_Loaded">
     <Window.InputBindings>
         <KeyBinding Key="Enter" Command="{Binding EnterCommand}" />
         <KeyBinding Key="Escape" Command="{Binding EscapeCommand}" />
@@ -11,5 +12,38 @@
         <KeyBinding Key="Up" Command="{Binding MoveUpCommand}" />
         <KeyBinding Key="Down" Command="{Binding MoveDownCommand}" />
     </Window.InputBindings>
-    <views:StageView x:Name="Stage" />
+    <DockPanel>
+        <Menu DockPanel.Dock="Top">
+            <MenuItem x:Name="MainMenuFirstItem" Header="Számlák" Tag="0" Click="MainMenuItem_Click">
+                <MenuItem Header="Bejövő szállítólevelek" Tag="0" Click="SubMenuItem_Click" />
+                <MenuItem Header="Bejövő számlák aktualizálása" Tag="1" Click="SubMenuItem_Click" />
+            </MenuItem>
+            <MenuItem Header="Törzsek" Tag="1" Click="MainMenuItem_Click">
+                <MenuItem Header="Termékek" Tag="0" Click="SubMenuItem_Click" />
+                <MenuItem Header="Termékcsoportok" Tag="1" Click="SubMenuItem_Click" />
+                <MenuItem Header="Szállítók" Tag="2" Click="SubMenuItem_Click" />
+                <MenuItem Header="ÁFA-kulcsok" Tag="3" Click="SubMenuItem_Click" />
+                <MenuItem Header="Fizetési módok" Tag="4" Click="SubMenuItem_Click" />
+            </MenuItem>
+            <MenuItem Header="Listák" Tag="2" Click="MainMenuItem_Click">
+                <MenuItem Header="Terméklista" Tag="0" Click="SubMenuItem_Click" />
+                <MenuItem Header="Szállítók listája" Tag="1" Click="SubMenuItem_Click" />
+                <MenuItem Header="Számlák listája" Tag="2" Click="SubMenuItem_Click" />
+                <MenuItem Header="Készletkarton" Tag="3" Click="SubMenuItem_Click" />
+            </MenuItem>
+            <MenuItem Header="Szerviz" Tag="3" Click="MainMenuItem_Click">
+                <MenuItem Header="Állományok ellenőrzése" Tag="0" Click="SubMenuItem_Click" />
+                <MenuItem Header="Áramszünet után" Tag="1" Click="SubMenuItem_Click" />
+                <MenuItem Header="Képernyő beállítása" Tag="2" Click="SubMenuItem_Click" />
+                <MenuItem Header="Nyomtató beállítás" Tag="3" Click="SubMenuItem_Click" />
+            </MenuItem>
+            <MenuItem Header="Névjegy" Tag="4" Click="MainMenuItem_Click">
+                <MenuItem Header="A program felhasználójának adatai" Tag="0" Click="SubMenuItem_Click" />
+            </MenuItem>
+            <MenuItem Header="Vége" Tag="5" Click="MainMenuItem_Click">
+                <MenuItem Header="Kilépés" Tag="0" Click="SubMenuItem_Click" />
+            </MenuItem>
+        </Menu>
+        <views:StageView x:Name="Stage" />
+    </DockPanel>
 </Window>

--- a/Wrecept.Desktop/MainWindow.xaml.cs
+++ b/Wrecept.Desktop/MainWindow.xaml.cs
@@ -1,4 +1,5 @@
 using System.Windows;
+using System.Windows.Controls;
 using System.Windows.Input;
 
 namespace Wrecept.Desktop;
@@ -14,4 +15,31 @@ public partial class MainWindow : Window
         DataContext = ViewModel;
     }
 
+    private void Window_Loaded(object sender, RoutedEventArgs e)
+    {
+        MainMenuFirstItem.Focus();
+    }
+
+    private void MainMenuItem_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is MenuItem mi && int.TryParse(mi.Tag?.ToString(), out var index))
+        {
+            ViewModel.Stage.SelectedIndex = index;
+            ViewModel.Stage.SelectedSubmenuIndex = 0;
+            ViewModel.Stage.IsSubMenuOpen = true;
+        }
+    }
+
+    private void SubMenuItem_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is MenuItem mi && int.TryParse(mi.Tag?.ToString(), out var subIndex))
+        {
+            if (mi.Parent is MenuItem parent && int.TryParse(parent.Tag?.ToString(), out var mainIndex))
+            {
+                ViewModel.Stage.SelectedIndex = mainIndex;
+                ViewModel.Stage.SelectedSubmenuIndex = subIndex;
+                ViewModel.EnterCommand.Execute(null);
+            }
+        }
+    }
 }

--- a/Wrecept.Desktop/Themes/RetroTheme.xaml
+++ b/Wrecept.Desktop/Themes/RetroTheme.xaml
@@ -74,6 +74,29 @@
         <Setter Property="Foreground" Value="{StaticResource ForegroundBrush}" />
     </Style>
 
+    <Style TargetType="MenuItem">
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="Foreground" Value="{StaticResource ForegroundBrush}" />
+        <Setter Property="Padding" Value="10,5" />
+        <Setter Property="FontWeight" Value="Bold" />
+        <Setter Property="FontSize" Value="14" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="MenuItem">
+                    <Border Background="{TemplateBinding Background}" Padding="{TemplateBinding Padding}">
+                        <ContentPresenter ContentSource="Header" />
+                    </Border>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+        <Style.Triggers>
+            <Trigger Property="IsHighlighted" Value="True">
+                <Setter Property="Background" Value="{StaticResource HighlightBrush}" />
+                <Setter Property="Foreground" Value="Black" />
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+
     <!-- Menu Item Buttons -->
     <Style x:Key="MenuItemStyle" TargetType="Button">
         <Setter Property="Foreground" Value="{StaticResource ForegroundBrush}" />

--- a/Wrecept.Desktop/ViewModels/MainWindowViewModel.cs
+++ b/Wrecept.Desktop/ViewModels/MainWindowViewModel.cs
@@ -33,6 +33,8 @@ public partial class MainWindowViewModel : ObservableObject
     public IRelayCommand EnterCommand { get; }
     public IRelayCommand EscapeCommand { get; }
 
+    public StageViewModel Stage => _stage;
+
     public MainWindowViewModel(StageViewModel stage)
     {
         _stage = stage;

--- a/Wrecept.Desktop/Views/StageView.xaml
+++ b/Wrecept.Desktop/Views/StageView.xaml
@@ -5,95 +5,12 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:views="clr-namespace:Wrecept.Desktop.Views"
              mc:Ignorable="d"
-             d:DesignHeight="450" d:DesignWidth="800"
-             Loaded="UserControl_Loaded">
+             d:DesignHeight="450" d:DesignWidth="800">
     <Grid Background="{DynamicResource StageBackground}">
         <Grid.RowDefinitions>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
-
-        <!-- Horizontal menu bar -->
-        <StackPanel Orientation="Horizontal" Background="{DynamicResource MenuBackground}">
-            <Button x:Name="MainMenuFirstButton" Content="Számlák" Style="{StaticResource MenuItemStyle}" Tag="0" Click="MainMenuButton_Click" />
-            <Button Content="Törzsek" Style="{StaticResource MenuItemStyle}" Tag="1" Click="MainMenuButton_Click" />
-            <Button Content="Listák" Style="{StaticResource MenuItemStyle}" Tag="2" Click="MainMenuButton_Click" />
-            <Button Content="Szerviz" Style="{StaticResource MenuItemStyle}" Tag="3" Click="MainMenuButton_Click" />
-            <Button Content="Névjegy" Style="{StaticResource MenuItemStyle}" Tag="4" Click="MainMenuButton_Click" />
-            <Button Content="Vége" Style="{StaticResource MenuItemStyle}" Tag="5" Click="MainMenuButton_Click" />
-        </StackPanel>
-
-        <!-- Vertical sub menu panels -->
-        <StackPanel Grid.Row="1" Orientation="Vertical" Background="{DynamicResource MenuBackground}" Visibility="{Binding IsSubMenuOpen, Converter={StaticResource BooleanToVisibilityConverter}}">
-        <StackPanel Tag="0">
-                <StackPanel.Visibility>
-                    <MultiBinding Converter="{StaticResource EqualityToVisibilityConverter}">
-                        <Binding Path="Tag" RelativeSource="{RelativeSource Self}" />
-                        <Binding Path="SelectedIndex" />
-                    </MultiBinding>
-                </StackPanel.Visibility>
-                <Button Content="Bejövő szállítólevelek" Style="{StaticResource SubMenuItemStyle}" Tag="0" Click="SubMenuButton_Click" />
-                <Button Content="Bejövő számlák aktualizálása" Style="{StaticResource SubMenuItemStyle}" Tag="1" Click="SubMenuButton_Click" />
-            </StackPanel>
-        <StackPanel Tag="1">
-                <StackPanel.Visibility>
-                    <MultiBinding Converter="{StaticResource EqualityToVisibilityConverter}">
-                        <Binding Path="Tag" RelativeSource="{RelativeSource Self}" />
-                        <Binding Path="SelectedIndex" />
-                    </MultiBinding>
-                </StackPanel.Visibility>
-                <Button Content="Termékek" Style="{StaticResource SubMenuItemStyle}" Tag="0" Click="SubMenuButton_Click" />
-                <Button Content="Termékcsoportok" Style="{StaticResource SubMenuItemStyle}" Tag="1" Click="SubMenuButton_Click" />
-                <Button Content="Szállítók" Style="{StaticResource SubMenuItemStyle}" Tag="2" Click="SubMenuButton_Click" />
-                <Button Content="ÁFA-kulcsok" Style="{StaticResource SubMenuItemStyle}" Tag="3" Click="SubMenuButton_Click" />
-                <Button Content="Fizetési módok" Style="{StaticResource SubMenuItemStyle}" Tag="4" Click="SubMenuButton_Click" />
-            </StackPanel>
-        <StackPanel Tag="2">
-                <StackPanel.Visibility>
-                    <MultiBinding Converter="{StaticResource EqualityToVisibilityConverter}">
-                        <Binding Path="Tag" RelativeSource="{RelativeSource Self}" />
-                        <Binding Path="SelectedIndex" />
-                    </MultiBinding>
-                </StackPanel.Visibility>
-                <Button Content="Terméklista" Style="{StaticResource SubMenuItemStyle}" Tag="0" Click="SubMenuButton_Click" />
-                <Button Content="Szállítók listája" Style="{StaticResource SubMenuItemStyle}" Tag="1" Click="SubMenuButton_Click" />
-                <Button Content="Számlák listája" Style="{StaticResource SubMenuItemStyle}" Tag="2" Click="SubMenuButton_Click" />
-                <Button Content="Készletkarton" Style="{StaticResource SubMenuItemStyle}" Tag="3" Click="SubMenuButton_Click" />
-            </StackPanel>
-        <StackPanel Tag="3">
-                <StackPanel.Visibility>
-                    <MultiBinding Converter="{StaticResource EqualityToVisibilityConverter}">
-                        <Binding Path="Tag" RelativeSource="{RelativeSource Self}" />
-                        <Binding Path="SelectedIndex" />
-                    </MultiBinding>
-                </StackPanel.Visibility>
-                <Button Content="Állományok ellenőrzése" Style="{StaticResource SubMenuItemStyle}" Tag="0" Click="SubMenuButton_Click" />
-                <Button Content="Áramszünet után" Style="{StaticResource SubMenuItemStyle}" Tag="1" Click="SubMenuButton_Click" />
-                <Button Content="Képernyő beállítása" Style="{StaticResource SubMenuItemStyle}" Tag="2" Click="SubMenuButton_Click" />
-                <Button Content="Nyomtató beállítás" Style="{StaticResource SubMenuItemStyle}" Tag="3" Click="SubMenuButton_Click" />
-            </StackPanel>
-        <StackPanel Tag="4">
-                <StackPanel.Visibility>
-                    <MultiBinding Converter="{StaticResource EqualityToVisibilityConverter}">
-                        <Binding Path="Tag" RelativeSource="{RelativeSource Self}" />
-                        <Binding Path="SelectedIndex" />
-                    </MultiBinding>
-                </StackPanel.Visibility>
-                <Button Content="A program felhasználójának adatai" Style="{StaticResource SubMenuItemStyle}" Tag="0" Click="SubMenuButton_Click" />
-            </StackPanel>
-        <StackPanel Tag="5">
-                <StackPanel.Visibility>
-                    <MultiBinding Converter="{StaticResource EqualityToVisibilityConverter}">
-                        <Binding Path="Tag" RelativeSource="{RelativeSource Self}" />
-                        <Binding Path="SelectedIndex" />
-                    </MultiBinding>
-                </StackPanel.Visibility>
-                <Button Content="Kilépés" Style="{StaticResource SubMenuItemStyle}" Tag="0" Click="SubMenuButton_Click" />
-            </StackPanel>
-        </StackPanel>
-
-        <Grid Grid.Row="2">
+        <Grid>
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*" />
                 <ColumnDefinition Width="*" />

--- a/Wrecept.Desktop/Views/StageView.xaml.cs
+++ b/Wrecept.Desktop/Views/StageView.xaml.cs
@@ -1,4 +1,3 @@
-using System.Windows;
 using System.Windows.Controls;
 using Wrecept.Desktop.ViewModels;
 using Wrecept.Desktop;
@@ -17,32 +16,4 @@ public partial class StageView : UserControl
         DataContext = ViewModel;
     }
 
-    private void UserControl_Loaded(object sender, System.Windows.RoutedEventArgs e)
-    {
-        MainMenuFirstButton.Focus();
-    }
-
-    private void MainMenuButton_Click(object sender, System.Windows.RoutedEventArgs e)
-    {
-        if (sender is Button btn && int.TryParse(btn.Tag?.ToString(), out var index))
-        {
-            ViewModel.SelectedIndex = index;
-            ViewModel.SelectedSubmenuIndex = 0;
-            ViewModel.IsSubMenuOpen = true;
-        }
-    }
-
-    private void SubMenuButton_Click(object sender, System.Windows.RoutedEventArgs e)
-    {
-        if (sender is Button btn && int.TryParse(btn.Tag?.ToString(), out var subIndex))
-        {
-            if (btn.Parent is FrameworkElement fe && int.TryParse(fe.Tag?.ToString(), out var mainIndex))
-            {
-                ViewModel.SelectedIndex = mainIndex;
-                ViewModel.SelectedSubmenuIndex = subIndex;
-                var mainVm = (Wrecept.Desktop.ViewModels.MainWindowViewModel?)Application.Current.MainWindow?.DataContext;
-                mainVm?.EnterCommand.Execute(null);
-            }
-        }
-    }
 }

--- a/docs/progress/2025-06-29_10-50-36_root_agent.md
+++ b/docs/progress/2025-06-29_10-50-36_root_agent.md
@@ -1,0 +1,3 @@
+- Replaced StageView button menu with standard WPF Menu in MainWindow.
+- Removed obsolete menu code from StageView and adjusted ViewModel exposure.
+- Added basic MenuItem style to RetroTheme for consistent look.


### PR DESCRIPTION
## Summary
- swap out old StageView button menu for a standard `Menu` in MainWindow
- expose StageViewModel to XAML bindings and handle menu clicks
- simplify StageView and drop menu handlers
- style `MenuItem` in RetroTheme
- log progress

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686119254fd08322b89ddb329fe3debc