### PR TITLE
Implement menu placeholders and BuildInfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,3 +39,9 @@ date: "2025-06-27"
 ## 2025-06-28
 - A menürendszert visszaállítottam a `fix-almenü-és-menü-hibák` állapotra.
 - Eltávolítottam a BuildInfo alapú Névjegy funkciót.
+
+## 2025-06-29
+- Visszahoztam a BuildInfo osztályt, a Névjegy menüpont kiírja a build adatait.
+- Létrehoztam a Termékek nézetet és ViewModelt.
+- A StageViewModel bővült új függőségekkel és megjelenítési logikával.
+- A Kilépés menüpont bezárja az alkalmazást.

--- a/Wrecept.Desktop/BuildInfo.cs
+++ b/Wrecept.Desktop/BuildInfo.cs
@@ -1,0 +1,20 @@
+using System.IO;
+using System.Reflection;
+
+namespace Wrecept.Desktop;
+
+public static class BuildInfo
+{
+    public static string Version { get; }
+    public static string CommitHash { get; }
+    public static DateTime BuildTime { get; }
+
+    static BuildInfo()
+    {
+        var asm = Assembly.GetExecutingAssembly();
+        Version = asm.GetName().Version?.ToString() ?? "0.0";
+        var info = asm.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+        CommitHash = info?.Split('+').LastOrDefault() ?? "unknown";
+        BuildTime = File.GetLastWriteTimeUtc(asm.Location);
+    }
+}

--- a/Wrecept.Desktop/ServiceLocator.cs
+++ b/Wrecept.Desktop/ServiceLocator.cs
@@ -9,6 +9,8 @@ public static class ServiceLocator
 {
     public static IInvoiceService InvoiceService { get; }
     public static IProductGroupRepository ProductGroupRepository { get; }
+    public static IProductRepository ProductRepository { get; }
+    public static ISupplierRepository SupplierRepository { get; }
     public static ITaxRateRepository TaxRateRepository { get; }
     public static IPaymentMethodRepository PaymentMethodRepository { get; }
 
@@ -18,6 +20,8 @@ public static class ServiceLocator
         var invoiceRepo = new InvoiceRepository(db);
         InvoiceService = new InvoiceService(invoiceRepo);
         ProductGroupRepository = new ProductGroupRepository(db);
+        ProductRepository = new ProductRepository(db);
+        SupplierRepository = new SupplierRepository(db);
         TaxRateRepository = new TaxRateRepository(db);
         PaymentMethodRepository = new PaymentMethodRepository(db);
     }

--- a/Wrecept.Desktop/ViewModels/MainWindowViewModel.cs
+++ b/Wrecept.Desktop/ViewModels/MainWindowViewModel.cs
@@ -1,3 +1,5 @@
+using System.Windows;
+using Wrecept.Desktop;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 
@@ -99,8 +101,14 @@ public partial class MainWindowViewModel : ObservableObject
         {
             switch (SelectedSubmenuIndex)
             {
+                case 0:
+                    _stage.ShowProduct = true;
+                    break;
                 case 1:
                     _stage.ShowProductGroup = true;
+                    break;
+                case 2:
+                    _stage.ShowSupplierLookup = true;
                     break;
                 case 3:
                     _stage.ShowTaxRate = true;
@@ -110,6 +118,25 @@ public partial class MainWindowViewModel : ObservableObject
                     break;
             }
         }
+        else if (SelectedIndex == 2)
+        {
+            MessageBox.Show("A listák funkció még nincs implementálva.", "Listák");
+        }
+        else if (SelectedIndex == 3)
+        {
+            MessageBox.Show("A szerviz funkció még nincs implementálva.", "Szerviz");
+        }
+        else if (SelectedIndex == 4)
+        {
+            var info = $"Felhasználó: {Environment.UserName}\nVerzió: {BuildInfo.Version}\nCommit: {BuildInfo.CommitHash}\nBuild idő: {BuildInfo.BuildTime:u}";
+            MessageBox.Show(info, "Wrecept");
+        }
+        else if (SelectedIndex == 5)
+        {
+            if (SelectedSubmenuIndex == 0)
+                Application.Current.Shutdown();
+        }
+
         IsSubMenuOpen = false;
     }
 }

--- a/Wrecept.Desktop/ViewModels/ProductViewModel.cs
+++ b/Wrecept.Desktop/ViewModels/ProductViewModel.cs
@@ -1,0 +1,27 @@
+using System.Threading;
+using System.Threading.Tasks;
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+using Wrecept.Core.Models;
+using Wrecept.Core.Repositories;
+
+namespace Wrecept.Desktop.ViewModels;
+
+public partial class ProductViewModel : ObservableObject
+{
+    private readonly IProductRepository _repo;
+
+    [ObservableProperty]
+    private ObservableCollection<Product> products = new();
+
+    public ProductViewModel(IProductRepository repo)
+    {
+        _repo = repo;
+    }
+
+    public async Task LoadAsync(CancellationToken ct = default)
+    {
+        var items = await _repo.GetAllAsync(ct);
+        Products = new ObservableCollection<Product>(items);
+    }
+}

--- a/Wrecept.Desktop/ViewModels/StageViewModel.cs
+++ b/Wrecept.Desktop/ViewModels/StageViewModel.cs
@@ -1,5 +1,6 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using Wrecept.Core.Services;
+using Wrecept.Core.Repositories;
 
 namespace Wrecept.Desktop.ViewModels;
 
@@ -7,6 +8,7 @@ public partial class StageViewModel : ObservableObject
 {
     public InvoiceEditorViewModel Editor { get; }
     public SupplierLookupViewModel SupplierLookup { get; }
+    public ProductViewModel Product { get; }
     public ProductGroupViewModel ProductGroup { get; }
     public TaxRateViewModel TaxRate { get; }
     public PaymentMethodViewModel PaymentMethod { get; }
@@ -27,6 +29,9 @@ public partial class StageViewModel : ObservableObject
     private bool showSupplierLookup;
 
     [ObservableProperty]
+    private bool showProduct;
+
+    [ObservableProperty]
     private bool showProductGroup;
 
     [ObservableProperty]
@@ -35,10 +40,11 @@ public partial class StageViewModel : ObservableObject
     [ObservableProperty]
     private bool showPaymentMethod;
 
-    public StageViewModel(IInvoiceService invoiceService)
+    public StageViewModel(IInvoiceService invoiceService, IProductRepository productRepository, ISupplierRepository supplierRepository)
     {
         Editor = new InvoiceEditorViewModel(invoiceService);
-        SupplierLookup = new SupplierLookupViewModel();
+        Product = new ProductViewModel(productRepository);
+        SupplierLookup = new SupplierLookupViewModel(supplierRepository);
         ProductGroup = new ProductGroupViewModel();
         TaxRate = new TaxRateViewModel();
         PaymentMethod = new PaymentMethodViewModel();
@@ -47,6 +53,7 @@ public partial class StageViewModel : ObservableObject
     public void HideAll()
     {
         ShowEditor = false;
+        ShowProduct = false;
         ShowSupplierLookup = false;
         ShowProductGroup = false;
         ShowTaxRate = false;

--- a/Wrecept.Desktop/ViewModels/SupplierLookupViewModel.cs
+++ b/Wrecept.Desktop/ViewModels/SupplierLookupViewModel.cs
@@ -1,16 +1,28 @@
+using System.Threading;
+using System.Threading.Tasks;
 using System.Collections.ObjectModel;
 using CommunityToolkit.Mvvm.ComponentModel;
 using Wrecept.Core.Models;
+using Wrecept.Core.Repositories;
 
 namespace Wrecept.Desktop.ViewModels;
 
 public partial class SupplierLookupViewModel : ObservableObject
 {
+    private readonly ISupplierRepository _repo;
+
     public ObservableCollection<Supplier> Suppliers { get; } = new();
 
-    public SupplierLookupViewModel()
+    public SupplierLookupViewModel(ISupplierRepository repo)
     {
-        Suppliers.Add(new Supplier { Id = 1, Name = "Teszt Kft." });
-        Suppliers.Add(new Supplier { Id = 2, Name = "Minta Bt." });
+        _repo = repo;
+    }
+
+    public async Task LoadAsync(CancellationToken ct = default)
+    {
+        var list = await _repo.GetAllAsync(ct);
+        Suppliers.Clear();
+        foreach (var s in list)
+            Suppliers.Add(s);
     }
 }

--- a/Wrecept.Desktop/Views/ProductView.xaml
+++ b/Wrecept.Desktop/Views/ProductView.xaml
@@ -1,0 +1,20 @@
+<UserControl x:Class="Wrecept.Desktop.Views.ProductView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             d:DesignHeight="300" d:DesignWidth="400">
+    <Border Background="{DynamicResource StageBackground}" Padding="10">
+        <StackPanel>
+            <TextBlock Text="Termékek" FontWeight="Bold" />
+            <ListBox ItemsSource="{Binding Products}">
+                <ListBox.ItemTemplate>
+                    <DataTemplate>
+                        <TextBlock Text="{Binding Name}" />
+                    </DataTemplate>
+                </ListBox.ItemTemplate>
+            </ListBox>
+        </StackPanel>
+    </Border>
+</UserControl>

--- a/Wrecept.Desktop/Views/StageView.xaml
+++ b/Wrecept.Desktop/Views/StageView.xaml
@@ -48,6 +48,11 @@
                                       Grid.ColumnSpan="2"
                                       Visibility="{Binding ShowSupplierLookup, Converter={StaticResource BooleanToVisibilityConverter}}" />
 
+            <views:ProductView x:Name="ProductHost"
+                               DataContext="{Binding Product}"
+                               Grid.ColumnSpan="2"
+                               Visibility="{Binding ShowProduct, Converter={StaticResource BooleanToVisibilityConverter}}" />
+
             <views:ProductGroupView x:Name="ProductGroupHost"
                                     DataContext="{Binding ProductGroup}"
                                     Grid.ColumnSpan="2"

--- a/Wrecept.Desktop/Views/StageView.xaml.cs
+++ b/Wrecept.Desktop/Views/StageView.xaml.cs
@@ -12,7 +12,10 @@ public partial class StageView : UserControl
     public StageView()
     {
         InitializeComponent();
-        ViewModel = new StageViewModel(ServiceLocator.InvoiceService);
+        ViewModel = new StageViewModel(
+            ServiceLocator.InvoiceService,
+            ServiceLocator.ProductRepository,
+            ServiceLocator.SupplierRepository);
         DataContext = ViewModel;
     }
 

--- a/docs/progress/2025-06-29_11-37-40_root_agent.md
+++ b/docs/progress/2025-06-29_11-37-40_root_agent.md
@@ -1,0 +1,7 @@
+- BuildInfo osztály újból bevezetve verzió- és build adatokkal.
+- Termékek View és ViewModel létrehozva, StageView-be integrálva.
+- StageViewModel új repo függőségeket és ShowProduct flaget kapott.
+- MainWindowViewModel bővítve a menüpontok logikájával, kilépés funkció hozzáadva.
+- ServiceLocator kibővült Product- és SupplierRepositoryval.
+- CHANGELOG frissítve.
+- Tesztfuttatás a dotnet hiánya miatt nem indult el.


### PR DESCRIPTION
## Summary
- introduce `BuildInfo` helper
- implement `ProductView` and `ProductViewModel`
- extend `StageViewModel` with new dependencies and ShowProduct flag
- wire up `StageView` and menu command logic
- document progress

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686120f358a48322a9561f07d028c78a