### PR TITLE
Fix MenuItem style in RetroTheme

### DIFF
--- a/Wrecept.Desktop/Themes/RetroTheme.xaml
+++ b/Wrecept.Desktop/Themes/RetroTheme.xaml
@@ -74,7 +74,8 @@
         <Setter Property="Foreground" Value="{StaticResource ForegroundBrush}" />
     </Style>
 
-    <Style TargetType="MenuItem" BasedOn="{StaticResource {x:Static MenuItem.StyleKey}}">
+    <!-- Base MenuItem style; removed invalid BasedOn reference -->
+    <Style TargetType="MenuItem">
         <Setter Property="Background" Value="Transparent" />
         <Setter Property="Foreground" Value="{StaticResource ForegroundBrush}" />
         <Setter Property="Padding" Value="10,5" />

--- a/docs/progress/2025-06-29_12-25-45_ui_agent.md
+++ b/docs/progress/2025-06-29_12-25-45_ui_agent.md
@@ -1,0 +1,2 @@
+- RetroTheme.xaml MenuItem stílusa frissítve: eltávolítottam a nem létező `MenuItem.StyleKey` hivatkozást.
+- Build eszköz hiánya miatt a tesztek nem futtathatók.


### PR DESCRIPTION
## Summary
- remove invalid MenuItem.StyleKey reference
- add progress log

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861305277648322923de849a867efb6