### PR TITLE
UI frissítés: felesleges menüpont eltávolítva

### DIFF
--- a/Wrecept.Desktop/MainWindow.xaml
+++ b/Wrecept.Desktop/MainWindow.xaml
@@ -15,9 +15,8 @@
     <DockPanel>
         <Menu DockPanel.Dock="Top">
             <MenuItem x:Name="MainMenuFirstItem" Header="Számlák" Tag="0" Click="MainMenuItem_Click">
-                <MenuItem Header="Bejövő szállítólevelek" Tag="0" Click="SubMenuItem_Click" />
-                <MenuItem Header="Bejövő számlák kezelése" Tag="1" Click="SubMenuItem_Click" />
-                <MenuItem Header="Bejövő számlák aktualizálása" Tag="2" Click="SubMenuItem_Click" />
+                <MenuItem Header="Bejövő számlák kezelése" Tag="0" Click="SubMenuItem_Click" />
+                <MenuItem Header="Bejövő számlák aktualizálása" Tag="1" Click="SubMenuItem_Click" />
             </MenuItem>
             <MenuItem Header="Törzsek" Tag="1" Click="MainMenuItem_Click">
                 <MenuItem Header="Termékek" Tag="0" Click="SubMenuItem_Click" />

--- a/Wrecept.Desktop/ViewModels/MainWindowViewModel.cs
+++ b/Wrecept.Desktop/ViewModels/MainWindowViewModel.cs
@@ -8,7 +8,7 @@ namespace Wrecept.Desktop.ViewModels;
 public partial class MainWindowViewModel : ObservableObject
 {
     private readonly StageViewModel _stage;
-    private readonly int[] _itemCounts = { 3, 5, 4, 4, 1, 1 };
+    private readonly int[] _itemCounts = { 2, 5, 4, 4, 1, 1 };
 
     private int SelectedIndex
     {

--- a/Wrecept.Desktop/Views/StageView.xaml
+++ b/Wrecept.Desktop/Views/StageView.xaml
@@ -41,32 +41,44 @@
             <views:InvoiceEditorView x:Name="InvoiceEditorHost"
                                      DataContext="{Binding Editor}"
                                      Grid.ColumnSpan="2"
-                                     Visibility="{Binding ShowEditor, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                                     Visibility="{Binding DataContext.ShowEditor,
+                                                         RelativeSource={RelativeSource AncestorType=UserControl},
+                                                         Converter={StaticResource BooleanToVisibilityConverter}}" />
 
             <views:SupplierLookupView x:Name="SupplierLookupHost"
                                       DataContext="{Binding SupplierLookup}"
                                       Grid.ColumnSpan="2"
-                                      Visibility="{Binding ShowSupplierLookup, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                                      Visibility="{Binding DataContext.ShowSupplierLookup,
+                                                          RelativeSource={RelativeSource AncestorType=UserControl},
+                                                          Converter={StaticResource BooleanToVisibilityConverter}}" />
 
             <views:ProductView x:Name="ProductHost"
                                DataContext="{Binding Product}"
                                Grid.ColumnSpan="2"
-                               Visibility="{Binding ShowProduct, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                               Visibility="{Binding DataContext.ShowProduct,
+                                                       RelativeSource={RelativeSource AncestorType=UserControl},
+                                                       Converter={StaticResource BooleanToVisibilityConverter}}" />
 
             <views:ProductGroupView x:Name="ProductGroupHost"
                                     DataContext="{Binding ProductGroup}"
                                     Grid.ColumnSpan="2"
-                                    Visibility="{Binding ShowProductGroup, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                                    Visibility="{Binding DataContext.ShowProductGroup,
+                                                        RelativeSource={RelativeSource AncestorType=UserControl},
+                                                        Converter={StaticResource BooleanToVisibilityConverter}}" />
 
             <views:TaxRateView x:Name="TaxRateHost"
                                DataContext="{Binding TaxRate}"
                                Grid.ColumnSpan="2"
-                               Visibility="{Binding ShowTaxRate, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                               Visibility="{Binding DataContext.ShowTaxRate,
+                                                       RelativeSource={RelativeSource AncestorType=UserControl},
+                                                       Converter={StaticResource BooleanToVisibilityConverter}}" />
 
             <views:PaymentMethodView x:Name="PaymentMethodHost"
                                     DataContext="{Binding PaymentMethod}"
                                     Grid.ColumnSpan="2"
-                                    Visibility="{Binding ShowPaymentMethod, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                                    Visibility="{Binding DataContext.ShowPaymentMethod,
+                                                        RelativeSource={RelativeSource AncestorType=UserControl},
+                                                        Converter={StaticResource BooleanToVisibilityConverter}}" />
         </Grid>
     </Grid>
 </UserControl>

--- a/docs/progress/2025-06-29_12-38-12_ui_agent.md
+++ b/docs/progress/2025-06-29_12-38-12_ui_agent.md
@@ -1,0 +1,3 @@
+- MainWindow: Bejövő szállítólevelek menüpont törölve, Tag értékek frissítve.
+- StageView: minden nézet láthatósági kötése a szülő DataContextjére mutat.
+- _itemCounts első eleme 2 lett.


### PR DESCRIPTION
## Summary
- eltávolítottam a `Bejövő szállítólevelek` menüpontot a Számlák almenüből
- StageView nézetek `Visibility` kötése most a szülő `UserControl` `DataContext`-jére hivatkozik
- frissítettem a `_itemCounts` tömböt két elemre az első menü esetén
- napló frissítve

## Testing
- `dotnet test` *(sikertelen: `dotnet` parancs nem található)*

------
https://chatgpt.com/codex/tasks/task_e_686133230c8c8322a7e9dd562bb15651