### PR TITLE
Fix submenu index for invoice editor

### DIFF
--- a/Wrecept.Desktop/ViewModels/MainWindowViewModel.cs
+++ b/Wrecept.Desktop/ViewModels/MainWindowViewModel.cs
@@ -88,10 +88,10 @@ public partial class MainWindowViewModel : ObservableObject
         {
             switch (SelectedSubmenuIndex)
             {
-                case 1:
+                case 0:
                     _stage.OpenInvoiceEditor();
                     break;
-                case 2:
+                case 1:
                     // TODO: bejövő számlák aktualizálása
                     break;
             }

--- a/docs/progress/2025-06-29_13-44-42_root_agent.md
+++ b/docs/progress/2025-06-29_13-44-42_root_agent.md
@@ -1,0 +1,3 @@
+- Menüpont indexeltetési hiba javítva a `MainWindowViewModel` switch ágában.
+- A `Bejövő számlák kezelése` almenü most már megnyitja a számlaszerkesztőt.
+- `dotnet` parancs hiánya miatt a tesztek nem futottak.


### PR DESCRIPTION
## Summary
- correct submenu index so the invoice editor opens
- log progress

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686142125348832283f67531bcf5f643