### PR TITLE
Fix StageViewModel debug logging

### DIFF
--- a/Wrecept.Desktop/ViewModels/StageViewModel.cs
+++ b/Wrecept.Desktop/ViewModels/StageViewModel.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using CommunityToolkit.Mvvm.ComponentModel;
 using Wrecept.Core.Services;
 using Wrecept.Core.Repositories;
@@ -97,9 +98,35 @@ public partial class StageViewModel : ObservableObject
         IsSubMenuOpen = false;
     }
 
+    partial void OnShowEditorChanged(bool value)
+    {
+        Debug.WriteLine($"ShowEditor set to {value}");
+    }
+
+    partial void OnShowSupplierLookupChanged(bool value)
+    {
+        Debug.WriteLine($"ShowSupplierLookup set to {value}");
+    }
+
     partial void OnShowProductChanged(bool value)
     {
+        Debug.WriteLine($"ShowProduct set to {value}");
         if (value)
             _ = Product.LoadAsync();
+    }
+
+    partial void OnShowProductGroupChanged(bool value)
+    {
+        Debug.WriteLine($"ShowProductGroup set to {value}");
+    }
+
+    partial void OnShowTaxRateChanged(bool value)
+    {
+        Debug.WriteLine($"ShowTaxRate set to {value}");
+    }
+
+    partial void OnShowPaymentMethodChanged(bool value)
+    {
+        Debug.WriteLine($"ShowPaymentMethod set to {value}");
     }
 }

--- a/docs/progress/2025-06-29_14-51-02_root_agent.md
+++ b/docs/progress/2025-06-29_14-51-02_root_agent.md
@@ -1,0 +1,2 @@
+- fix StageViewModel debug lines and confirm bindings
+


### PR DESCRIPTION
## Summary
- add debug logs to StageViewModel property changes
- log progress

## Testing
- `dotnet build Wrecept.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686152603b0c832285f395dd1b9c55c2