### PR TITLE
Rebuild StageView with integrated menu

### DIFF
--- a/Wrecept.Desktop/MainWindow.xaml
+++ b/Wrecept.Desktop/MainWindow.xaml
@@ -12,38 +12,7 @@
         <KeyBinding Key="Up" Command="{Binding MoveUpCommand}" />
         <KeyBinding Key="Down" Command="{Binding MoveDownCommand}" />
     </Window.InputBindings>
-    <DockPanel>
-        <Menu DockPanel.Dock="Top">
-            <MenuItem x:Name="MainMenuFirstItem" Header="Számlák" Tag="0" Click="MainMenuItem_Click">
-                <MenuItem Header="Bejövő számlák kezelése" Tag="0" Click="SubMenuItem_Click" />
-                <MenuItem Header="Bejövő számlák aktualizálása" Tag="1" Click="SubMenuItem_Click" />
-            </MenuItem>
-            <MenuItem Header="Törzsek" Tag="1" Click="MainMenuItem_Click">
-                <MenuItem Header="Termékek" Tag="0" Click="SubMenuItem_Click" />
-                <MenuItem Header="Termékcsoportok" Tag="1" Click="SubMenuItem_Click" />
-                <MenuItem Header="Szállítók" Tag="2" Click="SubMenuItem_Click" />
-                <MenuItem Header="ÁFA-kulcsok" Tag="3" Click="SubMenuItem_Click" />
-                <MenuItem Header="Fizetési módok" Tag="4" Click="SubMenuItem_Click" />
-            </MenuItem>
-            <MenuItem Header="Listák" Tag="2" Click="MainMenuItem_Click">
-                <MenuItem Header="Terméklista" Tag="0" Click="SubMenuItem_Click" />
-                <MenuItem Header="Szállítók listája" Tag="1" Click="SubMenuItem_Click" />
-                <MenuItem Header="Számlák listája" Tag="2" Click="SubMenuItem_Click" />
-                <MenuItem Header="Készletkarton" Tag="3" Click="SubMenuItem_Click" />
-            </MenuItem>
-            <MenuItem Header="Szerviz" Tag="3" Click="MainMenuItem_Click">
-                <MenuItem Header="Állományok ellenőrzése" Tag="0" Click="SubMenuItem_Click" />
-                <MenuItem Header="Áramszünet után" Tag="1" Click="SubMenuItem_Click" />
-                <MenuItem Header="Képernyő beállítása" Tag="2" Click="SubMenuItem_Click" />
-                <MenuItem Header="Nyomtató beállítás" Tag="3" Click="SubMenuItem_Click" />
-            </MenuItem>
-            <MenuItem Header="Névjegy" Tag="4" Click="MainMenuItem_Click">
-                <MenuItem Header="A program felhasználójának adatai" Tag="0" Click="SubMenuItem_Click" />
-            </MenuItem>
-            <MenuItem Header="Vége" Tag="5" Click="MainMenuItem_Click">
-                <MenuItem Header="Kilépés" Tag="0" Click="SubMenuItem_Click" />
-            </MenuItem>
-        </Menu>
+    <Grid>
         <views:StageView x:Name="Stage" />
-    </DockPanel>
+    </Grid>
 </Window>

--- a/Wrecept.Desktop/MainWindow.xaml.cs
+++ b/Wrecept.Desktop/MainWindow.xaml.cs
@@ -1,6 +1,4 @@
 using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Input;
 
 namespace Wrecept.Desktop;
 
@@ -22,27 +20,6 @@ public partial class MainWindow : Window
 
     private void Window_Loaded(object sender, RoutedEventArgs e)
     {
-        MainMenuFirstItem.Focus();
-    }
-
-    private void MainMenuItem_Click(object sender, RoutedEventArgs e)
-    {
-        if (sender is MenuItem mi && int.TryParse(mi.Tag?.ToString(), out var index))
-        {
-            ViewModel.Stage.SelectedIndex = index;
-            ViewModel.Stage.SelectedSubmenuIndex = 0;
-            ViewModel.Stage.IsSubMenuOpen = true;
-        }
-    }
-
-    private void SubMenuItem_Click(object sender, RoutedEventArgs e)
-    {
-        if (sender is MenuItem mi && int.TryParse(mi.Tag?.ToString(), out var subIndex))
-        {
-            if (mi.Parent is MenuItem parent && int.TryParse(parent.Tag?.ToString(), out var mainIndex))
-            {
-                ViewModel.ActivateMenuItem(mainIndex, subIndex);
-            }
-        }
+        Stage.FocusMainMenu();
     }
 }

--- a/Wrecept.Desktop/ViewModels/StageViewModel.cs
+++ b/Wrecept.Desktop/ViewModels/StageViewModel.cs
@@ -13,6 +13,30 @@ public partial class StageViewModel : ObservableObject
     public TaxRateViewModel TaxRate { get; }
     public PaymentMethodViewModel PaymentMethod { get; }
 
+    private readonly string[] _mainMenu =
+    {
+        "Számlák",
+        "Törzsek",
+        "Listák",
+        "Szerviz",
+        "Névjegy",
+        "Vége"
+    };
+
+    private readonly string[][] _subMenus =
+    {
+        new[] { "Bejövő számlák kezelése", "Bejövő számlák aktualizálása" },
+        new[] { "Termékek", "Termékcsoportok", "Szállítók", "ÁFA-kulcsok", "Fizetési módok" },
+        new[] { "Terméklista", "Szállítók listája", "Számlák listája", "Készletkarton" },
+        new[] { "Állományok ellenőrzése", "Áramszünet után", "Képernyő beállítása", "Nyomtató beállítás" },
+        new[] { "A program felhasználójának adatai" },
+        new[] { "Kilépés" }
+    };
+
+    public IReadOnlyList<string> MainMenuItems => _mainMenu;
+
+    public IReadOnlyList<string> CurrentSubMenuItems => _subMenus[SelectedIndex];
+
     [ObservableProperty]
     private int selectedIndex;
 

--- a/Wrecept.Desktop/Views/StageView.xaml
+++ b/Wrecept.Desktop/Views/StageView.xaml
@@ -6,7 +6,7 @@
              xmlns:views="clr-namespace:Wrecept.Desktop.Views"
              xmlns:vm="clr-namespace:Wrecept.Desktop.ViewModels"
              mc:Ignorable="d"
-             d:DesignHeight="450" d:DesignWidth="800">
+             d:DesignWidth="800" d:DesignHeight="450">
     <UserControl.Resources>
         <DataTemplate DataType="{x:Type vm:InvoiceEditorViewModel}">
             <views:InvoiceEditorView />
@@ -29,6 +29,27 @@
     </UserControl.Resources>
 
     <Grid Background="{DynamicResource StageBackground}">
-        <ContentControl Content="{Binding ActiveViewModel}" />
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="180" />
+            <ColumnDefinition Width="*" />
+        </Grid.ColumnDefinitions>
+
+        <StackPanel Grid.Column="0" Background="{DynamicResource ControlBackgroundBrush}" Padding="5">
+            <ListBox x:Name="MainMenuBox"
+                     ItemsSource="{Binding MainMenuItems}"
+                     SelectedIndex="{Binding SelectedIndex}"
+                     BorderThickness="0"
+                     Focusable="True"/>
+            <ListBox ItemsSource="{Binding CurrentSubMenuItems}"
+                     SelectedIndex="{Binding SelectedSubmenuIndex}"
+                     Visibility="{Binding IsSubMenuOpen, Converter={StaticResource BooleanToVisibilityConverter}}"
+                     Margin="0,5,0,0"
+                     BorderThickness="0"
+                     Focusable="True"/>
+        </StackPanel>
+
+        <ContentControl Content="{Binding ActiveViewModel}"
+                        Grid.Column="1"
+                        Margin="5" />
     </Grid>
 </UserControl>

--- a/Wrecept.Desktop/Views/StageView.xaml.cs
+++ b/Wrecept.Desktop/Views/StageView.xaml.cs
@@ -11,6 +11,11 @@ public partial class StageView : UserControl
         set => DataContext = value;
     }
 
+    public void FocusMainMenu()
+    {
+        MainMenuBox.Focus();
+    }
+
 
     public StageView()
     {

--- a/docs/README.md
+++ b/docs/README.md
@@ -48,9 +48,9 @@ Wrecept is a Windows desktop application designed to replicate the speed, clarit
 Wrecept.Desktop/
 ├── App.xaml / MainWindow.xaml        # App entry point and shell
 ├── Views/
-│   ├── StageView.xaml                # Main placeholder canvas
-│   ├── MenuBar.xaml                  # Visual top menu only
-│   └── StatusBar.xaml                # ESC/Enter hints footer
+│   ├── StageView.xaml                # Menü és tartalom egyben
+│   ├── InvoiceEditorView.xaml        # Számla rögzítés nézet
+│   └── ProductView.xaml              # Termékek kezelése
 ├── Themes/RetroTheme.xaml           # Retro color scheme
 ├── Assets/                          # Future icons, sounds, etc.
 └── README.md

--- a/docs/progress/2025-06-29_17-28-59_ui_agent.md
+++ b/docs/progress/2025-06-29_17-28-59_ui_agent.md
@@ -1,0 +1,6 @@
+# StageView újratervezés
+
+- Teljesen új menü- és tartalomelrendezést alakítottam ki a StageView-ban.
+- A MainWindow menüsávját eltávolítottam; a navigációt most a StageView ListBoxai kezelik.
+- StageViewModel kiegészült a menüpontok szövegeivel, így adatkötéssel jeleníthetők meg.
+- README frissült a mappa-struktúra új leírásával.


### PR DESCRIPTION
## Summary
- redesign StageView with ListBox-based main and sub menu
- remove old Menu from `MainWindow` and hook up focus to new menu
- expose menu items in `StageViewModel`
- update repo README structure
- log progress

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686175cc2bbc8322b1fd004d7003b06d