### PR TITLE
Implement menu command bindings

### DIFF
--- a/Wrecept.Desktop/MainMenu.cs
+++ b/Wrecept.Desktop/MainMenu.cs
@@ -1,0 +1,12 @@
+namespace Wrecept.Desktop;
+
+public enum MainMenu
+{
+    Invoice,
+    MasterData,
+    Lists,
+    Service,
+    About,
+    Exit
+}
+

--- a/Wrecept.Desktop/MainWindow.xaml
+++ b/Wrecept.Desktop/MainWindow.xaml
@@ -14,34 +14,57 @@
     </Window.InputBindings>
     <DockPanel>
         <Menu DockPanel.Dock="Top">
-            <MenuItem x:Name="MainMenuFirstItem" Header="Számlák" Tag="0" Click="MainMenuItem_Click">
-                <MenuItem Header="Bejövő számlák kezelése" Tag="0" Click="SubMenuItem_Click" />
-                <MenuItem Header="Bejövő számlák aktualizálása" Tag="1" Click="SubMenuItem_Click" />
+            <MenuItem x:Name="MainMenuFirstItem" Header="Számlák" Tag="0"
+                      Command="{Binding SelectMainMenuCommand}" CommandParameter="0" Focusable="True">
+                <MenuItem Header="Bejövő számlák kezelése" Tag="0"
+                          Command="{Binding SelectSubMenuCommand}" CommandParameter="0|0" Focusable="True" />
+                <MenuItem Header="Bejövő számlák aktualizálása" Tag="1"
+                          Command="{Binding SelectSubMenuCommand}" CommandParameter="0|1" Focusable="True" />
             </MenuItem>
-            <MenuItem Header="Törzsek" Tag="1" Click="MainMenuItem_Click">
-                <MenuItem Header="Termékek" Tag="0" Click="SubMenuItem_Click" />
-                <MenuItem Header="Termékcsoportok" Tag="1" Click="SubMenuItem_Click" />
-                <MenuItem Header="Szállítók" Tag="2" Click="SubMenuItem_Click" />
-                <MenuItem Header="ÁFA-kulcsok" Tag="3" Click="SubMenuItem_Click" />
-                <MenuItem Header="Fizetési módok" Tag="4" Click="SubMenuItem_Click" />
+            <MenuItem Header="Törzsek" Tag="1"
+                      Command="{Binding SelectMainMenuCommand}" CommandParameter="1" Focusable="True">
+                <MenuItem Header="Termékek" Tag="0"
+                          Command="{Binding SelectSubMenuCommand}" CommandParameter="1|0" Focusable="True" />
+                <MenuItem Header="Termékcsoportok" Tag="1"
+                          Command="{Binding SelectSubMenuCommand}" CommandParameter="1|1" Focusable="True" />
+                <MenuItem Header="Szállítók" Tag="2"
+                          Command="{Binding SelectSubMenuCommand}" CommandParameter="1|2" Focusable="True" />
+                <MenuItem Header="ÁFA-kulcsok" Tag="3"
+                          Command="{Binding SelectSubMenuCommand}" CommandParameter="1|3" Focusable="True" />
+                <MenuItem Header="Fizetési módok" Tag="4"
+                          Command="{Binding SelectSubMenuCommand}" CommandParameter="1|4" Focusable="True" />
             </MenuItem>
-            <MenuItem Header="Listák" Tag="2" Click="MainMenuItem_Click">
-                <MenuItem Header="Terméklista" Tag="0" Click="SubMenuItem_Click" />
-                <MenuItem Header="Szállítók listája" Tag="1" Click="SubMenuItem_Click" />
-                <MenuItem Header="Számlák listája" Tag="2" Click="SubMenuItem_Click" />
-                <MenuItem Header="Készletkarton" Tag="3" Click="SubMenuItem_Click" />
+            <MenuItem Header="Listák" Tag="2"
+                      Command="{Binding SelectMainMenuCommand}" CommandParameter="2" Focusable="True">
+                <MenuItem Header="Terméklista" Tag="0"
+                          Command="{Binding SelectSubMenuCommand}" CommandParameter="2|0" Focusable="True" />
+                <MenuItem Header="Szállítók listája" Tag="1"
+                          Command="{Binding SelectSubMenuCommand}" CommandParameter="2|1" Focusable="True" />
+                <MenuItem Header="Számlák listája" Tag="2"
+                          Command="{Binding SelectSubMenuCommand}" CommandParameter="2|2" Focusable="True" />
+                <MenuItem Header="Készletkarton" Tag="3"
+                          Command="{Binding SelectSubMenuCommand}" CommandParameter="2|3" Focusable="True" />
             </MenuItem>
-            <MenuItem Header="Szerviz" Tag="3" Click="MainMenuItem_Click">
-                <MenuItem Header="Állományok ellenőrzése" Tag="0" Click="SubMenuItem_Click" />
-                <MenuItem Header="Áramszünet után" Tag="1" Click="SubMenuItem_Click" />
-                <MenuItem Header="Képernyő beállítása" Tag="2" Click="SubMenuItem_Click" />
-                <MenuItem Header="Nyomtató beállítás" Tag="3" Click="SubMenuItem_Click" />
+            <MenuItem Header="Szerviz" Tag="3"
+                      Command="{Binding SelectMainMenuCommand}" CommandParameter="3" Focusable="True">
+                <MenuItem Header="Állományok ellenőrzése" Tag="0"
+                          Command="{Binding SelectSubMenuCommand}" CommandParameter="3|0" Focusable="True" />
+                <MenuItem Header="Áramszünet után" Tag="1"
+                          Command="{Binding SelectSubMenuCommand}" CommandParameter="3|1" Focusable="True" />
+                <MenuItem Header="Képernyő beállítása" Tag="2"
+                          Command="{Binding SelectSubMenuCommand}" CommandParameter="3|2" Focusable="True" />
+                <MenuItem Header="Nyomtató beállítás" Tag="3"
+                          Command="{Binding SelectSubMenuCommand}" CommandParameter="3|3" Focusable="True" />
             </MenuItem>
-            <MenuItem Header="Névjegy" Tag="4" Click="MainMenuItem_Click">
-                <MenuItem Header="A program felhasználójának adatai" Tag="0" Click="SubMenuItem_Click" />
+            <MenuItem Header="Névjegy" Tag="4"
+                      Command="{Binding SelectMainMenuCommand}" CommandParameter="4" Focusable="True">
+                <MenuItem Header="A program felhasználójának adatai" Tag="0"
+                          Command="{Binding SelectSubMenuCommand}" CommandParameter="4|0" Focusable="True" />
             </MenuItem>
-            <MenuItem Header="Vége" Tag="5" Click="MainMenuItem_Click">
-                <MenuItem Header="Kilépés" Tag="0" Click="SubMenuItem_Click" />
+            <MenuItem Header="Vége" Tag="5"
+                      Command="{Binding SelectMainMenuCommand}" CommandParameter="5" Focusable="True">
+                <MenuItem Header="Kilépés" Tag="0"
+                          Command="{Binding SelectSubMenuCommand}" CommandParameter="5|0" Focusable="True" />
             </MenuItem>
         </Menu>
         <views:StageView x:Name="Stage" />

--- a/Wrecept.Desktop/MainWindow.xaml.cs
+++ b/Wrecept.Desktop/MainWindow.xaml.cs
@@ -25,24 +25,5 @@ public partial class MainWindow : Window
         MainMenuFirstItem.Focus();
     }
 
-    private void MainMenuItem_Click(object sender, RoutedEventArgs e)
-    {
-        if (sender is MenuItem mi && int.TryParse(mi.Tag?.ToString(), out var index))
-        {
-            ViewModel.Stage.SelectedIndex = index;
-            ViewModel.Stage.SelectedSubmenuIndex = 0;
-            ViewModel.Stage.IsSubMenuOpen = true;
-        }
-    }
-
-    private void SubMenuItem_Click(object sender, RoutedEventArgs e)
-    {
-        if (sender is MenuItem mi && int.TryParse(mi.Tag?.ToString(), out var subIndex))
-        {
-            if (mi.Parent is MenuItem parent && int.TryParse(parent.Tag?.ToString(), out var mainIndex))
-            {
-                ViewModel.ActivateMenuItem(mainIndex, subIndex);
-            }
-        }
-    }
+    // korábbi Click-kezelők helyett parancskötéseket használunk
 }

--- a/Wrecept.Desktop/ViewModels/MainWindowViewModel.cs
+++ b/Wrecept.Desktop/ViewModels/MainWindowViewModel.cs
@@ -34,6 +34,8 @@ public partial class MainWindowViewModel : ObservableObject
     public IRelayCommand MoveDownCommand { get; }
     public IRelayCommand EnterCommand { get; }
     public IRelayCommand EscapeCommand { get; }
+    public IRelayCommand SelectMainMenuCommand { get; }
+    public IRelayCommand SelectSubMenuCommand { get; }
 
     public StageViewModel Stage => _stage;
 
@@ -46,11 +48,30 @@ public partial class MainWindowViewModel : ObservableObject
         MoveDownCommand = new RelayCommand(() => { if(IsSubMenuOpen) ChangeSub(1); });
         EnterCommand = new RelayCommand(OnEnter);
         EscapeCommand = new RelayCommand(OnEscape);
+        SelectMainMenuCommand = new RelayCommand<string>(p =>
+        {
+            if (int.TryParse(p, out var idx))
+            {
+                SelectedIndex = idx;
+                IsSubMenuOpen = true;
+                SelectedSubmenuIndex = 0;
+            }
+        });
+        SelectSubMenuCommand = new RelayCommand<string>(p =>
+        {
+            var parts = p.Split('|');
+            if (parts.Length == 2 &&
+                int.TryParse(parts[0], out var main) &&
+                int.TryParse(parts[1], out var sub))
+            {
+                ActivateMenuItem((MainMenu)main, sub);
+            }
+        });
     }
 
-    public void ActivateMenuItem(int mainIndex, int subIndex)
+    public void ActivateMenuItem(MainMenu main, int subIndex)
     {
-        SelectedIndex = mainIndex;
+        SelectedIndex = (int)main;
         SelectedSubmenuIndex = subIndex;
         IsSubMenuOpen = true;
         ExecuteCurrent();

--- a/docs/progress/2025-06-29_17-47-06_root_agent.md
+++ b/docs/progress/2025-06-29_17-47-06_root_agent.md
@@ -1,0 +1,6 @@
+# Progress Log - 2025-06-29 17:47 UTC
+
+* Audited MainWindow menu interaction logic as requested.
+* Confirmed event bindings and command wiring in MainWindow.xaml/.cs.
+* Identified potential Enter key interception by window-level KeyBindings.
+* No code changes were required at this stage.

--- a/docs/progress/2025-06-29_17-52-01_root_agent.md
+++ b/docs/progress/2025-06-29_17-52-01_root_agent.md
@@ -1,0 +1,7 @@
+# Progress Log - 2025-06-29 17:52 UTC
+
+* Implemented suggested fixes for menu interaction.
+* MenuItems now use RelayCommand bindings with Focusable="True".
+* Introduced `MainMenu` enum and updated `MainWindowViewModel` accordingly.
+* Removed obsolete click handlers from `MainWindow.xaml.cs`.
+


### PR DESCRIPTION
## Summary
- bind menu items to RelayCommands instead of Click handlers
- add MainMenu enum for clearer activation
- set Focusable=true on menu items
- remove obsolete click handlers
- add progress log

## Testing
- `dotnet build Wrecept.sln --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68617a79e280832288f0a2d882ce48d8