### PR TITLE
Implement product editor activation

### DIFF
--- a/Wrecept.Desktop/App.xaml
+++ b/Wrecept.Desktop/App.xaml
@@ -6,6 +6,7 @@
     <Application.Resources>
         <ResourceDictionary>
             <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
+            <local:InverseBooleanToVisibilityConverter x:Key="InverseBooleanConverter" />
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="Themes/RetroTheme.xaml" />
             </ResourceDictionary.MergedDictionaries>

--- a/Wrecept.Desktop/InverseBooleanToVisibilityConverter.cs
+++ b/Wrecept.Desktop/InverseBooleanToVisibilityConverter.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+
+namespace Wrecept.Desktop;
+
+public class InverseBooleanToVisibilityConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object? parameter, CultureInfo culture)
+        => value is bool b && b ? Visibility.Collapsed : Visibility.Visible;
+
+    public object ConvertBack(object value, Type targetType, object? parameter, CultureInfo culture)
+        => Binding.DoNothing;
+}

--- a/Wrecept.Desktop/ViewModels/MainWindowViewModel.cs
+++ b/Wrecept.Desktop/ViewModels/MainWindowViewModel.cs
@@ -69,6 +69,19 @@ public partial class MainWindowViewModel : ObservableObject
         });
     }
 
+    public void ActivateMenuItem(MainMenu item)
+    {
+        switch (item)
+        {
+            case MainMenu.MasterData:
+                _stage.ShowProductEditor();
+                break;
+            default:
+                ActivateMenuItem(item, 0);
+                break;
+        }
+    }
+
     public void ActivateMenuItem(MainMenu main, int subIndex)
     {
         SelectedIndex = (int)main;

--- a/Wrecept.Desktop/ViewModels/ProductEditorViewModel.cs
+++ b/Wrecept.Desktop/ViewModels/ProductEditorViewModel.cs
@@ -1,0 +1,14 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using Wrecept.Core.Services;
+
+namespace Wrecept.Desktop.ViewModels;
+
+public partial class ProductEditorViewModel : ObservableObject
+{
+    private readonly IProductService _service;
+
+    public ProductEditorViewModel(IProductService service)
+    {
+        _service = service;
+    }
+}

--- a/Wrecept.Desktop/ViewModels/StageViewModel.cs
+++ b/Wrecept.Desktop/ViewModels/StageViewModel.cs
@@ -12,6 +12,10 @@ public partial class StageViewModel : ObservableObject
     public ProductGroupViewModel ProductGroup { get; }
     public TaxRateViewModel TaxRate { get; }
     public PaymentMethodViewModel PaymentMethod { get; }
+    public ProductEditorViewModel ProductEditor { get; }
+
+    [ObservableProperty]
+    private bool showEditor;
 
     [ObservableProperty]
     private int selectedIndex;
@@ -29,6 +33,7 @@ public partial class StageViewModel : ObservableObject
     {
         Editor = new InvoiceEditorViewModel(invoiceService);
         Product = new ProductViewModel(productService);
+        ProductEditor = new ProductEditorViewModel(productService);
         SupplierLookup = new SupplierLookupViewModel(supplierRepository);
         ProductGroup = new ProductGroupViewModel();
         TaxRate = new TaxRateViewModel();
@@ -47,11 +52,14 @@ public partial class StageViewModel : ObservableObject
 
     public void OpenPaymentMethodView() => Activate(PaymentMethod);
 
-    private void Activate(ObservableObject viewModel)
+    public void ShowProductEditor() => Activate(ProductEditor, true);
+
+    private void Activate(ObservableObject viewModel, bool editor = false)
     {
         ActiveViewModel = viewModel;
         if (viewModel == Product)
             _ = Product.LoadAsync();
+        ShowEditor = editor;
         IsSubMenuOpen = false;
     }
 }

--- a/Wrecept.Desktop/Views/ProductEditorView.xaml
+++ b/Wrecept.Desktop/Views/ProductEditorView.xaml
@@ -1,0 +1,8 @@
+<UserControl x:Class="Wrecept.Desktop.Views.ProductEditorView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             d:DesignHeight="300" d:DesignWidth="400">
+    <Border Background="{DynamicResource StageBackground}" Padding="10">
+        <TextBlock Text="Termék szerkesztő" />
+    </Border>
+</UserControl>

--- a/Wrecept.Desktop/Views/ProductEditorView.xaml.cs
+++ b/Wrecept.Desktop/Views/ProductEditorView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace Wrecept.Desktop.Views;
+
+public partial class ProductEditorView : UserControl
+{
+    public ProductEditorView()
+    {
+        InitializeComponent();
+    }
+}

--- a/Wrecept.Desktop/Views/StageView.xaml
+++ b/Wrecept.Desktop/Views/StageView.xaml
@@ -26,9 +26,16 @@
         <DataTemplate DataType="{x:Type vm:PaymentMethodViewModel}">
             <views:PaymentMethodView />
         </DataTemplate>
+        <DataTemplate DataType="{x:Type vm:ProductEditorViewModel}">
+            <views:ProductEditorView />
+        </DataTemplate>
     </UserControl.Resources>
 
     <Grid Background="{DynamicResource StageBackground}">
-        <ContentControl Content="{Binding ActiveViewModel}" />
+        <ContentControl Content="{Binding ActiveViewModel}"
+                        Visibility="{Binding ShowEditor, Converter={StaticResource InverseBooleanConverter}}" />
+        <views:ProductEditorView x:Name="ProductEditorHost"
+                                 DataContext="{Binding ActiveViewModel}"
+                                 Visibility="{Binding ShowEditor, Converter={StaticResource BooleanToVisibilityConverter}}" />
     </Grid>
 </UserControl>

--- a/docs/progress/2025-06-29_18-04-38_code_agent.md
+++ b/docs/progress/2025-06-29_18-04-38_code_agent.md
@@ -1,0 +1,7 @@
+# Progress Log - 2025-06-29 18:04 UTC
+
+* Implemented `ProductEditorViewModel` and `ProductEditorView` placeholders.
+* Added `ShowProductEditor` logic in `StageViewModel` with new `ShowEditor` flag.
+* Introduced `ActivateMenuItem(MainMenu)` in `MainWindowViewModel` to open the product editor.
+* Updated `StageView.xaml` and `App.xaml` with new converter and bindings.
+* `dotnet test` failed: `dotnet` CLI not found in container.


### PR DESCRIPTION
## Summary
- add placeholder ProductEditorView/ViewModel
- add ShowProductEditor support in StageViewModel
- add ActivateMenuItem overload in MainWindowViewModel
- add inverse boolean visibility converter and wiring
- document progress

## Testing
- `dotnet test` *(fails: dotnet CLI not found)*

------
https://chatgpt.com/codex/tasks/task_e_68617f10d0fc8322abf76bc58657360a