### PR TITLE
Fix ProductEditorView design namespaces

### DIFF
--- a/Wrecept.Desktop/Views/ProductEditorView.xaml
+++ b/Wrecept.Desktop/Views/ProductEditorView.xaml
@@ -1,6 +1,9 @@
 <UserControl x:Class="Wrecept.Desktop.Views.ProductEditorView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
              d:DesignHeight="300" d:DesignWidth="400">
     <Border Background="{DynamicResource StageBackground}" Padding="10">
         <TextBlock Text="Termék szerkesztő" />

--- a/docs/progress/2025-06-29_18-10-12_ui_agent.md
+++ b/docs/progress/2025-06-29_18-10-12_ui_agent.md
@@ -1,0 +1,4 @@
+# Progress Log - 2025-06-29 18:10 UTC
+
+* Added missing `d` and `mc` namespaces to `ProductEditorView.xaml` for valid design-time markup.
+* Removed build artifacts with `git clean`.


### PR DESCRIPTION
## Summary
- add missing design namespaces to ProductEditorView
- clean build artefacts
- log progress

## Testing
- `dotnet test Wrecept.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_686180b4262083229d64d9df27e1c673