### PR TITLE
Fix global DataTemplate binding

### DIFF
--- a/Wrecept.Desktop/App.xaml
+++ b/Wrecept.Desktop/App.xaml
@@ -8,6 +8,7 @@
             <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="Themes/RetroTheme.xaml" />
+                <ResourceDictionary Source="Resources/DataTemplates.xaml" />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </Application.Resources>

--- a/Wrecept.Desktop/Resources/DataTemplates.xaml
+++ b/Wrecept.Desktop/Resources/DataTemplates.xaml
@@ -1,0 +1,23 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:views="clr-namespace:Wrecept.Desktop.Views"
+                    xmlns:vm="clr-namespace:Wrecept.Desktop.ViewModels">
+    <DataTemplate DataType="{x:Type vm:InvoiceEditorViewModel}">
+        <views:InvoiceEditorView />
+    </DataTemplate>
+    <DataTemplate DataType="{x:Type vm:SupplierLookupViewModel}">
+        <views:SupplierLookupView />
+    </DataTemplate>
+    <DataTemplate DataType="{x:Type vm:ProductViewModel}">
+        <views:ProductView />
+    </DataTemplate>
+    <DataTemplate DataType="{x:Type vm:ProductGroupViewModel}">
+        <views:ProductGroupView />
+    </DataTemplate>
+    <DataTemplate DataType="{x:Type vm:TaxRateViewModel}">
+        <views:TaxRateView />
+    </DataTemplate>
+    <DataTemplate DataType="{x:Type vm:PaymentMethodViewModel}">
+        <views:PaymentMethodView />
+    </DataTemplate>
+</ResourceDictionary>

--- a/Wrecept.Desktop/Views/StageView.xaml
+++ b/Wrecept.Desktop/Views/StageView.xaml
@@ -7,26 +7,7 @@
              xmlns:vm="clr-namespace:Wrecept.Desktop.ViewModels"
              mc:Ignorable="d"
              d:DesignHeight="450" d:DesignWidth="800">
-    <UserControl.Resources>
-        <DataTemplate DataType="{x:Type vm:InvoiceEditorViewModel}">
-            <views:InvoiceEditorView />
-        </DataTemplate>
-        <DataTemplate DataType="{x:Type vm:SupplierLookupViewModel}">
-            <views:SupplierLookupView />
-        </DataTemplate>
-        <DataTemplate DataType="{x:Type vm:ProductViewModel}">
-            <views:ProductView />
-        </DataTemplate>
-        <DataTemplate DataType="{x:Type vm:ProductGroupViewModel}">
-            <views:ProductGroupView />
-        </DataTemplate>
-        <DataTemplate DataType="{x:Type vm:TaxRateViewModel}">
-            <views:TaxRateView />
-        </DataTemplate>
-        <DataTemplate DataType="{x:Type vm:PaymentMethodViewModel}">
-            <views:PaymentMethodView />
-        </DataTemplate>
-    </UserControl.Resources>
+
 
     <Grid Background="{DynamicResource StageBackground}">
         <ContentControl Content="{Binding ActiveViewModel}" />

--- a/docs/progress/2025-06-29_18-36-19_root_agent.md
+++ b/docs/progress/2025-06-29_18-36-19_root_agent.md
@@ -1,0 +1,6 @@
+# Progress Log - 2025-06-29 18:36 UTC
+
+* Global DataTemplates created in `Resources/DataTemplates.xaml`.
+* `App.xaml` now merges the new dictionary.
+* `StageView.xaml` cleaned from local DataTemplates.
+* Build/test runs fail due to missing WindowsDesktop SDK in container.


### PR DESCRIPTION
## Summary
- centralize view DataTemplates in `Resources/DataTemplates.xaml`
- merge the dictionary in `App.xaml`
- simplify `StageView.xaml` since templates are global
- log progress

## Testing
- `dotnet build Wrecept.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861868af71c8322a2ffc78046775fd0