### PR TITLE
Fix README WPF path reference

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -45,7 +45,7 @@ Wrecept eredetileg Windowson futó WPF alkalmazásként indult. A multiplatform 
 ## 📁 Folder Structure
 
 ```
-Wrecept.Wpf/
+<tervezett WPF projekt>
 ├── App.xaml                          # Alkalmazás definíció
 ├── MainWindow.xaml                   # Főablak
 ├── Views/                            # XAML nézetek
@@ -74,7 +74,7 @@ Wrecept.Wpf/
 
 ## ✅ Kick OFF
 
-A WPF projekt a `Wrecept.Wpf` mappában indul az alábbi alapelemekkel:
+A WPF projekt a jövőben `Wrecept.Wpf` néven jön létre, és a tervek szerint az alábbi alapelemeket tartalmazza:
 
 * `App.xaml` és `App.xaml.cs` – alkalmazásbeállítások
 * `MainWindow.xaml` – főablak

--- a/docs/progress/2025-06-29_21-48-20_docs_agent.md
+++ b/docs/progress/2025-06-29_21-48-20_docs_agent.md
@@ -1,0 +1,3 @@
+# README frissítése
+- Kivettem a Wrecept.Wpf mappára való konkrét hivatkozást.
+- A Kick OFF szakasz most jelzi, hogy a WPF projekt később jön létre.


### PR DESCRIPTION
## Summary
- update README to clarify the WPF project folder does not yet exist
- log progress

## Testing
- `dotnet build Wrecept.sln -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861b44dde008322bf9496e58be7c916