### PR TITLE
Configure SQLite storage

### DIFF
--- a/Wrecept.Storage/Data/AppDbContext.cs
+++ b/Wrecept.Storage/Data/AppDbContext.cs
@@ -14,19 +14,8 @@ public class AppDbContext : DbContext
     public DbSet<TaxRate> TaxRates => Set<TaxRate>();
     public DbSet<PaymentMethod> PaymentMethods => Set<PaymentMethod>();
 
-    private readonly string _dbPath;
-
-    public AppDbContext(string dbPath)
-    {
-        _dbPath = dbPath;
-    }
-
-    public AppDbContext(DbContextOptions<AppDbContext> options, string dbPath)
+    public AppDbContext(DbContextOptions<AppDbContext> options)
         : base(options)
     {
-        _dbPath = dbPath;
     }
-
-    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-        => optionsBuilder.UseSqlite($"Data Source={_dbPath}");
 }

--- a/Wrecept.Storage/Repositories/InvoiceRepository.cs
+++ b/Wrecept.Storage/Repositories/InvoiceRepository.cs
@@ -12,7 +12,6 @@ public class InvoiceRepository : IInvoiceRepository
     public InvoiceRepository(AppDbContext db)
     {
         _db = db;
-        _db.Database.EnsureCreated();
     }
 
     public async Task<int> AddAsync(Invoice invoice, CancellationToken ct = default)

--- a/Wrecept.Storage/Repositories/PaymentMethodRepository.cs
+++ b/Wrecept.Storage/Repositories/PaymentMethodRepository.cs
@@ -12,7 +12,6 @@ public class PaymentMethodRepository : IPaymentMethodRepository
     public PaymentMethodRepository(AppDbContext db)
     {
         _db = db;
-        _db.Database.EnsureCreated();
     }
 
     public Task<List<PaymentMethod>> GetAllAsync(CancellationToken ct = default)

--- a/Wrecept.Storage/Repositories/ProductGroupRepository.cs
+++ b/Wrecept.Storage/Repositories/ProductGroupRepository.cs
@@ -12,7 +12,6 @@ public class ProductGroupRepository : IProductGroupRepository
     public ProductGroupRepository(AppDbContext db)
     {
         _db = db;
-        _db.Database.EnsureCreated();
     }
 
     public Task<List<ProductGroup>> GetAllAsync(CancellationToken ct = default)

--- a/Wrecept.Storage/Repositories/ProductRepository.cs
+++ b/Wrecept.Storage/Repositories/ProductRepository.cs
@@ -12,7 +12,6 @@ public class ProductRepository : IProductRepository
     public ProductRepository(AppDbContext db)
     {
         _db = db;
-        _db.Database.EnsureCreated();
     }
 
     public Task<List<Product>> GetAllAsync(CancellationToken ct = default)

--- a/Wrecept.Storage/Repositories/SupplierRepository.cs
+++ b/Wrecept.Storage/Repositories/SupplierRepository.cs
@@ -12,7 +12,6 @@ public class SupplierRepository : ISupplierRepository
     public SupplierRepository(AppDbContext db)
     {
         _db = db;
-        _db.Database.EnsureCreated();
     }
 
     public Task<List<Supplier>> GetAllAsync(CancellationToken ct = default)

--- a/Wrecept.Storage/Repositories/TaxRateRepository.cs
+++ b/Wrecept.Storage/Repositories/TaxRateRepository.cs
@@ -12,7 +12,6 @@ public class TaxRateRepository : ITaxRateRepository
     public TaxRateRepository(AppDbContext db)
     {
         _db = db;
-        _db.Database.EnsureCreated();
     }
 
     public Task<List<TaxRate>> GetAllAsync(CancellationToken ct = default)

--- a/Wrecept.Storage/ServiceCollectionExtensions.cs
+++ b/Wrecept.Storage/ServiceCollectionExtensions.cs
@@ -1,0 +1,29 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Wrecept.Core.Repositories;
+using Wrecept.Storage.Data;
+using Wrecept.Storage.Repositories;
+
+namespace Wrecept.Storage;
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AddStorage(this IServiceCollection services, string dbPath)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(dbPath);
+
+        services.AddDbContext<AppDbContext>(o => o.UseSqlite($"Data Source={dbPath}"));
+        services.AddScoped<IInvoiceRepository, InvoiceRepository>();
+        services.AddScoped<IProductRepository, ProductRepository>();
+        services.AddScoped<ISupplierRepository, SupplierRepository>();
+        services.AddScoped<IPaymentMethodRepository, PaymentMethodRepository>();
+        services.AddScoped<IProductGroupRepository, ProductGroupRepository>();
+        services.AddScoped<ITaxRateRepository, TaxRateRepository>();
+
+        using var provider = services.BuildServiceProvider();
+        var ctx = provider.GetRequiredService<AppDbContext>();
+        ctx.Database.EnsureCreated();
+
+        return services;
+    }
+}

--- a/docs/progress/2025-06-29_22-15-36_storage_agent.md
+++ b/docs/progress/2025-06-29_22-15-36_storage_agent.md
@@ -1,0 +1,4 @@
+# Storage réteg stabilizálása
+- AppDbContext átalakítva, hogy DI-n keresztül kapjon SQLite beállítást.
+- Új `AddStorage` kiterjesztés regisztrálja a repositorykat és létrehozza az adatbázist.
+- Repository konstruktorokból kivettük az `EnsureCreated` hívást.


### PR DESCRIPTION
## Summary
- modify `AppDbContext` to accept `DbContextOptions`
- add `ServiceCollectionExtensions` for registering storage
- drop `EnsureCreated` from repository constructors
- log storage work in progress notes

## Testing
- `dotnet test ../Wrecept.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861ba42c6c88322a977dea93a51cef7