### PR TITLE
Add WPF shell with DI

### DIFF
--- a/Wrecept.Core/ServiceCollectionExtensions.cs
+++ b/Wrecept.Core/ServiceCollectionExtensions.cs
@@ -1,0 +1,14 @@
+using Microsoft.Extensions.DependencyInjection;
+using Wrecept.Core.Services;
+
+namespace Wrecept.Core;
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AddCore(this IServiceCollection services)
+    {
+        services.AddScoped<IProductService, ProductService>();
+        services.AddScoped<IInvoiceService, InvoiceService>();
+        return services;
+    }
+}

--- a/Wrecept.Core/Wrecept.Core.csproj
+++ b/Wrecept.Core/Wrecept.Core.csproj
@@ -6,4 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
+  </ItemGroup>
+
 </Project>

--- a/Wrecept.Wpf/App.xaml
+++ b/Wrecept.Wpf/App.xaml
@@ -1,0 +1,12 @@
+<Application x:Class="Wrecept.Wpf.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             StartupUri="MainWindow.xaml">
+    <Application.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="Themes/RetroTheme.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </Application.Resources>
+</Application>

--- a/Wrecept.Wpf/App.xaml.cs
+++ b/Wrecept.Wpf/App.xaml.cs
@@ -1,0 +1,39 @@
+using System;
+using System.IO;
+using System.Windows;
+using Microsoft.Extensions.DependencyInjection;
+using Wrecept.Core;
+using Wrecept.Storage;
+
+namespace Wrecept.Wpf;
+
+public partial class App : Application
+{
+    public IServiceProvider Services { get; }
+
+    public App()
+    {
+        var serviceCollection = new ServiceCollection();
+        ConfigureServices(serviceCollection);
+        Services = serviceCollection.BuildServiceProvider();
+    }
+
+    private static void ConfigureServices(IServiceCollection services)
+    {
+        var appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+        var dataDir = Path.Combine(appData, "Wrecept");
+        Directory.CreateDirectory(dataDir);
+        var dbPath = Path.Combine(dataDir, "app.db");
+
+        services.AddCore();
+        services.AddStorage(dbPath);
+        services.AddSingleton<MainWindow>();
+    }
+
+    protected override void OnStartup(StartupEventArgs e)
+    {
+        base.OnStartup(e);
+        var window = Services.GetRequiredService<MainWindow>();
+        window.Show();
+    }
+}

--- a/Wrecept.Wpf/MainWindow.xaml
+++ b/Wrecept.Wpf/MainWindow.xaml
@@ -1,0 +1,7 @@
+<Window x:Class="Wrecept.Wpf.MainWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:views="clr-namespace:Wrecept.Wpf.Views"
+        Title="Wrecept" Height="450" Width="800">
+    <views:StageView />
+</Window>

--- a/Wrecept.Wpf/MainWindow.xaml.cs
+++ b/Wrecept.Wpf/MainWindow.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows;
+
+namespace Wrecept.Wpf;
+
+public partial class MainWindow : Window
+{
+    public MainWindow()
+    {
+        InitializeComponent();
+    }
+}

--- a/Wrecept.Wpf/Themes/RetroTheme.xaml
+++ b/Wrecept.Wpf/Themes/RetroTheme.xaml
@@ -1,0 +1,5 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Color x:Key="StageBackgroundColor">#FFE187</Color>
+    <SolidColorBrush x:Key="StageBackground" Color="{StaticResource StageBackgroundColor}" />
+</ResourceDictionary>

--- a/Wrecept.Wpf/Views/StageView.xaml
+++ b/Wrecept.Wpf/Views/StageView.xaml
@@ -1,0 +1,7 @@
+<UserControl x:Class="Wrecept.Wpf.Views.StageView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Grid Background="{DynamicResource StageBackground}">
+        <TextBlock Text="StageView" HorizontalAlignment="Center" VerticalAlignment="Center" />
+    </Grid>
+</UserControl>

--- a/Wrecept.Wpf/Views/StageView.xaml.cs
+++ b/Wrecept.Wpf/Views/StageView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace Wrecept.Wpf.Views;
+
+public partial class StageView : UserControl
+{
+    public StageView()
+    {
+        InitializeComponent();
+    }
+}

--- a/Wrecept.Wpf/Wrecept.Wpf.csproj
+++ b/Wrecept.Wpf/Wrecept.Wpf.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <Nullable>enable</Nullable>
+    <UseWPF>true</UseWPF>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Wrecept.Core\Wrecept.Core.csproj" />
+    <ProjectReference Include="..\Wrecept.Storage\Wrecept.Storage.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Wrecept.sln
+++ b/Wrecept.sln
@@ -7,6 +7,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Wrecept.Core", "Wrecept.Cor
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Wrecept.Storage", "Wrecept.Storage\Wrecept.Storage.csproj", "{BA378FCA-B5E5-4A5A-99E3-9DA7BCDBAC10}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Wrecept.Wpf", "Wrecept.Wpf\Wrecept.Wpf.csproj", "{E0783601-4640-44C9-B878-FACD240E377D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -23,6 +25,10 @@ Global
 		{BA378FCA-B5E5-4A5A-99E3-9DA7BCDBAC10}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{BA378FCA-B5E5-4A5A-99E3-9DA7BCDBAC10}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{BA378FCA-B5E5-4A5A-99E3-9DA7BCDBAC10}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{BA378FCA-B5E5-4A5A-99E3-9DA7BCDBAC10}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+                {BA378FCA-B5E5-4A5A-99E3-9DA7BCDBAC10}.Release|Any CPU.Build.0 = Release|Any CPU
+                {E0783601-4640-44C9-B878-FACD240E377D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {E0783601-4640-44C9-B878-FACD240E377D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {E0783601-4640-44C9-B878-FACD240E377D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {E0783601-4640-44C9-B878-FACD240E377D}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 EndGlobal

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -11,13 +11,14 @@ Az alkalmazás rétegei tisztán el vannak választva, hogy a karbantarthatósá
 
 ## Rétegzett felépítés
 
-1. **UI (Views / Themes)** – XAML nézetek és stílusfájlok. Csak vizuális elemeket tartalmaz, logikát nem.
+1. **UI (Views / Themes)** – XAML nézetek és stílusfájlok a `Wrecept.Wpf` projektben. Csak vizuális elemeket tartalmaz, logikát nem.
    *A globális RetroTheme.xaml minden vezérlőre egységes stílust ad.*
 2. **ViewModel** – A CommunityToolkit.Mvvm segítségével kezeli a felhasználói interakciókat és az adatkötéseket.
 3. **Core** – Domain modellek, szolgáltatás interfészek és belső számítások.
 4. **Storage** – SQLite + Entity Framework Core konténer, migrációk, repositoryk.
 
 Minden réteg csak az alatta lévőt éri el, közvetlen átjárás nem megengedett.
+Az elsődleges ablak a `MainWindow`, amely a `StageView` kontrollt jeleníti meg.
 
 ## Adatáramlás
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -47,7 +47,7 @@ Wrecept eredetileg Windowson futó WPF alkalmazásként indult. A multiplatform 
 ```
 Wrecept.Core/          # Domain modellek és szolgáltatások
 Wrecept.Storage/       # EF Core adatkezelés és repositoryk
-<tervezett Wrecept.Wpf>  # Későbbi WPF UI projekt
+Wrecept.Wpf/           # WPF UI projekt
 docs/                  # Dokumentációk
 tools/                 # Segédszkriptek
 CHANGELOG.md
@@ -74,11 +74,12 @@ Wrecept.sln
 
 ## ✅ Kick OFF
 
-A WPF projekt a jövőben `Wrecept.Wpf` néven jön létre, és a tervek szerint az alábbi alapelemeket tartalmazza:
+A WPF projekt `Wrecept.Wpf` néven jött létre, és az alábbi alapelemeket tartalmazza:
 
 * `App.xaml` és `App.xaml.cs` – alkalmazásbeállítások
 * `MainWindow.xaml` – főablak
 * `App.xaml.cs` tartalmazza a DI és indítási logikát
+* A `MainWindow` betölti a `StageView` felületet
 
 Ezek garantálják, hogy a program Windows környezetben azonnal futtatható legyen.
 

--- a/docs/progress/2025-06-29_22-24-12_code_agent.md
+++ b/docs/progress/2025-06-29_22-24-12_code_agent.md
@@ -1,0 +1,6 @@
+# WPF project bootstrap
+- Létrehoztam a `Wrecept.Wpf` projektet.
+- Beállítottam az `App` osztályban a DI konténert Core és Storage rétegekhez.
+- `MainWindow` betölti a `StageView` felületet.
+- `RetroTheme.xaml` tartalmazza az alap színbeállítást.
+- Dokumentáció frissítve az új projektre.


### PR DESCRIPTION
## Summary
- introduce Wrecept.Wpf project with simple shell
- load StageView from MainWindow
- register Core services via new AddCore extension
- wire up storage and core DI in App
- document the new project and update architecture
- log progress

## Testing
- `dotnet build Wrecept.sln -c Release` *(fails: Windows Desktop workload missing)*

------
https://chatgpt.com/codex/tasks/task_e_6861bbf7198083228fa0e16266b04a1f