### PR TITLE
Fix XAML load error on MainWindow

### DIFF
--- a/Wrecept.Wpf/App.xaml
+++ b/Wrecept.Wpf/App.xaml
@@ -1,7 +1,6 @@
 <Application x:Class="Wrecept.Wpf.App"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             StartupUri="MainWindow.xaml">
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Application.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>

--- a/docs/progress/2025-06-29_22-56-25_code_agent.md
+++ b/docs/progress/2025-06-29_22-56-25_code_agent.md
@@ -1,0 +1,2 @@
+- Removed StartupUri from App.xaml so DI-created MainWindow loads without parameterless constructor.
+- Verified build fails due to missing WindowsDesktop SDK in container.


### PR DESCRIPTION
## Summary
- remove `StartupUri` to allow DI to instantiate `MainWindow`
- log progress for code changes

## Testing
- `dotnet build Wrecept.sln -c Release` *(fails: Microsoft.NET.Sdk.WindowsDesktop missing)*

------
https://chatgpt.com/codex/tasks/task_e_6861c41bb7488322b43d02493ddfd5b8