### PR TITLE
Fix StageView focus handler

### DIFF
--- a/Wrecept.Wpf/Views/StageView.xaml.cs
+++ b/Wrecept.Wpf/Views/StageView.xaml.cs
@@ -14,13 +14,13 @@ public partial class StageView : UserControl
         InitializeComponent();
         _viewModel = viewModel;
         DataContext = viewModel;
-        FocusManager.AddGotFocusHandler(this, OnGotFocus);
+        Keyboard.AddGotKeyboardFocusHandler(this, OnGotKeyboardFocus);
     }
 
     private void OnKeyDown(object sender, KeyEventArgs e)
         => NavigationHelper.Handle(e);
 
-    private void OnGotFocus(object sender, KeyboardFocusChangedEventArgs e)
+    private void OnGotKeyboardFocus(object sender, KeyboardFocusChangedEventArgs e)
     {
         var fe = e.NewFocus as FrameworkElement;
         _viewModel.StatusBar.FocusedElement = fe?.Name ?? fe?.GetType().Name ?? string.Empty;

--- a/docs/progress/2025-06-29_23-24-14_ui_agent.md
+++ b/docs/progress/2025-06-29_23-24-14_ui_agent.md
@@ -1,0 +1,1 @@
+- fix StageView focus handler compile error


### PR DESCRIPTION
## Summary
- update focus handler to use `Keyboard.AddGotKeyboardFocusHandler`
- log progress for ui agent

## Testing
- `dotnet build Wrecept.sln -clp:ErrorsOnly` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*
- `dotnet test Wrecept.sln -clp:ErrorsOnly` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861ca9adea483228276ea76897e26c8