### PR TITLE
Add about document

### DIFF
--- a/docs/about_hu.md
+++ b/docs/about_hu.md
@@ -1,0 +1,20 @@
+---
+title: "Névjegy"
+purpose: "Programinformációk"
+author: "docs_agent"
+date: "2025-06-29"
+---
+
+# ℹ️ Névjegy
+
+A Wrecept program az alábbi adatokkal rendelkezik:
+
+- **Program neve:** Wrecept
+- **Verzió:** 0.1 (a verziókezelés bevezetés alatt áll)
+- **Build dátuma:** 2025-06-29 (UTC)
+- **Fejlesztő:** Tankó Ferenc & ChatGPT Codex Agents (<tankoferenc@icloud.com>)
+- **Rövid leírás:** Offline módon használható, billentyűzetközpontú számlázó rendszer.
+- **Licenc:** Free, OpenSource program és kód.
+- **Felhasznált technológiák:** .NET 8, WPF, SQLite, Dapper, MVVM architektúra.
+- **Előzmények:** Tácsi Egon (HA3MN) készítette az eredeti DOS-os, Clipper-es RECEPT.EXE programot.
+

--- a/docs/progress/2025-06-29_23-33-54_docs_agent.md
+++ b/docs/progress/2025-06-29_23-33-54_docs_agent.md
@@ -1,0 +1,1 @@
+- Hozzáadtam a `docs/about_hu.md` dokumentumot a Névjegy adataival.


### PR DESCRIPTION
## Summary
- add a Hungarian `about` file with program info
- log progress for documentation update

## Testing
- `dotnet test Wrecept.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861cbc01d948322a5d637afebe0b876