### PR TITLE
Add About view for UserInfo menu

### DIFF
--- a/Wrecept.Wpf/App.xaml.cs
+++ b/Wrecept.Wpf/App.xaml.cs
@@ -34,9 +34,11 @@ public partial class App : Application
         services.AddTransient<InvoiceEditorViewModel>();
         services.AddTransient<ProductMasterViewModel>();
         services.AddTransient<SupplierMasterViewModel>();
+        services.AddTransient<AboutViewModel>();
         services.AddTransient<PlaceholderViewModel>();
         services.AddSingleton<StatusBarViewModel>();
         services.AddTransient<StageView>();
+        services.AddTransient<AboutView>();
         services.AddTransient<PlaceholderView>();
         services.AddTransient<Views.Controls.StatusBar>();
 

--- a/Wrecept.Wpf/ViewModels/AboutViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/AboutViewModel.cs
@@ -1,0 +1,40 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using System.IO;
+using System.Reflection;
+
+namespace Wrecept.Wpf.ViewModels;
+
+public partial class AboutViewModel : ObservableObject
+{
+    [ObservableProperty]
+    private string aboutText = string.Empty;
+
+    public AboutViewModel()
+    {
+        var assembly = Assembly.GetExecutingAssembly();
+        var resourceName = "Wrecept.Wpf.Resources.about_hu.md";
+        using var stream = assembly.GetManifestResourceStream(resourceName);
+        if (stream is not null)
+        {
+            using var reader = new StreamReader(stream);
+            AboutText = StripFrontMatter(reader.ReadToEnd());
+        }
+        else
+        {
+            AboutText = "A Névjegy információ nem található.";
+        }
+    }
+
+    private static string StripFrontMatter(string text)
+    {
+        if (text.StartsWith("---"))
+        {
+            var end = text.IndexOf("---", 3);
+            if (end != -1)
+            {
+                return text[(end + 3)..].Trim();
+            }
+        }
+        return text.Trim();
+    }
+}

--- a/Wrecept.Wpf/ViewModels/StageViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/StageViewModel.cs
@@ -33,6 +33,7 @@ public partial class StageViewModel : ObservableObject
     private readonly InvoiceEditorViewModel _invoiceEditor;
     private readonly ProductMasterViewModel _productMaster;
     private readonly SupplierMasterViewModel _supplierMaster;
+    private readonly AboutViewModel _about;
     private readonly PlaceholderViewModel _placeholder;
     private readonly StatusBarViewModel _statusBar;
 
@@ -42,12 +43,14 @@ public partial class StageViewModel : ObservableObject
         InvoiceEditorViewModel invoiceEditor,
         ProductMasterViewModel productMaster,
         SupplierMasterViewModel supplierMaster,
+        AboutViewModel about,
         PlaceholderViewModel placeholder,
         StatusBarViewModel statusBar)
     {
         _invoiceEditor = invoiceEditor;
         _productMaster = productMaster;
         _supplierMaster = supplierMaster;
+        _about = about;
         _placeholder = placeholder;
         _statusBar = statusBar;
         CurrentViewModel = _invoiceEditor;
@@ -82,8 +85,16 @@ public partial class StageViewModel : ObservableObject
             case StageMenuAction.ScreenSettings:
             case StageMenuAction.PrinterSettings:
             case StageMenuAction.UserInfo:
-                CurrentViewModel = _placeholder;
-                _statusBar.Message = "Funkció még nincs kész";
+                if (action == StageMenuAction.UserInfo)
+                {
+                    CurrentViewModel = _about;
+                    _statusBar.Message = "Névjegy megjelenítve";
+                }
+                else
+                {
+                    CurrentViewModel = _placeholder;
+                    _statusBar.Message = "Funkció még nincs kész";
+                }
                 break;
             case StageMenuAction.ExitApplication:
                 Application.Current.Shutdown();

--- a/Wrecept.Wpf/Views/AboutView.xaml
+++ b/Wrecept.Wpf/Views/AboutView.xaml
@@ -1,0 +1,8 @@
+<UserControl x:Class="Wrecept.Wpf.Views.AboutView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             KeyDown="OnKeyDown">
+    <ScrollViewer Background="{DynamicResource StageBackground}" Margin="4">
+        <TextBlock Text="{Binding AboutText}" TextWrapping="Wrap" FontFamily="Consolas"/>
+    </ScrollViewer>
+</UserControl>

--- a/Wrecept.Wpf/Views/AboutView.xaml.cs
+++ b/Wrecept.Wpf/Views/AboutView.xaml.cs
@@ -1,0 +1,15 @@
+using System.Windows.Controls;
+using System.Windows.Input;
+
+namespace Wrecept.Wpf.Views;
+
+public partial class AboutView : UserControl
+{
+    public AboutView()
+    {
+        InitializeComponent();
+    }
+
+    private void OnKeyDown(object sender, KeyEventArgs e)
+        => NavigationHelper.Handle(e);
+}

--- a/Wrecept.Wpf/Wrecept.Wpf.csproj
+++ b/Wrecept.Wpf/Wrecept.Wpf.csproj
@@ -12,6 +12,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <EmbeddedResource Include="..\docs\about_hu.md" Link="Resources\about_hu.md" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Wrecept.Core\Wrecept.Core.csproj" />
     <ProjectReference Include="..\Wrecept.Storage\Wrecept.Storage.csproj" />
   </ItemGroup>

--- a/docs/progress/2025-06-29_23-46-24_code_agent.md
+++ b/docs/progress/2025-06-29_23-46-24_code_agent.md
@@ -1,0 +1,4 @@
+- Implementáltam a Névjegy funkciót.
+- Létrehoztam AboutView és ViewModel osztályokat, beolvasom a docs/about_hu.md tartalmát.
+- StageViewModel frissítve, hogy a menüből megjelenítse az új nézetet.
+- DI konfiguráció bővítve az AboutView és ViewModel regisztrálásával.


### PR DESCRIPTION
## Summary
- read `docs/about_hu.md` as embedded resource
- display it with new `AboutView` and `AboutViewModel`
- wire up dependency injection
- update `StageViewModel` to open the view
- log progress

## Testing
- `dotnet build Wrecept.sln -c Release` *(fails: Microsoft.NET.Sdk.WindowsDesktop missing)*

------
https://chatgpt.com/codex/tasks/task_e_6861cf33caf8832281fe8d298fa160f9