### PR TITLE
Fix About view display

### DIFF
--- a/Wrecept.Wpf/App.xaml
+++ b/Wrecept.Wpf/App.xaml
@@ -1,12 +1,29 @@
 <Application x:Class="Wrecept.Wpf.App"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="clr-namespace:Wrecept.Wpf.ViewModels"
+             xmlns:view="clr-namespace:Wrecept.Wpf.Views">
     <Application.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="Themes/RetroTheme.xaml" />
             </ResourceDictionary.MergedDictionaries>
             <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter"/>
+            <DataTemplate DataType="{x:Type vm:InvoiceEditorViewModel}">
+                <view:InvoiceEditorView />
+            </DataTemplate>
+            <DataTemplate DataType="{x:Type vm:ProductMasterViewModel}">
+                <view:ProductMasterView />
+            </DataTemplate>
+            <DataTemplate DataType="{x:Type vm:SupplierMasterViewModel}">
+                <view:SupplierMasterView />
+            </DataTemplate>
+            <DataTemplate DataType="{x:Type vm:AboutViewModel}">
+                <view:AboutView />
+            </DataTemplate>
+            <DataTemplate DataType="{x:Type vm:PlaceholderViewModel}">
+                <view:PlaceholderView />
+            </DataTemplate>
         </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/docs/progress/2025-06-29_23-56-00_code_agent.md
+++ b/docs/progress/2025-06-29_23-56-00_code_agent.md
@@ -1,0 +1,2 @@
+- Added DataTemplates in App.xaml to map ViewModels to their views.
+- This fixes AboutView display when selecting the Névjegy menu item.


### PR DESCRIPTION
## Summary
- define view data templates in `App.xaml` so ViewModels render their respective views
- log the fix in progress notes

## Testing
- `dotnet build Wrecept.sln -v minimal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861d18700b4832296e78c7905f44754