### PR TITLE
Fix InvoiceEditorView DI instantiation

### DIFF
--- a/Wrecept.Wpf/App.xaml
+++ b/Wrecept.Wpf/App.xaml
@@ -10,13 +10,13 @@
             </ResourceDictionary.MergedDictionaries>
             <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter"/>
             <DataTemplate DataType="{x:Type vm:InvoiceEditorViewModel}">
-                <view:InvoiceEditorView />
+                <view:InvoiceEditorView x:FactoryMethod="Create" />
             </DataTemplate>
             <DataTemplate DataType="{x:Type vm:ProductMasterViewModel}">
-                <view:ProductMasterView />
+                <view:ProductMasterView x:FactoryMethod="Create" />
             </DataTemplate>
             <DataTemplate DataType="{x:Type vm:SupplierMasterViewModel}">
-                <view:SupplierMasterView />
+                <view:SupplierMasterView x:FactoryMethod="Create" />
             </DataTemplate>
             <DataTemplate DataType="{x:Type vm:AboutViewModel}">
                 <view:AboutView />

--- a/Wrecept.Wpf/App.xaml.cs
+++ b/Wrecept.Wpf/App.xaml.cs
@@ -12,6 +12,7 @@ namespace Wrecept.Wpf;
 public partial class App : Application
 {
     public IServiceProvider Services { get; }
+    public static IServiceProvider Provider => ((App)Current).Services;
 
     public App()
     {
@@ -38,6 +39,9 @@ public partial class App : Application
         services.AddTransient<PlaceholderViewModel>();
         services.AddSingleton<StatusBarViewModel>();
         services.AddTransient<StageView>();
+        services.AddTransient<InvoiceEditorView>();
+        services.AddTransient<ProductMasterView>();
+        services.AddTransient<SupplierMasterView>();
         services.AddTransient<AboutView>();
         services.AddTransient<PlaceholderView>();
         services.AddTransient<Views.Controls.StatusBar>();

--- a/Wrecept.Wpf/Views/InvoiceEditorView.xaml.cs
+++ b/Wrecept.Wpf/Views/InvoiceEditorView.xaml.cs
@@ -1,5 +1,6 @@
 using System.Windows.Controls;
 using System.Windows.Input;
+using Microsoft.Extensions.DependencyInjection;
 using Wrecept.Wpf.ViewModels;
 
 namespace Wrecept.Wpf.Views;
@@ -11,6 +12,9 @@ public partial class InvoiceEditorView : UserControl
         InitializeComponent();
         DataContext = viewModel;
     }
+
+    public static InvoiceEditorView Create()
+        => App.Provider.GetRequiredService<InvoiceEditorView>();
 
     private void OnKeyDown(object sender, KeyEventArgs e)
         => NavigationHelper.Handle(e);

--- a/Wrecept.Wpf/Views/ProductMasterView.xaml.cs
+++ b/Wrecept.Wpf/Views/ProductMasterView.xaml.cs
@@ -1,5 +1,6 @@
 using System.Windows.Controls;
 using System.Windows.Input;
+using Microsoft.Extensions.DependencyInjection;
 using Wrecept.Wpf.ViewModels;
 
 namespace Wrecept.Wpf.Views;
@@ -12,6 +13,9 @@ public partial class ProductMasterView : UserControl
         DataContext = viewModel;
         Loaded += async (_, _) => await viewModel.LoadAsync();
     }
+
+    public static ProductMasterView Create()
+        => App.Provider.GetRequiredService<ProductMasterView>();
 
     private void OnKeyDown(object sender, KeyEventArgs e)
         => NavigationHelper.Handle(e);

--- a/Wrecept.Wpf/Views/SupplierMasterView.xaml.cs
+++ b/Wrecept.Wpf/Views/SupplierMasterView.xaml.cs
@@ -1,5 +1,6 @@
 using System.Windows.Controls;
 using System.Windows.Input;
+using Microsoft.Extensions.DependencyInjection;
 using Wrecept.Wpf.ViewModels;
 
 namespace Wrecept.Wpf.Views;
@@ -12,6 +13,9 @@ public partial class SupplierMasterView : UserControl
         DataContext = viewModel;
         Loaded += async (_, _) => await viewModel.LoadAsync();
     }
+
+    public static SupplierMasterView Create()
+        => App.Provider.GetRequiredService<SupplierMasterView>();
 
     private void OnKeyDown(object sender, KeyEventArgs e)
         => NavigationHelper.Handle(e);

--- a/docs/progress/2025-06-30_00-02-35_code_agent.md
+++ b/docs/progress/2025-06-30_00-02-35_code_agent.md
@@ -1,0 +1,3 @@
+- Fixed InvoiceEditorView instantiation via DI.
+- Registered view services and added factory methods.
+- Build/test attempted; fails due to missing WindowsDesktop SDK.


### PR DESCRIPTION
## Summary
- enable DI based view creation
- register views with the container
- document build failure due to missing WindowsDesktop SDK

## Testing
- `dotnet build Wrecept.sln -c Release` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*
- `dotnet test Wrecept.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861d34afef08322b2d521945480e97f