### PR TITLE
Fix DI view instantiation without FactoryMethod

### DIFF
--- a/Wrecept.Wpf/App.xaml
+++ b/Wrecept.Wpf/App.xaml
@@ -10,13 +10,13 @@
             </ResourceDictionary.MergedDictionaries>
             <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter"/>
             <DataTemplate DataType="{x:Type vm:InvoiceEditorViewModel}">
-                <view:InvoiceEditorView x:FactoryMethod="Create" />
+                <view:InvoiceEditorView />
             </DataTemplate>
             <DataTemplate DataType="{x:Type vm:ProductMasterViewModel}">
-                <view:ProductMasterView x:FactoryMethod="Create" />
+                <view:ProductMasterView />
             </DataTemplate>
             <DataTemplate DataType="{x:Type vm:SupplierMasterViewModel}">
-                <view:SupplierMasterView x:FactoryMethod="Create" />
+                <view:SupplierMasterView />
             </DataTemplate>
             <DataTemplate DataType="{x:Type vm:AboutViewModel}">
                 <view:AboutView />

--- a/Wrecept.Wpf/Views/InvoiceEditorView.xaml.cs
+++ b/Wrecept.Wpf/Views/InvoiceEditorView.xaml.cs
@@ -7,14 +7,15 @@ namespace Wrecept.Wpf.Views;
 
 public partial class InvoiceEditorView : UserControl
 {
+    public InvoiceEditorView() : this(App.Provider.GetRequiredService<InvoiceEditorViewModel>())
+    {
+    }
+
     public InvoiceEditorView(InvoiceEditorViewModel viewModel)
     {
         InitializeComponent();
         DataContext = viewModel;
     }
-
-    public static InvoiceEditorView Create()
-        => App.Provider.GetRequiredService<InvoiceEditorView>();
 
     private void OnKeyDown(object sender, KeyEventArgs e)
         => NavigationHelper.Handle(e);

--- a/Wrecept.Wpf/Views/ProductMasterView.xaml.cs
+++ b/Wrecept.Wpf/Views/ProductMasterView.xaml.cs
@@ -7,15 +7,16 @@ namespace Wrecept.Wpf.Views;
 
 public partial class ProductMasterView : UserControl
 {
+    public ProductMasterView() : this(App.Provider.GetRequiredService<ProductMasterViewModel>())
+    {
+    }
+
     public ProductMasterView(ProductMasterViewModel viewModel)
     {
         InitializeComponent();
         DataContext = viewModel;
         Loaded += async (_, _) => await viewModel.LoadAsync();
     }
-
-    public static ProductMasterView Create()
-        => App.Provider.GetRequiredService<ProductMasterView>();
 
     private void OnKeyDown(object sender, KeyEventArgs e)
         => NavigationHelper.Handle(e);

--- a/Wrecept.Wpf/Views/SupplierMasterView.xaml.cs
+++ b/Wrecept.Wpf/Views/SupplierMasterView.xaml.cs
@@ -7,15 +7,16 @@ namespace Wrecept.Wpf.Views;
 
 public partial class SupplierMasterView : UserControl
 {
+    public SupplierMasterView() : this(App.Provider.GetRequiredService<SupplierMasterViewModel>())
+    {
+    }
+
     public SupplierMasterView(SupplierMasterViewModel viewModel)
     {
         InitializeComponent();
         DataContext = viewModel;
         Loaded += async (_, _) => await viewModel.LoadAsync();
     }
-
-    public static SupplierMasterView Create()
-        => App.Provider.GetRequiredService<SupplierMasterView>();
 
     private void OnKeyDown(object sender, KeyEventArgs e)
         => NavigationHelper.Handle(e);

--- a/docs/progress/2025-06-30_00-07-54_code_agent.md
+++ b/docs/progress/2025-06-30_00-07-54_code_agent.md
@@ -1,0 +1,3 @@
+- Removed FactoryMethod usage in App.xaml.
+- Added DI-based parameterless constructors for views.
+- Build/test couldn't run: dotnet not installed in container.


### PR DESCRIPTION
## Summary
- simplify App.xaml DataTemplates to remove `x:FactoryMethod`
- use DI provider in parameterless constructors of editor and master views
- log progress

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861d4b0b92483229e88cded5968f786