### PR TITLE
Handle empty DB with seeding

### DIFF
--- a/Wrecept.Storage/Data/DataSeeder.cs
+++ b/Wrecept.Storage/Data/DataSeeder.cs
@@ -1,0 +1,23 @@
+using Microsoft.EntityFrameworkCore;
+using Wrecept.Core.Entities;
+using Wrecept.Core.Models;
+
+namespace Wrecept.Storage.Data;
+
+public static class DataSeeder
+{
+    public static async Task<bool> SeedAsync(AppDbContext db, CancellationToken ct = default)
+    {
+        var hasData = await db.Products.AnyAsync(ct) || await db.Suppliers.AnyAsync(ct);
+        if (hasData) return false;
+
+        var now = DateTime.UtcNow;
+        db.PaymentMethods.Add(new PaymentMethod { Id = Guid.NewGuid(), Name = "Készpénz", CreatedAt = now, UpdatedAt = now });
+        db.ProductGroups.Add(new ProductGroup { Id = Guid.NewGuid(), Name = "Általános", CreatedAt = now, UpdatedAt = now });
+        db.TaxRates.Add(new TaxRate { Id = Guid.NewGuid(), Name = "ÁFA 27%", CreatedAt = now, UpdatedAt = now });
+        db.Suppliers.Add(new Supplier { Name = "Teszt Kft.", TaxId = "12345678-1-42", CreatedAt = now, UpdatedAt = now });
+        db.Products.Add(new Product { Name = "Teszt termék", Net = 1000m, Gross = 1270m, CreatedAt = now, UpdatedAt = now });
+        await db.SaveChangesAsync(ct);
+        return true;
+    }
+}

--- a/Wrecept.Wpf/App.xaml.cs
+++ b/Wrecept.Wpf/App.xaml.cs
@@ -49,9 +49,19 @@ public partial class App : Application
         services.AddSingleton<MainWindow>();
     }
 
-    protected override void OnStartup(StartupEventArgs e)
+    protected override async void OnStartup(StartupEventArgs e)
     {
         base.OnStartup(e);
+
+        var ctx = Services.GetRequiredService<Wrecept.Storage.Data.AppDbContext>();
+        var seeded = await Wrecept.Storage.Data.DataSeeder.SeedAsync(ctx);
+        if (seeded)
+            MessageBox.Show(
+                "A(z) app.db hiányzott vagy üres volt. Mintaadatok betöltve.",
+                "Első indítás",
+                MessageBoxButton.OK,
+                MessageBoxImage.Information);
+
         var window = Services.GetRequiredService<MainWindow>();
         window.Show();
     }

--- a/docs/ERROR_HANDLING.md
+++ b/docs/ERROR_HANDLING.md
@@ -28,8 +28,9 @@ Ez a dokumentum összefoglalja a hibakezelési stratégiát. Cél, hogy az alkal
 ## Konkrét példák
 
 1. **Adatbázis fájl hiánya** – Ha a `wrecept.db` nem található indításkor, a Storage réteg új üres adatbázist hoz létre, majd figyelmeztető üzenetet jelenítünk meg.
-2. **Sérült import fájl** – Hibás formátumú vagy hiányzó adatfájl betöltésekor megszakítjuk a folyamatot, naplózzuk a fájl nevét és a kiváltó hibát, és lehetőséget adunk új fájl kiválasztására.
-3. **Hálózati kimaradás** – Külső frissítések letöltése közben kapcsolatvesztés esetén újrapróbálkozunk, majd offline módra váltunk, miközben a felhasználót tájékoztatjuk.
-4. **Sikertelen adatbázis írás** – Ha a fájl zárolt vagy elfogy a tárhely, hibaüzenetet jelenítünk meg, a műveletet naplózzuk, majd biztonsági mentés után újrapróbáljuk.
+2. **Üres adatbázis** – Ha egyetlen táblában sincs adat, minta rekordokat szúrunk be és figyelmeztetjük a felhasználót.
+3. **Sérült import fájl** – Hibás formátumú vagy hiányzó adatfájl betöltésekor megszakítjuk a folyamatot, naplózzuk a fájl nevét és a kiváltó hibát, és lehetőséget adunk új fájl kiválasztására.
+4. **Hálózati kimaradás** – Külső frissítések letöltése közben kapcsolatvesztés esetén újrapróbálkozunk, majd offline módra váltunk, miközben a felhasználót tájékoztatjuk.
+5. **Sikertelen adatbázis írás** – Ha a fájl zárolt vagy elfogy a tárhely, hibaüzenetet jelenítünk meg, a műveletet naplózzuk, majd biztonsági mentés után újrapróbáljuk.
 
 ---

--- a/docs/progress/2025-06-30_00-16-12_storage_agent.md
+++ b/docs/progress/2025-06-30_00-16-12_storage_agent.md
@@ -1,0 +1,3 @@
+- Added DataSeeder for automatic sample data population when database missing or empty.
+- App.OnStartup now seeds data and shows a MessageBox warning on first launch.
+- Updated ERROR_HANDLING.md with new case for empty database.


### PR DESCRIPTION
## Summary
- seed default data when database is empty
- warn the user on first start if sample data is inserted
- document handling of empty database
- log storage work

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861d69340d88322abe3152349a08ada