### PR TITLE
Implement TaxRate versioning

### DIFF
--- a/Wrecept.Core/Entities/TaxRate.cs
+++ b/Wrecept.Core/Entities/TaxRate.cs
@@ -1,9 +1,0 @@
-namespace Wrecept.Core.Entities;
-
-public class TaxRate
-{
-    public Guid Id { get; set; }
-    public string Name { get; set; } = string.Empty;
-    public DateTime CreatedAt { get; set; }
-    public DateTime UpdatedAt { get; set; }
-}

--- a/Wrecept.Core/Models/TaxRate.cs
+++ b/Wrecept.Core/Models/TaxRate.cs
@@ -1,0 +1,13 @@
+namespace Wrecept.Core.Models;
+
+public class TaxRate
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public decimal Percentage { get; set; }
+    public DateTime EffectiveFrom { get; set; }
+    public DateTime? EffectiveTo { get; set; }
+    public bool IsArchived { get; set; } = false;
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+}

--- a/Wrecept.Core/ServiceCollectionExtensions.cs
+++ b/Wrecept.Core/ServiceCollectionExtensions.cs
@@ -10,6 +10,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IProductService, ProductService>();
         services.AddScoped<IInvoiceService, InvoiceService>();
         services.AddScoped<ISupplierService, SupplierService>();
+        services.AddScoped<ITaxRateService, TaxRateService>();
         return services;
     }
 }

--- a/Wrecept.Core/Services/ITaxRateService.cs
+++ b/Wrecept.Core/Services/ITaxRateService.cs
@@ -1,8 +1,8 @@
 using Wrecept.Core.Models;
 
-namespace Wrecept.Core.Repositories;
+namespace Wrecept.Core.Services;
 
-public interface ITaxRateRepository
+public interface ITaxRateService
 {
     Task<List<TaxRate>> GetAllAsync(CancellationToken ct = default);
     Task<TaxRate?> GetActiveAsync(DateTime asOf, CancellationToken ct = default);

--- a/Wrecept.Core/Services/TaxRateService.cs
+++ b/Wrecept.Core/Services/TaxRateService.cs
@@ -1,0 +1,20 @@
+using Wrecept.Core.Models;
+using Wrecept.Core.Repositories;
+
+namespace Wrecept.Core.Services;
+
+public class TaxRateService : ITaxRateService
+{
+    private readonly ITaxRateRepository _taxRates;
+
+    public TaxRateService(ITaxRateRepository taxRates)
+    {
+        _taxRates = taxRates;
+    }
+
+    public Task<List<TaxRate>> GetAllAsync(CancellationToken ct = default)
+        => _taxRates.GetAllAsync(ct);
+
+    public Task<TaxRate?> GetActiveAsync(DateTime asOf, CancellationToken ct = default)
+        => _taxRates.GetActiveAsync(asOf, ct);
+}

--- a/Wrecept.Storage/Data/AppDbContext.cs
+++ b/Wrecept.Storage/Data/AppDbContext.cs
@@ -18,4 +18,10 @@ public class AppDbContext : DbContext
         : base(options)
     {
     }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<TaxRate>()
+            .HasIndex(t => new { t.EffectiveFrom, t.EffectiveTo, t.IsArchived });
+    }
 }

--- a/Wrecept.Storage/Data/DataSeeder.cs
+++ b/Wrecept.Storage/Data/DataSeeder.cs
@@ -14,7 +14,15 @@ public static class DataSeeder
         var now = DateTime.UtcNow;
         db.PaymentMethods.Add(new PaymentMethod { Id = Guid.NewGuid(), Name = "Készpénz", CreatedAt = now, UpdatedAt = now });
         db.ProductGroups.Add(new ProductGroup { Id = Guid.NewGuid(), Name = "Általános", CreatedAt = now, UpdatedAt = now });
-        db.TaxRates.Add(new TaxRate { Id = Guid.NewGuid(), Name = "ÁFA 27%", CreatedAt = now, UpdatedAt = now });
+        db.TaxRates.Add(new TaxRate
+        {
+            Id = Guid.NewGuid(),
+            Name = "ÁFA 27%",
+            Percentage = 27m,
+            EffectiveFrom = new DateTime(2020, 1, 1),
+            CreatedAt = now,
+            UpdatedAt = now
+        });
         db.Suppliers.Add(new Supplier { Name = "Teszt Kft.", TaxId = "12345678-1-42", CreatedAt = now, UpdatedAt = now });
         db.Products.Add(new Product { Name = "Teszt termék", Net = 1000m, Gross = 1270m, CreatedAt = now, UpdatedAt = now });
         await db.SaveChangesAsync(ct);

--- a/Wrecept.Storage/Migrations/20250630110858_AddTaxRateVersioningFields.cs
+++ b/Wrecept.Storage/Migrations/20250630110858_AddTaxRateVersioningFields.cs
@@ -1,0 +1,45 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Wrecept.Storage.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddTaxRateVersioningFields : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "TaxRates",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "TEXT", nullable: false),
+                    Name = table.Column<string>(type: "TEXT", maxLength: 100, nullable: false),
+                    Percentage = table.Column<decimal>(type: "TEXT", nullable: false),
+                    EffectiveFrom = table.Column<DateTime>(type: "TEXT", nullable: false),
+                    EffectiveTo = table.Column<DateTime>(type: "TEXT", nullable: true),
+                    IsArchived = table.Column<bool>(type: "INTEGER", nullable: false, defaultValue: false),
+                    CreatedAt = table.Column<DateTime>(type: "TEXT", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_TaxRates", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TaxRates_EffectiveFrom_EffectiveTo_IsArchived",
+                table: "TaxRates",
+                columns: new[] { "EffectiveFrom", "EffectiveTo", "IsArchived" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "TaxRates");
+        }
+    }
+}

--- a/Wrecept.Storage/Repositories/TaxRateRepository.cs
+++ b/Wrecept.Storage/Repositories/TaxRateRepository.cs
@@ -1,5 +1,5 @@
 using Microsoft.EntityFrameworkCore;
-using Wrecept.Core.Entities;
+using Wrecept.Core.Models;
 using Wrecept.Core.Repositories;
 using Wrecept.Storage.Data;
 
@@ -16,4 +16,10 @@ public class TaxRateRepository : ITaxRateRepository
 
     public Task<List<TaxRate>> GetAllAsync(CancellationToken ct = default)
         => _db.Set<TaxRate>().ToListAsync(ct);
+
+    public Task<TaxRate?> GetActiveAsync(DateTime asOf, CancellationToken ct = default)
+        => _db.Set<TaxRate>()
+            .Where(t => t.EffectiveFrom <= asOf && (!t.EffectiveTo.HasValue || t.EffectiveTo >= asOf) && !t.IsArchived)
+            .OrderByDescending(t => t.EffectiveFrom)
+            .FirstOrDefaultAsync(ct);
 }

--- a/Wrecept.Wpf/App.xaml
+++ b/Wrecept.Wpf/App.xaml
@@ -18,6 +18,9 @@
             <DataTemplate DataType="{x:Type vm:SupplierMasterViewModel}">
                 <view:SupplierMasterView />
             </DataTemplate>
+            <DataTemplate DataType="{x:Type vm:TaxRateMasterViewModel}">
+                <view:TaxRateMasterView />
+            </DataTemplate>
             <DataTemplate DataType="{x:Type vm:AboutViewModel}">
                 <view:AboutView />
             </DataTemplate>

--- a/Wrecept.Wpf/App.xaml.cs
+++ b/Wrecept.Wpf/App.xaml.cs
@@ -35,6 +35,7 @@ public partial class App : Application
         services.AddTransient<InvoiceEditorViewModel>();
         services.AddTransient<ProductMasterViewModel>();
         services.AddTransient<SupplierMasterViewModel>();
+        services.AddTransient<TaxRateMasterViewModel>();
         services.AddTransient<AboutViewModel>();
         services.AddTransient<PlaceholderViewModel>();
         services.AddSingleton<StatusBarViewModel>();
@@ -42,6 +43,7 @@ public partial class App : Application
         services.AddTransient<InvoiceEditorView>();
         services.AddTransient<ProductMasterView>();
         services.AddTransient<SupplierMasterView>();
+        services.AddTransient<TaxRateMasterView>();
         services.AddTransient<AboutView>();
         services.AddTransient<PlaceholderView>();
         services.AddTransient<Views.Controls.StatusBar>();

--- a/Wrecept.Wpf/ViewModels/StageViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/StageViewModel.cs
@@ -33,6 +33,7 @@ public partial class StageViewModel : ObservableObject
     private readonly InvoiceEditorViewModel _invoiceEditor;
     private readonly ProductMasterViewModel _productMaster;
     private readonly SupplierMasterViewModel _supplierMaster;
+    private readonly TaxRateMasterViewModel _taxRateMaster;
     private readonly AboutViewModel _about;
     private readonly PlaceholderViewModel _placeholder;
     private readonly StatusBarViewModel _statusBar;
@@ -43,6 +44,7 @@ public partial class StageViewModel : ObservableObject
         InvoiceEditorViewModel invoiceEditor,
         ProductMasterViewModel productMaster,
         SupplierMasterViewModel supplierMaster,
+        TaxRateMasterViewModel taxRateMaster,
         AboutViewModel about,
         PlaceholderViewModel placeholder,
         StatusBarViewModel statusBar)
@@ -50,6 +52,7 @@ public partial class StageViewModel : ObservableObject
         _invoiceEditor = invoiceEditor;
         _productMaster = productMaster;
         _supplierMaster = supplierMaster;
+        _taxRateMaster = taxRateMaster;
         _about = about;
         _placeholder = placeholder;
         _statusBar = statusBar;
@@ -73,10 +76,13 @@ public partial class StageViewModel : ObservableObject
                 CurrentViewModel = _supplierMaster;
                 _statusBar.Message = "Szállító nézet megnyitva";
                 break;
+            case StageMenuAction.EditVatKeys:
+                CurrentViewModel = _taxRateMaster;
+                _statusBar.Message = "Adókulcs nézet megnyitva";
+                break;
             case StageMenuAction.InboundDeliveryNotes:
             case StageMenuAction.UpdateInboundInvoices:
             case StageMenuAction.EditProductGroups:
-            case StageMenuAction.EditVatKeys:
             case StageMenuAction.EditPaymentMethods:
             case StageMenuAction.ListInvoices:
             case StageMenuAction.InventoryCard:

--- a/Wrecept.Wpf/ViewModels/TaxRateMasterViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/TaxRateMasterViewModel.cs
@@ -1,0 +1,26 @@
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+using Wrecept.Core.Models;
+using Wrecept.Core.Services;
+
+namespace Wrecept.Wpf.ViewModels;
+
+public partial class TaxRateMasterViewModel : ObservableObject
+{
+    public ObservableCollection<TaxRate> TaxRates { get; } = new();
+
+    private readonly ITaxRateService _service;
+
+    public TaxRateMasterViewModel(ITaxRateService service)
+    {
+        _service = service;
+    }
+
+    public async Task LoadAsync()
+    {
+        var items = await _service.GetAllAsync();
+        TaxRates.Clear();
+        foreach (var item in items)
+            TaxRates.Add(item);
+    }
+}

--- a/Wrecept.Wpf/Views/TaxRateMasterView.xaml
+++ b/Wrecept.Wpf/Views/TaxRateMasterView.xaml
@@ -1,0 +1,14 @@
+<UserControl x:Class="Wrecept.Wpf.Views.TaxRateMasterView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             KeyDown="OnKeyDown">
+    <DataGrid ItemsSource="{Binding TaxRates}" AutoGenerateColumns="False" Margin="4">
+        <DataGrid.Columns>
+            <DataGridTextColumn Binding="{Binding Name}" Header="Név" />
+            <DataGridTextColumn Binding="{Binding Percentage}" Header="Százalék" />
+            <DataGridTextColumn Binding="{Binding EffectiveFrom}" Header="Érvényes tól" />
+            <DataGridTextColumn Binding="{Binding EffectiveTo}" Header="Érvényes ig" />
+            <DataGridCheckBoxColumn Binding="{Binding IsArchived}" Header="Archivált" />
+        </DataGrid.Columns>
+    </DataGrid>
+</UserControl>

--- a/Wrecept.Wpf/Views/TaxRateMasterView.xaml.cs
+++ b/Wrecept.Wpf/Views/TaxRateMasterView.xaml.cs
@@ -1,0 +1,23 @@
+using System.Windows.Controls;
+using System.Windows.Input;
+using Microsoft.Extensions.DependencyInjection;
+using Wrecept.Wpf.ViewModels;
+
+namespace Wrecept.Wpf.Views;
+
+public partial class TaxRateMasterView : UserControl
+{
+    public TaxRateMasterView() : this(App.Provider.GetRequiredService<TaxRateMasterViewModel>())
+    {
+    }
+
+    public TaxRateMasterView(TaxRateMasterViewModel viewModel)
+    {
+        InitializeComponent();
+        DataContext = viewModel;
+        Loaded += async (_, _) => await viewModel.LoadAsync();
+    }
+
+    private void OnKeyDown(object sender, KeyEventArgs e)
+        => NavigationHelper.Handle(e);
+}

--- a/docs/progress/2025-06-30_11-10-40_code_agent.md
+++ b/docs/progress/2025-06-30_11-10-40_code_agent.md
@@ -1,0 +1,5 @@
+- Átdolgozott TaxRate modell verziókövetéssel (Percentage, EffectiveFrom, EffectiveTo, IsArchived).
+- Minden referencia átállítva Models névtérre; új szolgáltatás és repository metódus készült.
+- AppDbContext indexet kapott az időszakos lekérdezésekhez.
+- Új Admin nézet hozzáadva az ÁFA-kulcsok listázásához.
+- DI regisztráció és menükezelés frissítve az új modulhoz.


### PR DESCRIPTION
## Summary
- refactor `TaxRate` as a domain model with percentage and validity fields
- add repository/service methods for active lookup
- seed sample tax rate data
- index tax rate validity range in EF Core context
- register new admin view for tax rates
- log progress

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68625a70f2908322991423dc5951b260