### PR TITLE
Add ProductGroup archival support

### DIFF
--- a/Wrecept.Core/Entities/ProductGroup.cs
+++ b/Wrecept.Core/Entities/ProductGroup.cs
@@ -1,9 +1,0 @@
-namespace Wrecept.Core.Entities;
-
-public class ProductGroup
-{
-    public Guid Id { get; set; }
-    public string Name { get; set; } = string.Empty;
-    public DateTime CreatedAt { get; set; }
-    public DateTime UpdatedAt { get; set; }
-}

--- a/Wrecept.Core/Entities/TaxRate.cs
+++ b/Wrecept.Core/Entities/TaxRate.cs
@@ -1,9 +1,0 @@
-namespace Wrecept.Core.Entities;
-
-public class TaxRate
-{
-    public Guid Id { get; set; }
-    public string Name { get; set; } = string.Empty;
-    public DateTime CreatedAt { get; set; }
-    public DateTime UpdatedAt { get; set; }
-}

--- a/Wrecept.Core/Models/ProductGroup.cs
+++ b/Wrecept.Core/Models/ProductGroup.cs
@@ -1,0 +1,10 @@
+namespace Wrecept.Core.Models;
+
+public class ProductGroup
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public bool IsArchived { get; set; } = false;
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+}

--- a/Wrecept.Core/Models/TaxRate.cs
+++ b/Wrecept.Core/Models/TaxRate.cs
@@ -1,0 +1,13 @@
+namespace Wrecept.Core.Models;
+
+public class TaxRate
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public decimal Percentage { get; set; }
+    public DateTime EffectiveFrom { get; set; }
+    public DateTime? EffectiveTo { get; set; }
+    public bool IsArchived { get; set; } = false;
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+}

--- a/Wrecept.Core/ServiceCollectionExtensions.cs
+++ b/Wrecept.Core/ServiceCollectionExtensions.cs
@@ -10,6 +10,8 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IProductService, ProductService>();
         services.AddScoped<IInvoiceService, InvoiceService>();
         services.AddScoped<ISupplierService, SupplierService>();
+        services.AddScoped<IProductGroupService, ProductGroupService>();
+        services.AddScoped<ITaxRateService, TaxRateService>();
         return services;
     }
 }

--- a/Wrecept.Core/Services/IProductGroupService.cs
+++ b/Wrecept.Core/Services/IProductGroupService.cs
@@ -1,8 +1,8 @@
 using Wrecept.Core.Models;
 
-namespace Wrecept.Core.Repositories;
+namespace Wrecept.Core.Services;
 
-public interface IProductGroupRepository
+public interface IProductGroupService
 {
     Task<List<ProductGroup>> GetAllAsync(CancellationToken ct = default);
     Task<List<ProductGroup>> GetActiveAsync(CancellationToken ct = default);

--- a/Wrecept.Core/Services/ITaxRateService.cs
+++ b/Wrecept.Core/Services/ITaxRateService.cs
@@ -1,8 +1,8 @@
 using Wrecept.Core.Models;
 
-namespace Wrecept.Core.Repositories;
+namespace Wrecept.Core.Services;
 
-public interface ITaxRateRepository
+public interface ITaxRateService
 {
     Task<List<TaxRate>> GetAllAsync(CancellationToken ct = default);
     Task<TaxRate?> GetActiveAsync(DateTime asOf, CancellationToken ct = default);

--- a/Wrecept.Core/Services/ProductGroupService.cs
+++ b/Wrecept.Core/Services/ProductGroupService.cs
@@ -1,0 +1,43 @@
+using Wrecept.Core.Models;
+using Wrecept.Core.Repositories;
+
+namespace Wrecept.Core.Services;
+
+public class ProductGroupService : IProductGroupService
+{
+    private readonly IProductGroupRepository _groups;
+
+    public ProductGroupService(IProductGroupRepository groups)
+    {
+        _groups = groups;
+    }
+
+    public Task<List<ProductGroup>> GetAllAsync(CancellationToken ct = default)
+        => _groups.GetAllAsync(ct);
+
+    public Task<List<ProductGroup>> GetActiveAsync(CancellationToken ct = default)
+        => _groups.GetActiveAsync(ct);
+
+    public async Task<Guid> AddAsync(ProductGroup group, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(group);
+        if (string.IsNullOrWhiteSpace(group.Name))
+            throw new ArgumentException("Name required", nameof(group));
+
+        group.CreatedAt = DateTime.UtcNow;
+        group.UpdatedAt = DateTime.UtcNow;
+        return await _groups.AddAsync(group, ct);
+    }
+
+    public async Task UpdateAsync(ProductGroup group, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(group);
+        if (group.Id == Guid.Empty)
+            throw new ArgumentException("Invalid Id", nameof(group));
+        if (string.IsNullOrWhiteSpace(group.Name))
+            throw new ArgumentException("Name required", nameof(group));
+
+        group.UpdatedAt = DateTime.UtcNow;
+        await _groups.UpdateAsync(group, ct);
+    }
+}

--- a/Wrecept.Core/Services/TaxRateService.cs
+++ b/Wrecept.Core/Services/TaxRateService.cs
@@ -1,0 +1,20 @@
+using Wrecept.Core.Models;
+using Wrecept.Core.Repositories;
+
+namespace Wrecept.Core.Services;
+
+public class TaxRateService : ITaxRateService
+{
+    private readonly ITaxRateRepository _taxRates;
+
+    public TaxRateService(ITaxRateRepository taxRates)
+    {
+        _taxRates = taxRates;
+    }
+
+    public Task<List<TaxRate>> GetAllAsync(CancellationToken ct = default)
+        => _taxRates.GetAllAsync(ct);
+
+    public Task<TaxRate?> GetActiveAsync(DateTime asOf, CancellationToken ct = default)
+        => _taxRates.GetActiveAsync(asOf, ct);
+}

--- a/Wrecept.Storage/Data/AppDbContext.cs
+++ b/Wrecept.Storage/Data/AppDbContext.cs
@@ -18,4 +18,10 @@ public class AppDbContext : DbContext
         : base(options)
     {
     }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<TaxRate>()
+            .HasIndex(t => new { t.EffectiveFrom, t.EffectiveTo, t.IsArchived });
+    }
 }

--- a/Wrecept.Storage/Data/DataSeeder.cs
+++ b/Wrecept.Storage/Data/DataSeeder.cs
@@ -14,7 +14,15 @@ public static class DataSeeder
         var now = DateTime.UtcNow;
         db.PaymentMethods.Add(new PaymentMethod { Id = Guid.NewGuid(), Name = "Készpénz", CreatedAt = now, UpdatedAt = now });
         db.ProductGroups.Add(new ProductGroup { Id = Guid.NewGuid(), Name = "Általános", CreatedAt = now, UpdatedAt = now });
-        db.TaxRates.Add(new TaxRate { Id = Guid.NewGuid(), Name = "ÁFA 27%", CreatedAt = now, UpdatedAt = now });
+        db.TaxRates.Add(new TaxRate
+        {
+            Id = Guid.NewGuid(),
+            Name = "ÁFA 27%",
+            Percentage = 27m,
+            EffectiveFrom = new DateTime(2020, 1, 1),
+            CreatedAt = now,
+            UpdatedAt = now
+        });
         db.Suppliers.Add(new Supplier { Name = "Teszt Kft.", TaxId = "12345678-1-42", CreatedAt = now, UpdatedAt = now });
         db.Products.Add(new Product { Name = "Teszt termék", Net = 1000m, Gross = 1270m, CreatedAt = now, UpdatedAt = now });
         await db.SaveChangesAsync(ct);

--- a/Wrecept.Storage/Migrations/20250630110858_AddTaxRateVersioningFields.cs
+++ b/Wrecept.Storage/Migrations/20250630110858_AddTaxRateVersioningFields.cs
@@ -1,0 +1,45 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Wrecept.Storage.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddTaxRateVersioningFields : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "TaxRates",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "TEXT", nullable: false),
+                    Name = table.Column<string>(type: "TEXT", maxLength: 100, nullable: false),
+                    Percentage = table.Column<decimal>(type: "TEXT", nullable: false),
+                    EffectiveFrom = table.Column<DateTime>(type: "TEXT", nullable: false),
+                    EffectiveTo = table.Column<DateTime>(type: "TEXT", nullable: true),
+                    IsArchived = table.Column<bool>(type: "INTEGER", nullable: false, defaultValue: false),
+                    CreatedAt = table.Column<DateTime>(type: "TEXT", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_TaxRates", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TaxRates_EffectiveFrom_EffectiveTo_IsArchived",
+                table: "TaxRates",
+                columns: new[] { "EffectiveFrom", "EffectiveTo", "IsArchived" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "TaxRates");
+        }
+    }
+}

--- a/Wrecept.Storage/Migrations/20250630120000_AddProductGroupArchivalSupport.cs
+++ b/Wrecept.Storage/Migrations/20250630120000_AddProductGroupArchivalSupport.cs
@@ -1,0 +1,37 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Wrecept.Storage.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddProductGroupArchivalSupport : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ProductGroups",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "TEXT", nullable: false),
+                    Name = table.Column<string>(type: "TEXT", maxLength: 100, nullable: false),
+                    IsArchived = table.Column<bool>(type: "INTEGER", nullable: false, defaultValue: false),
+                    CreatedAt = table.Column<DateTime>(type: "TEXT", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ProductGroups", x => x.Id);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ProductGroups");
+        }
+    }
+}

--- a/Wrecept.Storage/Repositories/ProductGroupRepository.cs
+++ b/Wrecept.Storage/Repositories/ProductGroupRepository.cs
@@ -1,5 +1,5 @@
 using Microsoft.EntityFrameworkCore;
-using Wrecept.Core.Entities;
+using Wrecept.Core.Models;
 using Wrecept.Core.Repositories;
 using Wrecept.Storage.Data;
 
@@ -16,4 +16,20 @@ public class ProductGroupRepository : IProductGroupRepository
 
     public Task<List<ProductGroup>> GetAllAsync(CancellationToken ct = default)
         => _db.Set<ProductGroup>().ToListAsync(ct);
+
+    public Task<List<ProductGroup>> GetActiveAsync(CancellationToken ct = default)
+        => _db.Set<ProductGroup>().Where(g => !g.IsArchived).ToListAsync(ct);
+
+    public async Task<Guid> AddAsync(ProductGroup group, CancellationToken ct = default)
+    {
+        _db.Add(group);
+        await _db.SaveChangesAsync(ct);
+        return group.Id;
+    }
+
+    public async Task UpdateAsync(ProductGroup group, CancellationToken ct = default)
+    {
+        _db.Update(group);
+        await _db.SaveChangesAsync(ct);
+    }
 }

--- a/Wrecept.Storage/Repositories/TaxRateRepository.cs
+++ b/Wrecept.Storage/Repositories/TaxRateRepository.cs
@@ -1,5 +1,5 @@
 using Microsoft.EntityFrameworkCore;
-using Wrecept.Core.Entities;
+using Wrecept.Core.Models;
 using Wrecept.Core.Repositories;
 using Wrecept.Storage.Data;
 
@@ -16,4 +16,10 @@ public class TaxRateRepository : ITaxRateRepository
 
     public Task<List<TaxRate>> GetAllAsync(CancellationToken ct = default)
         => _db.Set<TaxRate>().ToListAsync(ct);
+
+    public Task<TaxRate?> GetActiveAsync(DateTime asOf, CancellationToken ct = default)
+        => _db.Set<TaxRate>()
+            .Where(t => t.EffectiveFrom <= asOf && (!t.EffectiveTo.HasValue || t.EffectiveTo >= asOf) && !t.IsArchived)
+            .OrderByDescending(t => t.EffectiveFrom)
+            .FirstOrDefaultAsync(ct);
 }

--- a/Wrecept.Wpf/App.xaml
+++ b/Wrecept.Wpf/App.xaml
@@ -18,6 +18,9 @@
             <DataTemplate DataType="{x:Type vm:SupplierMasterViewModel}">
                 <view:SupplierMasterView />
             </DataTemplate>
+            <DataTemplate DataType="{x:Type vm:TaxRateMasterViewModel}">
+                <view:TaxRateMasterView />
+            </DataTemplate>
             <DataTemplate DataType="{x:Type vm:AboutViewModel}">
                 <view:AboutView />
             </DataTemplate>

--- a/Wrecept.Wpf/App.xaml.cs
+++ b/Wrecept.Wpf/App.xaml.cs
@@ -34,14 +34,18 @@ public partial class App : Application
         services.AddTransient<StageViewModel>();
         services.AddTransient<InvoiceEditorViewModel>();
         services.AddTransient<ProductMasterViewModel>();
+        services.AddTransient<ProductGroupMasterViewModel>();
         services.AddTransient<SupplierMasterViewModel>();
+        services.AddTransient<TaxRateMasterViewModel>();
         services.AddTransient<AboutViewModel>();
         services.AddTransient<PlaceholderViewModel>();
         services.AddSingleton<StatusBarViewModel>();
         services.AddTransient<StageView>();
         services.AddTransient<InvoiceEditorView>();
         services.AddTransient<ProductMasterView>();
+        services.AddTransient<ProductGroupMasterView>();
         services.AddTransient<SupplierMasterView>();
+        services.AddTransient<TaxRateMasterView>();
         services.AddTransient<AboutView>();
         services.AddTransient<PlaceholderView>();
         services.AddTransient<Views.Controls.StatusBar>();

--- a/Wrecept.Wpf/ViewModels/ProductGroupMasterViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/ProductGroupMasterViewModel.cs
@@ -1,0 +1,26 @@
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+using Wrecept.Core.Models;
+using Wrecept.Core.Services;
+
+namespace Wrecept.Wpf.ViewModels;
+
+public partial class ProductGroupMasterViewModel : ObservableObject
+{
+    public ObservableCollection<ProductGroup> ProductGroups { get; } = new();
+
+    private readonly IProductGroupService _service;
+
+    public ProductGroupMasterViewModel(IProductGroupService service)
+    {
+        _service = service;
+    }
+
+    public async Task LoadAsync()
+    {
+        var items = await _service.GetAllAsync();
+        ProductGroups.Clear();
+        foreach (var item in items)
+            ProductGroups.Add(item);
+    }
+}

--- a/Wrecept.Wpf/ViewModels/StageViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/StageViewModel.cs
@@ -32,7 +32,9 @@ public partial class StageViewModel : ObservableObject
 
     private readonly InvoiceEditorViewModel _invoiceEditor;
     private readonly ProductMasterViewModel _productMaster;
+    private readonly ProductGroupMasterViewModel _productGroupMaster;
     private readonly SupplierMasterViewModel _supplierMaster;
+    private readonly TaxRateMasterViewModel _taxRateMaster;
     private readonly AboutViewModel _about;
     private readonly PlaceholderViewModel _placeholder;
     private readonly StatusBarViewModel _statusBar;
@@ -42,14 +44,18 @@ public partial class StageViewModel : ObservableObject
     public StageViewModel(
         InvoiceEditorViewModel invoiceEditor,
         ProductMasterViewModel productMaster,
+        ProductGroupMasterViewModel productGroupMaster,
         SupplierMasterViewModel supplierMaster,
+        TaxRateMasterViewModel taxRateMaster,
         AboutViewModel about,
         PlaceholderViewModel placeholder,
         StatusBarViewModel statusBar)
     {
         _invoiceEditor = invoiceEditor;
         _productMaster = productMaster;
+        _productGroupMaster = productGroupMaster;
         _supplierMaster = supplierMaster;
+        _taxRateMaster = taxRateMaster;
         _about = about;
         _placeholder = placeholder;
         _statusBar = statusBar;
@@ -73,10 +79,16 @@ public partial class StageViewModel : ObservableObject
                 CurrentViewModel = _supplierMaster;
                 _statusBar.Message = "Szállító nézet megnyitva";
                 break;
+            case StageMenuAction.EditProductGroups:
+                CurrentViewModel = _productGroupMaster;
+                _statusBar.Message = "Termékcsoport nézet megnyitva";
+                break;
+            case StageMenuAction.EditVatKeys:
+                CurrentViewModel = _taxRateMaster;
+                _statusBar.Message = "Adókulcs nézet megnyitva";
+                break;
             case StageMenuAction.InboundDeliveryNotes:
             case StageMenuAction.UpdateInboundInvoices:
-            case StageMenuAction.EditProductGroups:
-            case StageMenuAction.EditVatKeys:
             case StageMenuAction.EditPaymentMethods:
             case StageMenuAction.ListInvoices:
             case StageMenuAction.InventoryCard:

--- a/Wrecept.Wpf/ViewModels/TaxRateMasterViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/TaxRateMasterViewModel.cs
@@ -1,0 +1,26 @@
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+using Wrecept.Core.Models;
+using Wrecept.Core.Services;
+
+namespace Wrecept.Wpf.ViewModels;
+
+public partial class TaxRateMasterViewModel : ObservableObject
+{
+    public ObservableCollection<TaxRate> TaxRates { get; } = new();
+
+    private readonly ITaxRateService _service;
+
+    public TaxRateMasterViewModel(ITaxRateService service)
+    {
+        _service = service;
+    }
+
+    public async Task LoadAsync()
+    {
+        var items = await _service.GetAllAsync();
+        TaxRates.Clear();
+        foreach (var item in items)
+            TaxRates.Add(item);
+    }
+}

--- a/Wrecept.Wpf/Views/ProductGroupMasterView.xaml
+++ b/Wrecept.Wpf/Views/ProductGroupMasterView.xaml
@@ -1,0 +1,12 @@
+<UserControl x:Class="Wrecept.Wpf.Views.ProductGroupMasterView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             KeyDown="OnKeyDown">
+    <DataGrid ItemsSource="{Binding ProductGroups}" AutoGenerateColumns="False" Margin="4">
+        <DataGrid.Columns>
+            <DataGridTextColumn Binding="{Binding Name}" Header="Név" />
+            <DataGridCheckBoxColumn Binding="{Binding IsArchived}" Header="Archivált" />
+            <DataGridTextColumn Binding="{Binding UpdatedAt}" Header="Módosítva" />
+        </DataGrid.Columns>
+    </DataGrid>
+</UserControl>

--- a/Wrecept.Wpf/Views/ProductGroupMasterView.xaml.cs
+++ b/Wrecept.Wpf/Views/ProductGroupMasterView.xaml.cs
@@ -1,0 +1,23 @@
+using System.Windows.Controls;
+using System.Windows.Input;
+using Microsoft.Extensions.DependencyInjection;
+using Wrecept.Wpf.ViewModels;
+
+namespace Wrecept.Wpf.Views;
+
+public partial class ProductGroupMasterView : UserControl
+{
+    public ProductGroupMasterView() : this(App.Provider.GetRequiredService<ProductGroupMasterViewModel>())
+    {
+    }
+
+    public ProductGroupMasterView(ProductGroupMasterViewModel viewModel)
+    {
+        InitializeComponent();
+        DataContext = viewModel;
+        Loaded += async (_, _) => await viewModel.LoadAsync();
+    }
+
+    private void OnKeyDown(object sender, KeyEventArgs e)
+        => NavigationHelper.Handle(e);
+}

--- a/Wrecept.Wpf/Views/TaxRateMasterView.xaml
+++ b/Wrecept.Wpf/Views/TaxRateMasterView.xaml
@@ -1,0 +1,14 @@
+<UserControl x:Class="Wrecept.Wpf.Views.TaxRateMasterView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             KeyDown="OnKeyDown">
+    <DataGrid ItemsSource="{Binding TaxRates}" AutoGenerateColumns="False" Margin="4">
+        <DataGrid.Columns>
+            <DataGridTextColumn Binding="{Binding Name}" Header="Név" />
+            <DataGridTextColumn Binding="{Binding Percentage}" Header="Százalék" />
+            <DataGridTextColumn Binding="{Binding EffectiveFrom}" Header="Érvényes tól" />
+            <DataGridTextColumn Binding="{Binding EffectiveTo}" Header="Érvényes ig" />
+            <DataGridCheckBoxColumn Binding="{Binding IsArchived}" Header="Archivált" />
+        </DataGrid.Columns>
+    </DataGrid>
+</UserControl>

--- a/Wrecept.Wpf/Views/TaxRateMasterView.xaml.cs
+++ b/Wrecept.Wpf/Views/TaxRateMasterView.xaml.cs
@@ -1,0 +1,23 @@
+using System.Windows.Controls;
+using System.Windows.Input;
+using Microsoft.Extensions.DependencyInjection;
+using Wrecept.Wpf.ViewModels;
+
+namespace Wrecept.Wpf.Views;
+
+public partial class TaxRateMasterView : UserControl
+{
+    public TaxRateMasterView() : this(App.Provider.GetRequiredService<TaxRateMasterViewModel>())
+    {
+    }
+
+    public TaxRateMasterView(TaxRateMasterViewModel viewModel)
+    {
+        InitializeComponent();
+        DataContext = viewModel;
+        Loaded += async (_, _) => await viewModel.LoadAsync();
+    }
+
+    private void OnKeyDown(object sender, KeyEventArgs e)
+        => NavigationHelper.Handle(e);
+}

--- a/docs/progress/2025-06-30_11-10-40_code_agent.md
+++ b/docs/progress/2025-06-30_11-10-40_code_agent.md
@@ -1,0 +1,5 @@
+- Átdolgozott TaxRate modell verziókövetéssel (Percentage, EffectiveFrom, EffectiveTo, IsArchived).
+- Minden referencia átállítva Models névtérre; új szolgáltatás és repository metódus készült.
+- AppDbContext indexet kapott az időszakos lekérdezésekhez.
+- Új Admin nézet hozzáadva az ÁFA-kulcsok listázásához.
+- DI regisztráció és menükezelés frissítve az új modulhoz.

--- a/docs/progress/2025-06-30_11-55-27_code_agent.md
+++ b/docs/progress/2025-06-30_11-55-27_code_agent.md
@@ -1,0 +1,4 @@
+- ProductGroup modell bővítve archiválással és időbélyegekkel
+- Új repository és service metódusok az aktív csoportok lekérésére
+- ProductGroupMasterView hozzáadva a StageView menüjéhez
+- EF Core migráció: AddProductGroupArchivalSupport


### PR DESCRIPTION
## Summary
- move `ProductGroup` to domain models with `IsArchived`
- extend repository and service APIs for product groups
- add migration to create ProductGroups table
- add `ProductGroupMasterView` and hook into StageView
- log progress

## Testing
- `dotnet build` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68625a70f2908322991423dc5951b260