### PR TITLE
Fix missing Task namespace

### DIFF
--- a/Wrecept.Wpf/ViewModels/ProductGroupMasterViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/ProductGroupMasterViewModel.cs
@@ -2,6 +2,7 @@ using System.Collections.ObjectModel;
 using CommunityToolkit.Mvvm.ComponentModel;
 using Wrecept.Core.Models;
 using Wrecept.Core.Services;
+using System.Threading.Tasks;
 
 namespace Wrecept.Wpf.ViewModels;
 

--- a/Wrecept.Wpf/ViewModels/TaxRateMasterViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/TaxRateMasterViewModel.cs
@@ -2,6 +2,7 @@ using System.Collections.ObjectModel;
 using CommunityToolkit.Mvvm.ComponentModel;
 using Wrecept.Core.Models;
 using Wrecept.Core.Services;
+using System.Threading.Tasks;
 
 namespace Wrecept.Wpf.ViewModels;
 

--- a/docs/progress/2025-06-30_12-28-17_code_agent.md
+++ b/docs/progress/2025-06-30_12-28-17_code_agent.md
@@ -1,0 +1,2 @@
+- Hiányzó `using System.Threading.Tasks` direktívák pótlása a `ProductGroupMasterViewModel` és `TaxRateMasterViewModel` fájlokban.
+- Build parancs lefuttatva, de a környezetben nincs telepítve a dotnet SDK.


### PR DESCRIPTION
## Summary
- add missing using directive for `Task` in ProductGroupMasterViewModel and TaxRateMasterViewModel
- log build attempt in progress notes

## Testing
- `dotnet build Wrecept.sln -v:m` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68628275a6988322993e3b89cbe81e0e