### PR TITLE
Fix missing EF Core migration on startup

### DIFF
--- a/Wrecept.Storage/ServiceCollectionExtensions.cs
+++ b/Wrecept.Storage/ServiceCollectionExtensions.cs
@@ -22,7 +22,7 @@ public static class ServiceCollectionExtensions
 
         using var provider = services.BuildServiceProvider();
         var ctx = provider.GetRequiredService<AppDbContext>();
-        ctx.Database.EnsureCreated();
+        ctx.Database.Migrate();
 
         return services;
     }

--- a/docs/BUILD_RUNTIME_NOTES.md
+++ b/docs/BUILD_RUNTIME_NOTES.md
@@ -24,5 +24,7 @@ Ez a jegyzet a fejlesztés során tapasztalt fordítási és futásidejű probl�
 2. Fordítás előtt futtassunk `dotnet build`-et és figyeljük a figyelmeztetéseket.
 3. A XAML fájlokat mindig ellenőrizzük jól formázott XML szempontjából.
 4. Teszteléskor győződjünk meg róla, hogy a szükséges SDK-k és NuGet csomagok telepítve vannak.
+5. Sémafrissítés után futtassuk le az EF Core migrációkat (`Database.Migrate()`),
+   különben futásidőben "no such column" hibát kaphatunk.
 
 ---

--- a/docs/progress/2025-06-30_12-40-04_code_agent.md
+++ b/docs/progress/2025-06-30_12-40-04_code_agent.md
@@ -1,0 +1,2 @@
+- AddStorage most `Database.Migrate()` hívással frissíti a sémát indításkor.
+- BUILD_RUNTIME_NOTES kiegészült migrációs emlékeztetővel.


### PR DESCRIPTION
## Summary
- run EF Core migrations during startup
- document migration reminder in build notes
- record progress

## Testing
- `dotnet build Wrecept.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*
- `dotnet test Wrecept.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_686284ee6b108322a3e33d7def40e3d0