### PR TITLE
Fix DataSeeder table creation fallback

### DIFF
--- a/Wrecept.Storage/Data/DataSeeder.cs
+++ b/Wrecept.Storage/Data/DataSeeder.cs
@@ -8,7 +8,15 @@ public static class DataSeeder
 {
     public static async Task<bool> SeedAsync(AppDbContext db, CancellationToken ct = default)
     {
-        await db.Database.MigrateAsync(ct);
+        try
+        {
+            await db.Database.MigrateAsync(ct);
+        }
+        catch (SqliteException)
+        {
+            await db.Database.EnsureCreatedAsync(ct);
+            await db.Database.MigrateAsync(ct);
+        }
 
         bool hasData;
         try
@@ -18,6 +26,7 @@ public static class DataSeeder
         catch (SqliteException)
         {
             await db.Database.EnsureCreatedAsync(ct);
+            await db.Database.MigrateAsync(ct);
             hasData = await db.Products.AnyAsync(ct) || await db.Suppliers.AnyAsync(ct);
         }
         if (hasData) return false;

--- a/docs/ERROR_HANDLING.md
+++ b/docs/ERROR_HANDLING.md
@@ -29,7 +29,7 @@ Ez a dokumentum összefoglalja a hibakezelési stratégiát. Cél, hogy az alkal
 
 1. **Adatbázis fájl hiánya** – Ha a `wrecept.db` nem található indításkor, a Storage réteg új üres adatbázist hoz létre, majd figyelmeztető üzenetet jelenítünk meg.
 2. **Üres adatbázis** – Ha egyetlen táblában sincs adat, minta rekordokat szúrunk be és figyelmeztetjük a felhasználót.
-3. **Sémahibák indításkor** – A `DataSeeder` megpróbálja automatikusan pótolni a hiányzó táblákat `EnsureCreated()` hívással, majd újra végrehajtja a migrációkat.
+3. **Sémahibák indításkor** – A `DataSeeder` először megkísérli lefuttatni a migrációkat. Ha ez sikertelen, `EnsureCreated()` hívással létrehozza az alap sémát, majd ismét futtatja a migrációkat.
 4. **Sérült import fájl** – Hibás formátumú vagy hiányzó adatfájl betöltésekor megszakítjuk a folyamatot, naplózzuk a fájl nevét és a kiváltó hibát, és lehetőséget adunk új fájl kiválasztására.
 5. **Hálózati kimaradás** – Külső frissítések letöltése közben kapcsolatvesztés esetén újrapróbálkozunk, majd offline módra váltunk, miközben a felhasználót tájékoztatjuk.
 6. **Sikertelen adatbázis írás** – Ha a fájl zárolt vagy elfogy a tárhely, hibaüzenetet jelenítünk meg, a műveletet naplózzuk, majd biztonsági mentés után újrapróbáljuk.

--- a/docs/progress/2025-06-30_13-25-45_storage_agent.md
+++ b/docs/progress/2025-06-30_13-25-45_storage_agent.md
@@ -1,0 +1,2 @@
+- DataSeeder most először migrál, hiba esetén EnsureCreated majd ismét migrál.
+- BUILD során hiányzott a WindowsDesktop SDK, dotnet build error MSB4019.


### PR DESCRIPTION
## Summary
- enhance seeding logic to retry migrations after ensuring schema
- update error handling docs with new startup recovery step
- log progress for storage agent

## Testing
- `dotnet build Wrecept.sln -v minimal` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets missing)*

------
https://chatgpt.com/codex/tasks/task_e_68628f715f7c83229dd9d88332570336