### PR TITLE
Improve database initialization

### DIFF
--- a/Wrecept.Storage/Data/DataSeeder.cs
+++ b/Wrecept.Storage/Data/DataSeeder.cs
@@ -1,5 +1,4 @@
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Data.Sqlite;
 using Wrecept.Core.Models;
 
 namespace Wrecept.Storage.Data;
@@ -8,15 +7,7 @@ public static class DataSeeder
 {
     public static async Task<bool> SeedAsync(AppDbContext db, CancellationToken ct = default)
     {
-        try
-        {
-            await db.Database.MigrateAsync(ct);
-        }
-        catch (SqliteException)
-        {
-            await db.Database.EnsureCreatedAsync(ct);
-            await db.Database.MigrateAsync(ct);
-        }
+        await DbInitializer.EnsureCreatedAndMigratedAsync(db, ct);
 
         bool hasData;
         try
@@ -25,8 +16,7 @@ public static class DataSeeder
         }
         catch (Exception)
         {
-            await db.Database.EnsureCreatedAsync(ct);
-            await db.Database.MigrateAsync(ct);
+            await DbInitializer.EnsureCreatedAndMigratedAsync(db, ct);
             hasData = await db.Products.AnyAsync(ct) || await db.Suppliers.AnyAsync(ct);
         }
         if (hasData) return false;

--- a/Wrecept.Storage/Data/DbInitializer.cs
+++ b/Wrecept.Storage/Data/DbInitializer.cs
@@ -1,0 +1,22 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+
+namespace Wrecept.Storage.Data;
+
+public static class DbInitializer
+{
+    public static async Task EnsureCreatedAndMigratedAsync(AppDbContext db, CancellationToken ct = default)
+    {
+        try
+        {
+            var pending = await db.Database.GetPendingMigrationsAsync(ct);
+            if (pending.Any())
+                await db.Database.MigrateAsync(ct);
+        }
+        catch (SqliteException)
+        {
+            await db.Database.EnsureCreatedAsync(ct);
+            await db.Database.MigrateAsync(ct);
+        }
+    }
+}

--- a/Wrecept.Storage/ServiceCollectionExtensions.cs
+++ b/Wrecept.Storage/ServiceCollectionExtensions.cs
@@ -22,7 +22,7 @@ public static class ServiceCollectionExtensions
 
         using var provider = services.BuildServiceProvider();
         var ctx = provider.GetRequiredService<AppDbContext>();
-        ctx.Database.Migrate();
+        DbInitializer.EnsureCreatedAndMigratedAsync(ctx).GetAwaiter().GetResult();
 
         return services;
     }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -46,7 +46,7 @@ Ezek fölött `InvoiceService`, `ProductService` és mostantól `SupplierService
 
 Minden domain modell tartalmaz `CreatedAt` és `UpdatedAt` mezőket. Ezeket a service réteg inicializálja, így naplózható az adat módosításának ideje.
 
-Az alkalmazás indításakor a `DataSeeder` gondoskodik a szükséges migrációk lefuttatásáról
-és – ha az adatbázis üres vagy hiányzik – egy minimális mintaadatkészlet betöltéséről.
+Az alkalmazás indításakor a `DbInitializer` futtatja a szükséges migrációkat.
+Ezt követően a `DataSeeder` – ha az adatbázis üres vagy hiányzik – egy minimális mintaadatkészletet tölt be.
 
 ---

--- a/docs/BUILD_RUNTIME_NOTES.md
+++ b/docs/BUILD_RUNTIME_NOTES.md
@@ -26,7 +26,6 @@ Ez a jegyzet a fejlesztés során tapasztalt fordítási és futásidejű probl�
 4. Teszteléskor győződjünk meg róla, hogy a szükséges SDK-k és NuGet csomagok telepítve vannak.
 5. Sémafrissítés után futtassuk le az EF Core migrációkat (`Database.Migrate()`),
    különben futásidőben "no such column" hibát kaphatunk.
-6. Az alkalmazás indításakor a `DataSeeder` automatikusan végrehajtja a migrációkat
-   és szükség esetén mintaadatokat tölt be, így a kézi frissítés ritkán szükséges.
+6. Indításkor a `DbInitializer` futtatja a migrációkat, majd a `DataSeeder` – ha kell – mintaadatokat tölt be, így a kézi frissítés ritkán szükséges.
 
 ---

--- a/docs/ERROR_HANDLING.md
+++ b/docs/ERROR_HANDLING.md
@@ -29,7 +29,7 @@ Ez a dokumentum összefoglalja a hibakezelési stratégiát. Cél, hogy az alkal
 
 1. **Adatbázis fájl hiánya** – Ha a `wrecept.db` nem található indításkor, a Storage réteg új üres adatbázist hoz létre, majd figyelmeztető üzenetet jelenítünk meg.
 2. **Üres adatbázis** – Ha egyetlen táblában sincs adat, minta rekordokat szúrunk be és figyelmeztetjük a felhasználót.
-3. **Sémahibák indításkor** – A `DataSeeder` először megkísérli lefuttatni a migrációkat. Ha ez sikertelen, `EnsureCreated()` hívással létrehozza az alap sémát, majd ismét futtatja a migrációkat.
+3. **Sémahibák indításkor** – A `DbInitializer` gondoskodik a migrációk lefuttatásáról. Sikertelenség esetén `EnsureCreated()` hívással létrehozza az alap sémát, majd ismét migrál. A `DataSeeder` csak ezután próbál adatot lekérni vagy beszúrni.
 4. **Sérült import fájl** – Hibás formátumú vagy hiányzó adatfájl betöltésekor megszakítjuk a folyamatot, naplózzuk a fájl nevét és a kiváltó hibát, és lehetőséget adunk új fájl kiválasztására.
 5. **Hálózati kimaradás** – Külső frissítések letöltése közben kapcsolatvesztés esetén újrapróbálkozunk, majd offline módra váltunk, miközben a felhasználót tájékoztatjuk.
 6. **Sikertelen adatbázis írás** – Ha a fájl zárolt vagy elfogy a tárhely, hibaüzenetet jelenítünk meg, a műveletet naplózzuk, majd biztonsági mentés után újrapróbáljuk.

--- a/docs/progress/2025-06-30_16-06-20_storage_agent.md
+++ b/docs/progress/2025-06-30_16-06-20_storage_agent.md
@@ -1,0 +1,4 @@
+- DbInitializer osztály bevezetve a migrációk egységes futtatására.
+- DataSeeder egyszerűsítve, már az initializerre támaszkodik.
+- ServiceCollectionExtensions is az új initializerre hivatkozik.
+- Dokumentáció frissítve ARCHITECTURE, ERROR_HANDLING és BUILD_RUNTIME_NOTES fájlokban.


### PR DESCRIPTION
## Summary
- create `DbInitializer` for guaranteed migrations
- simplify `DataSeeder` using the initializer
- hook the initializer in `AddStorage`
- document the new process
- log progress

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862b53568688322870c08feda0f6616