### PR TITLE
Improve sample data detection

### DIFF
--- a/Wrecept.Storage/Data/DataSeeder.cs
+++ b/Wrecept.Storage/Data/DataSeeder.cs
@@ -1,12 +1,20 @@
 using Microsoft.EntityFrameworkCore;
 using Wrecept.Core.Models;
+using System.IO;
 
 namespace Wrecept.Storage.Data;
 
 public static class DataSeeder
 {
-    public static async Task<bool> SeedAsync(AppDbContext db, CancellationToken ct = default)
+    private const string SampleSupplier = "Teszt Kft.";
+    private const string SampleProduct = "Teszt termék";
+    private const string SampleGroup = "Általános";
+    private const string SampleTax = "ÁFA 27%";
+    private const string SamplePayment = "Készpénz";
+
+    public static async Task<SeedStatus> SeedAsync(AppDbContext db, string dbPath, CancellationToken ct = default)
     {
+        _ = File.Exists(dbPath);
         await DbInitializer.EnsureCreatedAndMigratedAsync(db, ct);
 
         bool hasData;
@@ -19,31 +27,62 @@ public static class DataSeeder
             await DbInitializer.EnsureCreatedAndMigratedAsync(db, ct);
             hasData = await db.Products.AnyAsync(ct) || await db.Suppliers.AnyAsync(ct);
         }
-        if (hasData) return false;
 
+        if (!hasData)
+        {
+            await InsertSampleDataAsync(db, ct);
+            return SeedStatus.Seeded;
+        }
+
+        var onlySamples = await HasOnlySampleDataAsync(db, ct);
+        return onlySamples ? SeedStatus.OnlySampleData : SeedStatus.None;
+    }
+
+    private static async Task InsertSampleDataAsync(AppDbContext db, CancellationToken ct)
+    {
         var now = DateTime.UtcNow;
         db.PaymentMethods.Add(new PaymentMethod
         {
             Id = Guid.NewGuid(),
-            Name = "Készpénz",
+            Name = SamplePayment,
             DueInDays = 0,
             IsArchived = false,
             CreatedAt = now,
             UpdatedAt = now
         });
-        db.ProductGroups.Add(new ProductGroup { Id = Guid.NewGuid(), Name = "Általános", CreatedAt = now, UpdatedAt = now });
+        db.ProductGroups.Add(new ProductGroup { Id = Guid.NewGuid(), Name = SampleGroup, CreatedAt = now, UpdatedAt = now });
         db.TaxRates.Add(new TaxRate
         {
             Id = Guid.NewGuid(),
-            Name = "ÁFA 27%",
+            Name = SampleTax,
             Percentage = 27m,
             EffectiveFrom = new DateTime(2020, 1, 1),
             CreatedAt = now,
             UpdatedAt = now
         });
-        db.Suppliers.Add(new Supplier { Name = "Teszt Kft.", TaxId = "12345678-1-42", CreatedAt = now, UpdatedAt = now });
-        db.Products.Add(new Product { Name = "Teszt termék", Net = 1000m, Gross = 1270m, CreatedAt = now, UpdatedAt = now });
+        db.Suppliers.Add(new Supplier { Name = SampleSupplier, TaxId = "12345678-1-42", CreatedAt = now, UpdatedAt = now });
+        db.Products.Add(new Product { Name = SampleProduct, Net = 1000m, Gross = 1270m, CreatedAt = now, UpdatedAt = now });
         await db.SaveChangesAsync(ct);
-        return true;
+    }
+
+    private static async Task<bool> HasOnlySampleDataAsync(AppDbContext db, CancellationToken ct)
+    {
+        var supplierCount = await db.Suppliers.CountAsync(ct);
+        var productCount = await db.Products.CountAsync(ct);
+        var groupCount = await db.ProductGroups.CountAsync(ct);
+        var taxCount = await db.TaxRates.CountAsync(ct);
+        var paymentCount = await db.PaymentMethods.CountAsync(ct);
+
+        if (supplierCount != 1 || productCount != 1 || groupCount != 1 || taxCount != 1 || paymentCount != 1)
+            return false;
+
+        var sampleMatch =
+            await db.Suppliers.AnyAsync(s => s.Name == SampleSupplier, ct) &&
+            await db.Products.AnyAsync(p => p.Name == SampleProduct, ct) &&
+            await db.ProductGroups.AnyAsync(g => g.Name == SampleGroup, ct) &&
+            await db.TaxRates.AnyAsync(t => t.Name == SampleTax, ct) &&
+            await db.PaymentMethods.AnyAsync(m => m.Name == SamplePayment, ct);
+
+        return sampleMatch;
     }
 }

--- a/Wrecept.Storage/Data/SeedStatus.cs
+++ b/Wrecept.Storage/Data/SeedStatus.cs
@@ -1,0 +1,8 @@
+namespace Wrecept.Storage.Data;
+
+public enum SeedStatus
+{
+    None,
+    Seeded,
+    OnlySampleData
+}

--- a/Wrecept.Wpf/App.xaml.cs
+++ b/Wrecept.Wpf/App.xaml.cs
@@ -62,11 +62,10 @@ public partial class App : Application
         base.OnStartup(e);
 
         var ctx = Services.GetRequiredService<Wrecept.Storage.Data.AppDbContext>();
-        var dbMissing = !File.Exists(DbPath);
-        var seeded = await Wrecept.Storage.Data.DataSeeder.SeedAsync(ctx);
-        if (seeded || dbMissing)
+        var status = await Wrecept.Storage.Data.DataSeeder.SeedAsync(ctx, DbPath);
+        if (status != Wrecept.Storage.Data.SeedStatus.None)
             MessageBox.Show(
-                "A(z) app.db hiányzott vagy üres volt. Mintaadatok betöltve.",
+                "A(z) app.db hiányzott vagy csak mintaadatokat tartalmazott. Mintaadatok betöltve.",
                 "Első indítás",
                 MessageBoxButton.OK,
                 MessageBoxImage.Information);

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -48,5 +48,6 @@ Minden domain modell tartalmaz `CreatedAt` és `UpdatedAt` mezőket. Ezeket a se
 
 Az alkalmazás indításakor a `DbInitializer` futtatja a szükséges migrációkat.
 Ezt követően a `DataSeeder` – ha az adatbázis üres vagy hiányzik – egy minimális mintaadatkészletet tölt be.
+Amennyiben csak ez a mintaadatkészlet érhető el, a UI figyelmezteti a felhasználót.
 
 ---

--- a/docs/BUILD_RUNTIME_NOTES.md
+++ b/docs/BUILD_RUNTIME_NOTES.md
@@ -26,6 +26,6 @@ Ez a jegyzet a fejlesztés során tapasztalt fordítási és futásidejű probl�
 4. Teszteléskor győződjünk meg róla, hogy a szükséges SDK-k és NuGet csomagok telepítve vannak.
 5. Sémafrissítés után futtassuk le az EF Core migrációkat (`Database.Migrate()`),
    különben futásidőben "no such column" hibát kaphatunk.
-6. Indításkor a `DbInitializer` futtatja a migrációkat, majd a `DataSeeder` – ha kell – mintaadatokat tölt be, így a kézi frissítés ritkán szükséges.
+6. Indításkor a `DbInitializer` futtatja a migrációkat, majd a `DataSeeder` – ha kell – mintaadatokat tölt be. Ha csak ezek az adatok vannak, a felület figyelmeztet.
 
 ---

--- a/docs/progress/2025-06-30_16-33-56_storage_agent.md
+++ b/docs/progress/2025-06-30_16-33-56_storage_agent.md
@@ -1,0 +1,3 @@
+- SeedStatus enum bevezetve, a DataSeeder már jelzi, ha csak mintaadatok vannak.
+- App indításkor egységes figyelmeztetés jelenik meg hiányzó vagy csak mintával teli adatbázis esetén.
+- ARCHITECTURE és BUILD_RUNTIME_NOTES dokumentum frissítve az új logikára.


### PR DESCRIPTION
## Summary
- add `SeedStatus` enum and update `DataSeeder` to detect when only the seed data exists
- show a message on startup if the database only contains seed data
- document the new behaviour
- log progress

## Testing
- `dotnet build Wrecept.sln -clp:ErrorsOnly` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862b76a00088322a071b879c5428224