### PR TITLE
Fix seeder failure when Products table missing

### DIFF
--- a/docs/progress/2025-06-30_18-00-37_storage_agent.md
+++ b/docs/progress/2025-06-30_18-00-37_storage_agent.md
@@ -1,0 +1,2 @@
+- DataSeeder immár új AppDbContext példányt hoz létre, ha a táblák ellenőrzése elsőre SQLite hibát jelez.
+- Ez megoldja az indításkor jelentkező "no such table: Products" problémát.


### PR DESCRIPTION
## Summary
- recreate AppDbContext after migration if initial data check fails
- log runtime error fix in progress log

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862cfd6917483228695b82e97bba24b