### PR TITLE
Improve storage initialization

### DIFF
--- a/Wrecept.Storage/Data/DbInitializer.cs
+++ b/Wrecept.Storage/Data/DbInitializer.cs
@@ -13,12 +13,28 @@ public static class DbInitializer
             var pending = await db.Database.GetPendingMigrationsAsync(ct);
             if (pending.Any())
                 await db.Database.MigrateAsync(ct);
+            else
+                await db.Database.EnsureCreatedAsync(ct);
         }
         catch (SqliteException ex)
         {
             await logService.LogError("Migration failed", ex);
             await db.Database.EnsureCreatedAsync(ct);
             await db.Database.MigrateAsync(ct);
+        }
+        catch (Exception ex)
+        {
+            await logService.LogError("Initialization failed", ex);
+            await db.Database.EnsureCreatedAsync(ct);
+            try
+            {
+                await db.Database.MigrateAsync(ct);
+            }
+            catch (Exception inner)
+            {
+                await logService.LogError("Second migration attempt failed", inner);
+                throw;
+            }
         }
     }
 }

--- a/Wrecept.Storage/ServiceCollectionExtensions.cs
+++ b/Wrecept.Storage/ServiceCollectionExtensions.cs
@@ -15,6 +15,7 @@ public static class ServiceCollectionExtensions
         ArgumentException.ThrowIfNullOrEmpty(dbPath);
 
         services.AddDbContext<AppDbContext>(o => o.UseSqlite($"Data Source={dbPath}"));
+        services.AddDbContextFactory<AppDbContext>(o => o.UseSqlite($"Data Source={dbPath}"));
         services.AddScoped<IInvoiceRepository, InvoiceRepository>();
         services.AddScoped<IProductRepository, ProductRepository>();
         services.AddScoped<ISupplierRepository, SupplierRepository>();
@@ -24,9 +25,9 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<ILogService, LogService>();
 
         using var provider = services.BuildServiceProvider();
-        using var scope = provider.CreateScope();
-        var ctx = scope.ServiceProvider.GetRequiredService<AppDbContext>();
-        var logger = scope.ServiceProvider.GetRequiredService<ILogService>();
+        var factory = provider.GetRequiredService<IDbContextFactory<AppDbContext>>();
+        var logger = provider.GetRequiredService<ILogService>();
+        using var ctx = factory.CreateDbContext();
         DbInitializer.EnsureCreatedAndMigratedAsync(ctx, logger).GetAwaiter().GetResult();
 
         return services;

--- a/Wrecept.Wpf/App.xaml.cs
+++ b/Wrecept.Wpf/App.xaml.cs
@@ -61,9 +61,8 @@ public partial class App : Application
     {
         base.OnStartup(e);
 
-        var ctx = Services.GetRequiredService<Wrecept.Storage.Data.AppDbContext>();
         var logger = Services.GetRequiredService<Wrecept.Core.Services.ILogService>();
-        var status = await Wrecept.Storage.Data.DataSeeder.SeedAsync(ctx, DbPath, logger);
+        var status = await Wrecept.Storage.Data.DataSeeder.SeedAsync(DbPath, logger);
         if (status == Wrecept.Storage.Data.SeedStatus.Failed)
         {
             MessageBox.Show(

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -49,9 +49,10 @@ Minden hibát az `ILogService` rögzít, amelyet a Storage réteg `LogService` i
 Minden domain modell tartalmaz `CreatedAt` és `UpdatedAt` mezőket. Ezeket a service réteg inicializálja, így naplózható az adat módosításának ideje.
 
 Az alkalmazás indításakor a `DbInitializer` futtatja a szükséges migrációkat.
-Az `AddStorage` kiterjesztés ehhez scopolt `AppDbContext` példányt használ,
-így a context élettartama pontosan egy scope-ra korlátozódik.
-Ezt követően a `DataSeeder` – ha az adatbázis üres vagy hiányzik – egy minimális mintaadatkészletet tölt be.
+Az `AddStorage` kiterjesztés ehhez már `IDbContextFactory`-t vesz igénybe,
+így a migráció egy külön kontextuson történik és azonnal eldobásra kerül.
+Ezt követően a `DataSeeder` – ha az adatbázis üres vagy hiányzik – saját
+kontextust hoz létre és egy minimális mintaadatkészletet tölt be.
 Amennyiben csak ez a mintaadatkészlet érhető el, a UI figyelmezteti a felhasználót.
 Ha a második adatlekérdezés is hibát jelez, a részleteket az `ILogService` naplózza a `logs` mappába, és a program hibát jelez.
 

--- a/docs/BUILD_RUNTIME_NOTES.md
+++ b/docs/BUILD_RUNTIME_NOTES.md
@@ -26,8 +26,8 @@ Ez a jegyzet a fejlesztés során tapasztalt fordítási és futásidejű probl�
 4. Teszteléskor győződjünk meg róla, hogy a szükséges SDK-k és NuGet csomagok telepítve vannak.
 5. Sémafrissítés után futtassuk le az EF Core migrációkat (`Database.Migrate()`),
    különben futásidőben "no such column" hibát kaphatunk.
-6. Indításkor a `DbInitializer` futtatja a migrációkat, majd a `DataSeeder` – ha kell – mintaadatokat tölt be. Ha csak ezek az adatok vannak, a felület figyelmeztet.
-7. Az `AddStorage` kiterjesztés a migrációkhoz scopolt szolgáltatás-scope-ban hozza létre az `AppDbContext`-et.
+6. Indításkor a `DbInitializer` futtatja a migrációkat, majd a `DataSeeder` – ha kell – saját kontextusban mintaadatokat tölt be. Ha csak ezek az adatok vannak, a felület figyelmeztet.
+7. Az `AddStorage` kiterjesztés migrációhoz `IDbContextFactory`-t használ, így a munkakontextus az inicializálás végén eldobásra kerül.
 8. Ha a második adatlekérdezés is `SqliteException`-t dob, a `DataSeeder` a `logs/startup.log` fájlba ír és `Failed` állapotot jelez.
 
 ---

--- a/docs/ERROR_HANDLING.md
+++ b/docs/ERROR_HANDLING.md
@@ -30,10 +30,11 @@ Ez a dokumentum összefoglalja a hibakezelési stratégiát. Cél, hogy az alkal
 
 1. **Adatbázis fájl hiánya** – Ha a `wrecept.db` nem található indításkor, a Storage réteg új üres adatbázist hoz létre, majd figyelmeztető üzenetet jelenítünk meg.
 2. **Üres adatbázis** – Ha egyetlen táblában sincs adat, minta rekordokat szúrunk be és figyelmeztetjük a felhasználót.
-3. **Sémahibák indításkor** – A `DbInitializer` gondoskodik a migrációk lefuttatásáról. Sikertelenség esetén `EnsureCreated()` hívással létrehozza az alap sémát, majd ismét migrál. A `DataSeeder` csak ezután próbál adatot lekérni vagy beszúrni.
+3. **Sémahibák indításkor** – A `DbInitializer` gondoskodik a migrációk lefuttatásáról. Sikertelenség esetén `EnsureCreated()` hívással létrehozza az alap sémát, majd ismét migrál. A `DataSeeder` külön kontextust használ, így a DI-ből kapott példány nem marad használatban.
 4. **Sérült import fájl** – Hibás formátumú vagy hiányzó adatfájl betöltésekor megszakítjuk a folyamatot, naplózzuk a fájl nevét és a kiváltó hibát, és lehetőséget adunk új fájl kiválasztására.
 5. **Hálózati kimaradás** – Külső frissítések letöltése közben kapcsolatvesztés esetén újrapróbálkozunk, majd offline módra váltunk, miközben a felhasználót tájékoztatjuk.
 6. **Sikertelen adatbázis írás** – Ha a fájl zárolt vagy elfogy a tárhely, hibaüzenetet jelenítünk meg, a műveletet naplózzuk, majd biztonsági mentés után újrapróbáljuk.
 7. **Indítási hiba** – Ha a `DataSeeder` másodszori próbálkozásra is `SqliteException`-t kap, a részleteket az `ILogService` naplózza a `logs` mappába, majd hibaüzenetet jelenítünk meg.
+8. **Egyéb inicializációs hiba** – A `DbInitializer` általános kivételt is naplóz. Ha a második migrációs kísérlet sikertelen, a program leáll.
 
 ---

--- a/docs/progress/2025-06-30_18-33-17_storage_agent.md
+++ b/docs/progress/2025-06-30_18-33-17_storage_agent.md
@@ -1,0 +1,3 @@
+- DbInitializer most általános kivételeket is naplóz és második migrációs próbát tesz.
+- DataSeeder saját AppDbContext példányt használ, így a DI-ből kapott nem marad használatban.
+- AddStorage IDbContextFactory segítségével indítja a migrációt.


### PR DESCRIPTION
## Summary
- extend DbInitializer with broader exception handling
- discard DI context in DataSeeder
- use IDbContextFactory for database setup in AddStorage
- adapt App startup to new seeder signature
- document the new initialization flow

## Testing
- `dotnet build Wrecept.sln -clp:ErrorsOnly` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862d6dc597883228e0b1cfc94412b54