### PR TITLE
Allow negative quantity

### DIFF
--- a/Wrecept.Core.Tests/Services/InvoiceServiceTests.cs
+++ b/Wrecept.Core.Tests/Services/InvoiceServiceTests.cs
@@ -1,0 +1,41 @@
+using Wrecept.Core.Models;
+using Wrecept.Core.Repositories;
+using Wrecept.Core.Services;
+using Xunit;
+
+namespace Wrecept.Core.Tests.Services;
+
+public class InvoiceServiceTests
+{
+    private sealed class FakeInvoiceRepository : IInvoiceRepository
+    {
+        public Task<int> AddAsync(Invoice invoice, CancellationToken ct = default) => Task.FromResult(1);
+        public Task<Invoice?> GetAsync(int id, CancellationToken ct = default) => Task.FromResult<Invoice?>(null);
+    }
+
+    [Fact]
+    public async Task CreateAsync_ReturnsFalse_WhenItemQuantityIsZero()
+    {
+        var repo = new FakeInvoiceRepository();
+        var service = new InvoiceService(repo);
+        var invoice = new Invoice { Number = "INV1", SupplierId = 1 };
+        invoice.Items.Add(new InvoiceItem { ProductId = 1, Quantity = 0, UnitPrice = 10 });
+
+        var result = await service.CreateAsync(invoice);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task CreateAsync_Allows_Negative_Quantity()
+    {
+        var repo = new FakeInvoiceRepository();
+        var service = new InvoiceService(repo);
+        var invoice = new Invoice { Number = "INV1", SupplierId = 1 };
+        invoice.Items.Add(new InvoiceItem { ProductId = 1, Quantity = -5, UnitPrice = 10 });
+
+        var result = await service.CreateAsync(invoice);
+
+        Assert.True(result);
+    }
+}

--- a/Wrecept.Core.Tests/Wrecept.Core.Tests.csproj
+++ b/Wrecept.Core.Tests/Wrecept.Core.Tests.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Wrecept.Core\Wrecept.Core.csproj" />
+  </ItemGroup>
+</Project>

--- a/Wrecept.Core/Services/InvoiceService.cs
+++ b/Wrecept.Core/Services/InvoiceService.cs
@@ -18,7 +18,7 @@ public class InvoiceService : IInvoiceService
         if (string.IsNullOrWhiteSpace(invoice.Number)) return false;
         if (invoice.SupplierId <= 0 && invoice.Supplier is null) return false;
         if (invoice.Items.Count == 0) return false;
-        if (invoice.Items.Any(i => i.Quantity <= 0 || i.UnitPrice < 0)) return false;
+        if (invoice.Items.Any(i => i.Quantity == 0 || i.UnitPrice < 0)) return false;
         if (invoice.Items.Any(i => i.ProductId <= 0)) return false;
 
         invoice.CreatedAt = DateTime.UtcNow;

--- a/docs/progress/2025-06-30_20-20-38_core_agent.md
+++ b/docs/progress/2025-06-30_20-20-38_core_agent.md
@@ -1,0 +1,3 @@
+- InvoiceService most már csak a 0 mennyiséget utasítja el.
+- Létrehoztam a Wrecept.Core.Tests projektet xUnit alapon.
+- Egységtesztek frissítve negatív Quantity elfogadására.


### PR DESCRIPTION
## Summary
- relax quantity validation in InvoiceService
- add xUnit tests for InvoiceService
- log change

## Testing
- `dotnet test Wrecept.Core.Tests/Wrecept.Core.Tests.csproj` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862f0935ebc8322b36390a31adad05f