### PR TITLE
Implement PaymentMethod selection in invoice editor

### DIFF
--- a/Wrecept.Wpf/ViewModels/InvoiceEditorViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/InvoiceEditorViewModel.cs
@@ -1,6 +1,9 @@
 using System.Collections.ObjectModel;
 using CommunityToolkit.Mvvm.ComponentModel;
 using System.Linq;
+using System.Threading.Tasks;
+using Wrecept.Core.Models;
+using Wrecept.Core.Services;
 
 namespace Wrecept.Wpf.ViewModels;
 
@@ -20,15 +23,34 @@ public partial class InvoiceEditorViewModel : ObservableObject
 {
     public ObservableCollection<InvoiceItemRowViewModel> Items { get; }
 
+    public ObservableCollection<PaymentMethod> PaymentMethods { get; } = new();
+
     [ObservableProperty]
     private string supplier = string.Empty;
 
     [ObservableProperty]
     private string number = string.Empty;
 
-    public InvoiceEditorViewModel()
+    [ObservableProperty]
+    private Guid paymentMethodId;
+
+    [ObservableProperty]
+    private bool isGross;
+
+    private readonly IPaymentMethodService _paymentMethods;
+
+    public InvoiceEditorViewModel(IPaymentMethodService paymentMethods)
     {
+        _paymentMethods = paymentMethods;
         Items = new ObservableCollection<InvoiceItemRowViewModel>(
             Enumerable.Range(1, 3).Select(_ => new InvoiceItemRowViewModel()));
+    }
+
+    public async Task LoadAsync()
+    {
+        var methods = await _paymentMethods.GetActiveAsync();
+        PaymentMethods.Clear();
+        foreach (var m in methods)
+            PaymentMethods.Add(m);
     }
 }

--- a/Wrecept.Wpf/Views/InvoiceEditorView.xaml
+++ b/Wrecept.Wpf/Views/InvoiceEditorView.xaml
@@ -13,6 +13,15 @@
             <TextBlock Text="Szám" Width="70" />
             <TextBox Width="120" Text="{Binding Number}" />
         </StackPanel>
+        <StackPanel Orientation="Horizontal" Margin="0,0,0,4">
+            <TextBlock Text="Fiz. mód" Width="70" />
+            <ComboBox Width="200"
+                      ItemsSource="{Binding PaymentMethods}"
+                      DisplayMemberPath="Name"
+                      SelectedValuePath="Id"
+                      SelectedValue="{Binding PaymentMethodId}" />
+        </StackPanel>
+        <CheckBox Content="Bruttó ár" IsChecked="{Binding IsGross}" Margin="0,0,0,4" />
 
         <DataGrid ItemsSource="{Binding Items}" AutoGenerateColumns="False" Height="120">
             <DataGrid.Columns>

--- a/Wrecept.Wpf/Views/InvoiceEditorView.xaml.cs
+++ b/Wrecept.Wpf/Views/InvoiceEditorView.xaml.cs
@@ -15,6 +15,7 @@ public partial class InvoiceEditorView : UserControl
     {
         InitializeComponent();
         DataContext = viewModel;
+        Loaded += async (_, _) => await viewModel.LoadAsync();
     }
 
     private void OnKeyDown(object sender, KeyEventArgs e)

--- a/docs/progress/2025-06-30_20-45-17_code_agent.md
+++ b/docs/progress/2025-06-30_20-45-17_code_agent.md
@@ -1,0 +1,3 @@
+- InvoiceEditorViewModel bővítve PaymentMethodId és IsGross mezőkkel.
+- InvoiceEditorView.xaml kapott bruttó kapcsolót és fizetési mód kombót.
+- Aktív fizetési módokat tölt be a szerkesztő; archivált elemek nem jelennek meg.


### PR DESCRIPTION
## Summary
- expand `InvoiceEditorViewModel` to include `PaymentMethodId` and `IsGross`
- load active payment methods via `IPaymentMethodService`
- update `InvoiceEditorView` with gross price toggle and payment method ComboBox
- auto-load data on `InvoiceEditorView` load event
- log progress

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862f687cd64832290813baca31bbb15