### PR TITLE
Fix build-time errors in viewmodels and services

### DIFF
--- a/Wrecept.Core/Repositories/IProductRepository.cs
+++ b/Wrecept.Core/Repositories/IProductRepository.cs
@@ -5,6 +5,7 @@ namespace Wrecept.Core.Repositories;
 public interface IProductRepository
 {
     Task<List<Product>> GetAllAsync(CancellationToken ct = default);
+    Task<List<Product>> GetActiveAsync(CancellationToken ct = default);
     Task<int> AddAsync(Product product, CancellationToken ct = default);
     Task UpdateAsync(Product product, CancellationToken ct = default);
 }

--- a/Wrecept.Core/Repositories/ISupplierRepository.cs
+++ b/Wrecept.Core/Repositories/ISupplierRepository.cs
@@ -5,4 +5,5 @@ namespace Wrecept.Core.Repositories;
 public interface ISupplierRepository
 {
     Task<List<Supplier>> GetAllAsync(CancellationToken ct = default);
+    Task<List<Supplier>> GetActiveAsync(CancellationToken ct = default);
 }

--- a/Wrecept.Core/Repositories/ITaxRateRepository.cs
+++ b/Wrecept.Core/Repositories/ITaxRateRepository.cs
@@ -5,5 +5,5 @@ namespace Wrecept.Core.Repositories;
 public interface ITaxRateRepository
 {
     Task<List<TaxRate>> GetAllAsync(CancellationToken ct = default);
-    Task<TaxRate?> GetActiveAsync(DateTime asOf, CancellationToken ct = default);
+    Task<List<TaxRate>> GetActiveAsync(DateTime asOf, CancellationToken ct = default);
 }

--- a/Wrecept.Core/Services/IProductService.cs
+++ b/Wrecept.Core/Services/IProductService.cs
@@ -5,6 +5,7 @@ namespace Wrecept.Core.Services;
 public interface IProductService
 {
     Task<List<Product>> GetAllAsync(CancellationToken ct = default);
+    Task<List<Product>> GetActiveAsync(CancellationToken ct = default);
     Task<int> AddAsync(Product product, CancellationToken ct = default);
     Task UpdateAsync(Product product, CancellationToken ct = default);
 }

--- a/Wrecept.Core/Services/ISupplierService.cs
+++ b/Wrecept.Core/Services/ISupplierService.cs
@@ -5,4 +5,5 @@ namespace Wrecept.Core.Services;
 public interface ISupplierService
 {
     Task<List<Supplier>> GetAllAsync(CancellationToken ct = default);
+    Task<List<Supplier>> GetActiveAsync(CancellationToken ct = default);
 }

--- a/Wrecept.Core/Services/ITaxRateService.cs
+++ b/Wrecept.Core/Services/ITaxRateService.cs
@@ -5,5 +5,5 @@ namespace Wrecept.Core.Services;
 public interface ITaxRateService
 {
     Task<List<TaxRate>> GetAllAsync(CancellationToken ct = default);
-    Task<TaxRate?> GetActiveAsync(DateTime asOf, CancellationToken ct = default);
+    Task<List<TaxRate>> GetActiveAsync(DateTime asOf, CancellationToken ct = default);
 }

--- a/Wrecept.Core/Services/ProductService.cs
+++ b/Wrecept.Core/Services/ProductService.cs
@@ -15,6 +15,9 @@ public class ProductService : IProductService
     public Task<List<Product>> GetAllAsync(CancellationToken ct = default)
         => _products.GetAllAsync(ct);
 
+    public Task<List<Product>> GetActiveAsync(CancellationToken ct = default)
+        => _products.GetActiveAsync(ct);
+
     public async Task<int> AddAsync(Product product, CancellationToken ct = default)
     {
         ArgumentNullException.ThrowIfNull(product);

--- a/Wrecept.Core/Services/SupplierService.cs
+++ b/Wrecept.Core/Services/SupplierService.cs
@@ -14,4 +14,7 @@ public class SupplierService : ISupplierService
 
     public Task<List<Supplier>> GetAllAsync(CancellationToken ct = default)
         => _suppliers.GetAllAsync(ct);
+
+    public Task<List<Supplier>> GetActiveAsync(CancellationToken ct = default)
+        => _suppliers.GetActiveAsync(ct);
 }

--- a/Wrecept.Core/Services/TaxRateService.cs
+++ b/Wrecept.Core/Services/TaxRateService.cs
@@ -15,6 +15,6 @@ public class TaxRateService : ITaxRateService
     public Task<List<TaxRate>> GetAllAsync(CancellationToken ct = default)
         => _taxRates.GetAllAsync(ct);
 
-    public Task<TaxRate?> GetActiveAsync(DateTime asOf, CancellationToken ct = default)
+    public Task<List<TaxRate>> GetActiveAsync(DateTime asOf, CancellationToken ct = default)
         => _taxRates.GetActiveAsync(asOf, ct);
 }

--- a/Wrecept.Storage/Repositories/ProductRepository.cs
+++ b/Wrecept.Storage/Repositories/ProductRepository.cs
@@ -17,6 +17,9 @@ public class ProductRepository : IProductRepository
     public Task<List<Product>> GetAllAsync(CancellationToken ct = default)
         => _db.Products.ToListAsync(ct);
 
+    public Task<List<Product>> GetActiveAsync(CancellationToken ct = default)
+        => _db.Products.Where(p => !p.IsArchived).ToListAsync(ct);
+
     public async Task<int> AddAsync(Product product, CancellationToken ct = default)
     {
         _db.Products.Add(product);

--- a/Wrecept.Storage/Repositories/SupplierRepository.cs
+++ b/Wrecept.Storage/Repositories/SupplierRepository.cs
@@ -16,4 +16,7 @@ public class SupplierRepository : ISupplierRepository
 
     public Task<List<Supplier>> GetAllAsync(CancellationToken ct = default)
         => _db.Suppliers.ToListAsync(ct);
+
+    public Task<List<Supplier>> GetActiveAsync(CancellationToken ct = default)
+        => _db.Suppliers.Where(s => !s.IsArchived).ToListAsync(ct);
 }

--- a/Wrecept.Storage/Repositories/TaxRateRepository.cs
+++ b/Wrecept.Storage/Repositories/TaxRateRepository.cs
@@ -17,9 +17,9 @@ public class TaxRateRepository : ITaxRateRepository
     public Task<List<TaxRate>> GetAllAsync(CancellationToken ct = default)
         => _db.Set<TaxRate>().ToListAsync(ct);
 
-    public Task<TaxRate?> GetActiveAsync(DateTime asOf, CancellationToken ct = default)
+    public Task<List<TaxRate>> GetActiveAsync(DateTime asOf, CancellationToken ct = default)
         => _db.Set<TaxRate>()
             .Where(t => t.EffectiveFrom <= asOf && (!t.EffectiveTo.HasValue || t.EffectiveTo >= asOf) && !t.IsArchived)
             .OrderByDescending(t => t.EffectiveFrom)
-            .FirstOrDefaultAsync(ct);
+            .ToListAsync(ct);
 }

--- a/docs/progress/2025-06-30_21-33-33_code_agent.md
+++ b/docs/progress/2025-06-30_21-33-33_code_agent.md
@@ -1,0 +1,4 @@
+# Build fixes
+- Added GetActiveAsync methods to product and supplier layers.
+- Adjusted tax rate retrieval to return list for active records.
+- Updated repositories and services accordingly.


### PR DESCRIPTION
## Summary
- add GetActiveAsync to product and supplier layers
- make tax rate active query return a list
- adjust repositories and services for active listing
- log progress

## Testing
- `dotnet build Wrecept.sln -c Release` *(fails: NETSDK1100)*
- `dotnet test Wrecept.sln -c Release --no-build`

------
https://chatgpt.com/codex/tasks/task_e_6863017f20148322a3bce3cf8655107e