### PR TITLE
Fix invoice menu navigation

### DIFF
--- a/Wrecept.Wpf/ViewModels/StageViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/StageViewModel.cs
@@ -104,6 +104,9 @@ public partial class StageViewModel : ObservableObject
                 break;
             case StageMenuAction.InboundDeliveryNotes:
             case StageMenuAction.UpdateInboundInvoices:
+                CurrentViewModel = _invoiceEditor;
+                _statusBar.Message = "Számla szerkesztő";
+                break;
             case StageMenuAction.ListInvoices:
             case StageMenuAction.InventoryCard:
             case StageMenuAction.CheckFiles:

--- a/Wrecept.Wpf/Views/PlaceholderView.xaml.cs
+++ b/Wrecept.Wpf/Views/PlaceholderView.xaml.cs
@@ -1,10 +1,15 @@
 using System.Windows.Controls;
+using Microsoft.Extensions.DependencyInjection;
 using Wrecept.Wpf.ViewModels;
 
 namespace Wrecept.Wpf.Views;
 
 public partial class PlaceholderView : UserControl
 {
+    public PlaceholderView() : this(App.Provider.GetRequiredService<PlaceholderViewModel>())
+    {
+    }
+
     public PlaceholderView(PlaceholderViewModel viewModel)
     {
         InitializeComponent();

--- a/docs/progress/2025-06-30_21-45-43_code_agent.md
+++ b/docs/progress/2025-06-30_21-45-43_code_agent.md
@@ -1,0 +1,3 @@
+# Placeholder bugfix
+- Default ctor added for `PlaceholderView` via DI.
+- `InboundDeliveryNotes` now opens `InvoiceEditor`.


### PR DESCRIPTION
## Summary
- add default constructor for `PlaceholderView`
- navigate to `InvoiceEditor` when selecting inbound delivery notes
- log changes in progress report

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686304f89e0483229544fd74e3ee2210