### PR TITLE
Fix missing using directives for async commands

### DIFF
--- a/Wrecept.Wpf/ViewModels/ProductCreatorViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/ProductCreatorViewModel.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Wrecept.Core.Models;

--- a/Wrecept.Wpf/ViewModels/SupplierCreatorViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/SupplierCreatorViewModel.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Wrecept.Core.Models;

--- a/Wrecept.Wpf/ViewModels/TaxRateCreatorViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/TaxRateCreatorViewModel.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Wrecept.Core.Models;

--- a/Wrecept.Wpf/ViewModels/UnitCreatorViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/UnitCreatorViewModel.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Wrecept.Core.Models;

--- a/docs/progress/2025-06-30_22-05-46_code_agent.md
+++ b/docs/progress/2025-06-30_22-05-46_code_agent.md
@@ -1,0 +1,2 @@
+# Fix creator view models
+- Added missing `System.Threading.Tasks` usings in entity creator view models to resolve build errors.


### PR DESCRIPTION
## Summary
- add `System.Threading.Tasks` using across creator view models
- log progress

## Testing
- `dotnet build Wrecept.sln -v minimal` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_686309af5ba483229f4a7ef48c6e3f7e