### PR TITLE
Fix SupplierId property type

### DIFF
--- a/Wrecept.Wpf/ViewModels/InvoiceEditorViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/InvoiceEditorViewModel.cs
@@ -47,7 +47,7 @@ public partial class InvoiceEditorViewModel : ObservableObject
     private string supplier = string.Empty;
 
     [ObservableProperty]
-    private Guid supplierId;
+    private int supplierId;
 
     [ObservableProperty]
     private DateOnly? invoiceDate;

--- a/docs/progress/2025-06-30_22-11-34_code_agent.md
+++ b/docs/progress/2025-06-30_22-11-34_code_agent.md
@@ -1,0 +1,2 @@
+# Fix SupplierId type
+- Changed `SupplierId` from `Guid` to `int` in `InvoiceEditorViewModel` to match model definition.


### PR DESCRIPTION
## Summary
- match `SupplierId` type in `InvoiceEditorViewModel` with the model (`int`)
- log progress for the change

## Testing
- `dotnet restore Wrecept.Core.Tests/Wrecept.Core.Tests.csproj`
- `dotnet test Wrecept.Core.Tests/Wrecept.Core.Tests.csproj --no-build --verbosity normal` *(fails: The argument ... is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_68630ab1ecac83229a56289b78e40090