### PR TITLE
Fix Progress usage and async warning

### DIFF
--- a/Wrecept.Wpf/ViewModels/InvoiceEditorViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/InvoiceEditorViewModel.cs
@@ -121,10 +121,10 @@ public partial class InvoiceEditorViewModel : ObservableObject
         progress?.Report(new ProgressReport { SubtaskPercent = 100, Message = "Betöltés kész." });
     }
 
-    public async Task CheckProductAsync(InvoiceItemRowViewModel row, string name)
+    public Task CheckProductAsync(InvoiceItemRowViewModel row, string name)
     {
         if (string.IsNullOrWhiteSpace(name))
-            return;
+            return Task.CompletedTask;
 
         var exists = Products.FirstOrDefault(p => p.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
         if (exists is null)
@@ -138,5 +138,7 @@ public partial class InvoiceEditorViewModel : ObservableObject
         {
             row.Product = exists.Name;
         }
+
+        return Task.CompletedTask;
     }
 }

--- a/Wrecept.Wpf/Views/InvoiceEditorView.xaml.cs
+++ b/Wrecept.Wpf/Views/InvoiceEditorView.xaml.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Windows.Controls;
 using System.Windows.Input;
 using Microsoft.Extensions.DependencyInjection;

--- a/docs/progress/2025-06-30_22-40-52_code_agent.md
+++ b/docs/progress/2025-06-30_22-40-52_code_agent.md
@@ -1,0 +1,3 @@
+- Fixed missing System namespace for Progress<> usage.
+- Simplified CheckProductAsync to synchronous Task to avoid CS1998 warning.
+- Installed .NET SDK for testing; build failed due to missing WindowsDesktop pack.


### PR DESCRIPTION
## Summary
- import `System` in `InvoiceEditorView` so `Progress<T>` resolves
- remove `async` from `CheckProductAsync` to avoid CS1998
- log progress

## Testing
- `dotnet test --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_686311e429c48322938ff6b0aca3af54