### PR TITLE
Fix DatePicker crash on startup

### DIFF
--- a/Wrecept.Wpf/ViewModels/InvoiceEditorViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/InvoiceEditorViewModel.cs
@@ -51,7 +51,7 @@ public partial class InvoiceEditorViewModel : ObservableObject
     private int supplierId;
 
     [ObservableProperty]
-    private DateOnly? invoiceDate;
+    private DateTime? invoiceDate;
 
     [ObservableProperty]
     private string number = string.Empty;

--- a/docs/progress/2025-06-30_22-53-24_code_agent.md
+++ b/docs/progress/2025-06-30_22-53-24_code_agent.md
@@ -1,0 +1,1 @@
+- Fixed InvoiceEditorViewModel.InvoiceDate type to DateTime? to avoid WPF binding exception.


### PR DESCRIPTION
## Summary
- fix binding issue in InvoiceEditorViewModel by changing InvoiceDate property to `DateTime?`
- log progress update

## Testing
- `dotnet test Wrecept.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686314b2cf4c83228eca4e20914e0912