### PR TITLE
Fix application exit on startup window close

### DIFF
--- a/Wrecept.Wpf/App.xaml.cs
+++ b/Wrecept.Wpf/App.xaml.cs
@@ -71,6 +71,8 @@ public partial class App : Application
     {
         base.OnStartup(e);
 
+        ShutdownMode = ShutdownMode.OnExplicitShutdown;
+
         var orchestrator = Services.GetRequiredService<StartupOrchestrator>();
         var progressVm = Services.GetRequiredService<ProgressViewModel>();
         using var cts = new CancellationTokenSource();
@@ -106,6 +108,8 @@ public partial class App : Application
         }
 
         var window = Services.GetRequiredService<MainWindow>();
+        MainWindow = window;
+        ShutdownMode = ShutdownMode.OnMainWindowClose;
         window.Show();
     }
 }

--- a/docs/progress/2025-06-30_23-55-24_code_agent.md
+++ b/docs/progress/2025-06-30_23-55-24_code_agent.md
@@ -1,0 +1,1 @@
+- Fixed startup shutdown mode so the app doesn't exit after closing StartupWindow.


### PR DESCRIPTION
## Summary
- keep app alive while StartupWindow closes
- log the startup fix

## Testing
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_686323269dd08322b7a34c52dd2b72b0