### PR TITLE
UI Flow: EditLookup and menu focus

### DIFF
--- a/Wrecept.Wpf/ViewModels/InvoiceEditorViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/InvoiceEditorViewModel.cs
@@ -3,6 +3,7 @@ using System.Collections.ObjectModel;
 using CommunityToolkit.Mvvm.ComponentModel;
 using System.Linq;
 using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.Input;
 using Wrecept.Core.Models;
 using Wrecept.Core.Services;
 using Wrecept.Core.Utilities;
@@ -46,6 +47,7 @@ public partial class InvoiceEditorViewModel : ObservableObject
 
     [ObservableProperty]
     private string supplier = string.Empty;
+partial void OnSupplierChanged(string value) => UpdateSupplierId(value);
 
     [ObservableProperty]
     private int supplierId;
@@ -140,5 +142,36 @@ public partial class InvoiceEditorViewModel : ObservableObject
         }
 
         return Task.CompletedTask;
+    }
+private void UpdateSupplierId(string name)
+{
+    var match = Suppliers.FirstOrDefault(s => s.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
+    if (match != null)
+        SupplierId = match.Id;
+}
+    [RelayCommand]
+    private void ShowSupplierCreator(string? name)
+    {
+        InlineCreator = new SupplierCreatorViewModel(this, _suppliers)
+        {
+            Name = name ?? string.Empty
+        };
+    }
+    [RelayCommand]
+    private void ShowProductCreator(InvoiceItemRowViewModel row)
+    {
+        InlineCreator = new ProductCreatorViewModel(this, row, _productsService)
+        {
+            Name = row.Product
+        };
+    }
+
+    [RelayCommand]
+    private void ShowTaxRateCreator(string name)
+    {
+        InlineCreator = new TaxRateCreatorViewModel(this, _taxRates)
+        {
+            Name = name
+        };
     }
 }

--- a/Wrecept.Wpf/Views/Controls/EditLookup.xaml
+++ b/Wrecept.Wpf/Views/Controls/EditLookup.xaml
@@ -1,0 +1,17 @@
+<UserControl x:Class="Wrecept.Wpf.Views.Controls.EditLookup"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d">
+    <ComboBox x:Name="Box"
+              ItemsSource="{Binding ItemsSource, RelativeSource={RelativeSource AncestorType=UserControl}}"
+              SelectedValuePath="{Binding SelectedValuePath, RelativeSource={RelativeSource AncestorType=UserControl}}"
+              DisplayMemberPath="{Binding DisplayMemberPath, RelativeSource={RelativeSource AncestorType=UserControl}}"
+              SelectedValue="{Binding SelectedValue, RelativeSource={RelativeSource AncestorType=UserControl}, Mode=TwoWay}"
+              IsEditable="True"
+              StaysOpenOnEdit="True"
+              IsTextSearchEnabled="False"
+              PreviewKeyDown="Box_PreviewKeyDown"
+              CreateCommandParameter="{Binding CreateCommandParameter, RelativeSource={RelativeSource AncestorType=UserControl}}"
+              IsSynchronizedWithCurrentItem="True"/>
+</UserControl>

--- a/Wrecept.Wpf/Views/Controls/EditLookup.xaml.cs
+++ b/Wrecept.Wpf/Views/Controls/EditLookup.xaml.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Input;
+
+namespace Wrecept.Wpf.Views.Controls;
+
+public partial class EditLookup : UserControl
+{
+    public static readonly DependencyProperty ItemsSourceProperty = DependencyProperty.Register(
+        nameof(ItemsSource), typeof(object), typeof(EditLookup));
+
+    public static readonly DependencyProperty SelectedValueProperty = DependencyProperty.Register(
+        nameof(SelectedValue), typeof(object), typeof(EditLookup), new FrameworkPropertyMetadata(null, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault));
+
+    public static readonly DependencyProperty SelectedValuePathProperty = DependencyProperty.Register(
+        nameof(SelectedValuePath), typeof(string), typeof(EditLookup));
+
+    public static readonly DependencyProperty DisplayMemberPathProperty = DependencyProperty.Register(
+        nameof(DisplayMemberPath), typeof(string), typeof(EditLookup));
+
+    public static readonly DependencyProperty CreateCommandProperty = DependencyProperty.Register(
+        nameof(CreateCommand), typeof(ICommand), typeof(EditLookup));
+
+    public object? ItemsSource
+    public static readonly DependencyProperty CreateCommandParameterProperty = DependencyProperty.Register(
+        nameof(CreateCommandParameter), typeof(object), typeof(EditLookup));
+    {
+        get => GetValue(ItemsSourceProperty);
+        set => SetValue(ItemsSourceProperty, value);
+    }
+
+    public object? SelectedValue
+    {
+        get => GetValue(SelectedValueProperty);
+        set => SetValue(SelectedValueProperty, value);
+    }
+
+    public string? SelectedValuePath
+    {
+        get => (string?)GetValue(SelectedValuePathProperty);
+        set => SetValue(SelectedValuePathProperty, value);
+    }
+
+    public string? DisplayMemberPath
+    {
+        get => (string?)GetValue(DisplayMemberPathProperty);
+        set => SetValue(DisplayMemberPathProperty, value);
+    public object? CreateCommandParameter
+    {
+        get => GetValue(CreateCommandParameterProperty);
+        set => SetValue(CreateCommandParameterProperty, value);
+    }
+    }
+
+    public ICommand? CreateCommand
+    {
+        get => (ICommand?)GetValue(CreateCommandProperty);
+        set => SetValue(CreateCommandProperty, value);
+    }
+
+    private TextBox? _textBox;
+
+    public EditLookup()
+    {
+        InitializeComponent();
+        Loaded += OnLoaded;
+    }
+
+    private void OnLoaded(object sender, RoutedEventArgs e)
+    {
+        _textBox = (TextBox)Box.Template.FindName("PART_EditableTextBox", Box);
+        if (_textBox != null)
+            _textBox.TextChanged += OnTextChanged;
+    }
+
+    private void OnTextChanged(object sender, TextChangedEventArgs e)
+    {
+        if (ItemsSource == null)
+            return;
+        var view = CollectionViewSource.GetDefaultView(ItemsSource);
+        var text = _textBox?.Text ?? string.Empty;
+        view.Filter = o => Matches(o, text);
+        Box.IsDropDownOpen = true;
+        view.Refresh();
+    }
+
+    private bool Matches(object? item, string text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+            return true;
+        if (item is null)
+            return false;
+        var prop = item.GetType().GetProperty(DisplayMemberPath ?? "Name");
+        var value = prop?.GetValue(item)?.ToString() ?? item.ToString();
+        return value != null && value.IndexOf(text, StringComparison.OrdinalIgnoreCase) >= 0;
+    }
+
+    private void Box_PreviewKeyDown(object sender, KeyEventArgs e)
+    {
+        if (e.Key == Key.Enter)
+        {
+            if (Box.SelectedItem == null)
+            {
+                var param = CreateCommandParameter ?? _textBox?.Text;
+                if (CreateCommand?.CanExecute(param) == true)
+                    CreateCommand.Execute(param);
+            }
+            else
+            {
+                MoveFocus(new TraversalRequest(FocusNavigationDirection.Next));
+            }
+            e.Handled = true;
+        }
+        else if (e.Key == Key.Escape)
+        {
+            Box.IsDropDownOpen = false;
+            e.Handled = true;
+        }
+    }
+}

--- a/Wrecept.Wpf/Views/InvoiceEditorView.xaml
+++ b/Wrecept.Wpf/Views/InvoiceEditorView.xaml
@@ -25,12 +25,12 @@
 
         <StackPanel Orientation="Horizontal" Margin="0,0,0,4">
             <TextBlock Text="Szállító" Width="70" />
-            <ComboBox Width="200"
-                      ItemsSource="{Binding Suppliers}"
-                      DisplayMemberPath="Name"
-                      SelectedValuePath="Id"
-                      SelectedValue="{Binding SupplierId}" />
-        </StackPanel>
+            <c:EditLookup Width="200"
+                          ItemsSource="{Binding Suppliers}"
+                          DisplayMemberPath="Name"
+                          SelectedValuePath="Id"
+                          SelectedValue="{Binding SupplierId}"
+                          CreateCommand="{Binding ShowSupplierCreatorCommand}" />
         <StackPanel Orientation="Horizontal" Margin="0,0,0,4">
             <TextBlock Text="Dátum" Width="70" />
             <DatePicker SelectedDate="{Binding InvoiceDate}" Width="120" />
@@ -51,7 +51,17 @@
 
         <DataGrid ItemsSource="{Binding Items}" AutoGenerateColumns="False" Height="120">
             <DataGrid.Columns>
-                <DataGridTextColumn Header="Termék" Binding="{Binding Product}" Width="*" />
+                <DataGridTemplateColumn Header="Termék" Width="*">
+                    <DataGridTemplateColumn.CellTemplate>
+                        <DataTemplate>
+                            <c:EditLookup ItemsSource="{Binding DataContext.Products, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                          DisplayMemberPath="Name"
+                                          SelectedValuePath="Name"
+                                          SelectedValue="{Binding Product, Mode=TwoWay}"
+                                          CreateCommand="{Binding DataContext.ShowProductCreatorCommand, RelativeSource={RelativeSource AncestorType=UserControl}}" CreateCommandParameter="{Binding}" />
+                        </DataTemplate>
+                    </DataGridTemplateColumn.CellTemplate>
+                </DataGridTemplateColumn>
                 <DataGridTextColumn Header="Menny." Binding="{Binding Quantity}" Width="80">
                     <DataGridTextColumn.ElementStyle>
                         <Style TargetType="TextBlock">
@@ -60,12 +70,17 @@
                     </DataGridTextColumn.ElementStyle>
                 </DataGridTextColumn>
                 <DataGridTextColumn Header="Ár" Binding="{Binding UnitPrice}" Width="80" />
-                <DataGridComboBoxColumn Header="ÁFA"
-                                        SelectedValueBinding="{Binding TaxRateId}"
-                                        SelectedValuePath="Id"
-                                        DisplayMemberPath="Name"
-                                        ItemsSource="{Binding DataContext.TaxRates, RelativeSource={RelativeSource AncestorType=UserControl}}" />
-            </DataGrid.Columns>
+                <DataGridTemplateColumn Header="ÁFA">
+                    <DataGridTemplateColumn.CellTemplate>
+                        <DataTemplate>
+                            <c:EditLookup ItemsSource="{Binding DataContext.TaxRates, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                          DisplayMemberPath="Name"
+                                          SelectedValuePath="Id"
+                                          SelectedValue="{Binding TaxRateId, Mode=TwoWay}"
+                                          CreateCommand="{Binding DataContext.ShowTaxRateCreatorCommand, RelativeSource={RelativeSource AncestorType=UserControl}}" />
+                        </DataTemplate>
+                    </DataGridTemplateColumn.CellTemplate>
+                </DataGridTemplateColumn>
         </DataGrid>
         <ContentControl Content="{Binding InlineCreator}" Margin="0,4,0,0" />
         <TextBlock Text="Negatív mennyiség visszárut jelez." FontStyle="Italic" Margin="0,4,0,0"/>

--- a/Wrecept.Wpf/Views/StageView.xaml
+++ b/Wrecept.Wpf/Views/StageView.xaml
@@ -14,6 +14,11 @@
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
 
+        <Menu.Resources>
+            <Style TargetType="MenuItem">
+                <EventSetter Event="Click" Handler="MenuItem_Click"/>
+            </Style>
+        </Menu.Resources>
         <Menu>
             <MenuItem Header="Számlák">
                 <MenuItem Header="Bejövő szállítólevelek"

--- a/Wrecept.Wpf/Views/StageView.xaml.cs
+++ b/Wrecept.Wpf/Views/StageView.xaml.cs
@@ -8,6 +8,7 @@ namespace Wrecept.Wpf.Views;
 public partial class StageView : UserControl
 {
     private readonly StageViewModel _viewModel;
+    private MenuItem? _lastMenuItem;
 
     public StageView(StageViewModel viewModel)
     {
@@ -18,7 +19,21 @@ public partial class StageView : UserControl
     }
 
     private void OnKeyDown(object sender, KeyEventArgs e)
-        => NavigationHelper.Handle(e);
+    {
+        if (e.Key == Key.Escape)
+        {
+            _lastMenuItem?.Focus();
+            e.Handled = true;
+            return;
+        }
+
+        NavigationHelper.Handle(e);
+    }
+
+    private void MenuItem_Click(object sender, RoutedEventArgs e)
+    {
+        _lastMenuItem = sender as MenuItem;
+    }
 
     private void OnGotKeyboardFocus(object sender, KeyboardFocusChangedEventArgs e)
     {

--- a/docs/progress/2025-07-01_00-13-47_code_agent.md
+++ b/docs/progress/2025-07-01_00-13-47_code_agent.md
@@ -1,0 +1,4 @@
+- Implemented EditLookup user control for keyboard-based lookup filtering.
+- Replaced supplier and line item lookups with EditLookup in InvoiceEditorView.
+- Added inline creator commands for supplier, product and tax rate.
+- Preserved last menu focus in StageView and restored on Escape.


### PR DESCRIPTION
## Summary
- add `EditLookup` user control with filtering and command hooks
- swap supplier and line item lookups to use EditLookup
- support inline creation commands for supplier, product and tax rate
- keep last menu item focused on Escape

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68632569fd508322a8d5b4ec2a9a1939