### PR TITLE
Fix XAML namespace issues

### DIFF
--- a/Wrecept.Wpf/Views/Controls/EditLookup.xaml
+++ b/Wrecept.Wpf/Views/Controls/EditLookup.xaml
@@ -1,8 +1,9 @@
 <UserControl x:Class="Wrecept.Wpf.Views.Controls.EditLookup"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             mc:Ignorable="d">
+            xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+            xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+            mc:Ignorable="d">
     <ComboBox x:Name="Box"
               ItemsSource="{Binding ItemsSource, RelativeSource={RelativeSource AncestorType=UserControl}}"
               SelectedValuePath="{Binding SelectedValuePath, RelativeSource={RelativeSource AncestorType=UserControl}}"

--- a/Wrecept.Wpf/Views/Controls/EditLookup.xaml.cs
+++ b/Wrecept.Wpf/Views/Controls/EditLookup.xaml.cs
@@ -12,7 +12,8 @@ public partial class EditLookup : UserControl
         nameof(ItemsSource), typeof(object), typeof(EditLookup));
 
     public static readonly DependencyProperty SelectedValueProperty = DependencyProperty.Register(
-        nameof(SelectedValue), typeof(object), typeof(EditLookup), new FrameworkPropertyMetadata(null, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault));
+        nameof(SelectedValue), typeof(object), typeof(EditLookup),
+        new FrameworkPropertyMetadata(null, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault));
 
     public static readonly DependencyProperty SelectedValuePathProperty = DependencyProperty.Register(
         nameof(SelectedValuePath), typeof(string), typeof(EditLookup));
@@ -23,9 +24,10 @@ public partial class EditLookup : UserControl
     public static readonly DependencyProperty CreateCommandProperty = DependencyProperty.Register(
         nameof(CreateCommand), typeof(ICommand), typeof(EditLookup));
 
-    public object? ItemsSource
     public static readonly DependencyProperty CreateCommandParameterProperty = DependencyProperty.Register(
         nameof(CreateCommandParameter), typeof(object), typeof(EditLookup));
+
+    public object? ItemsSource
     {
         get => GetValue(ItemsSourceProperty);
         set => SetValue(ItemsSourceProperty, value);
@@ -47,11 +49,12 @@ public partial class EditLookup : UserControl
     {
         get => (string?)GetValue(DisplayMemberPathProperty);
         set => SetValue(DisplayMemberPathProperty, value);
+    }
+
     public object? CreateCommandParameter
     {
         get => GetValue(CreateCommandParameterProperty);
         set => SetValue(CreateCommandParameterProperty, value);
-    }
     }
 
     public ICommand? CreateCommand

--- a/Wrecept.Wpf/Views/InvoiceEditorView.xaml
+++ b/Wrecept.Wpf/Views/InvoiceEditorView.xaml
@@ -4,6 +4,7 @@
             xmlns:local="clr-namespace:Wrecept.Wpf.Converters"
             xmlns:vm="clr-namespace:Wrecept.Wpf.ViewModels"
             xmlns:views="clr-namespace:Wrecept.Wpf.Views.InlineCreators"
+            xmlns:c="clr-namespace:Wrecept.Wpf.Views.Controls"
             KeyDown="OnKeyDown">
     <UserControl.Resources>
         <local:NegativeValueForegroundConverter x:Key="NegativeForegroundConverter" />
@@ -31,6 +32,7 @@
                           SelectedValuePath="Id"
                           SelectedValue="{Binding SupplierId}"
                           CreateCommand="{Binding ShowSupplierCreatorCommand}" />
+        </StackPanel>
         <StackPanel Orientation="Horizontal" Margin="0,0,0,4">
             <TextBlock Text="Dátum" Width="70" />
             <DatePicker SelectedDate="{Binding InvoiceDate}" Width="120" />
@@ -81,6 +83,7 @@
                         </DataTemplate>
                     </DataGridTemplateColumn.CellTemplate>
                 </DataGridTemplateColumn>
+            </DataGrid.Columns>
         </DataGrid>
         <ContentControl Content="{Binding InlineCreator}" Margin="0,4,0,0" />
         <TextBlock Text="Negatív mennyiség visszárut jelez." FontStyle="Italic" Margin="0,4,0,0"/>

--- a/Wrecept.Wpf/Views/StageView.xaml
+++ b/Wrecept.Wpf/Views/StageView.xaml
@@ -14,11 +14,11 @@
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
 
-        <Menu.Resources>
+        <Grid.Resources>
             <Style TargetType="MenuItem">
                 <EventSetter Event="Click" Handler="MenuItem_Click"/>
             </Style>
-        </Menu.Resources>
+        </Grid.Resources>
         <Menu>
             <MenuItem Header="Számlák">
                 <MenuItem Header="Bejövő szállítólevelek"

--- a/docs/progress/2025-07-01_00-21-34_code_agent.md
+++ b/docs/progress/2025-07-01_00-21-34_code_agent.md
@@ -1,0 +1,3 @@
+- Fix build errors: undefined prefixes in XAML.
+- Added missing namespaces and corrected XAML structure.
+- Cleaned up EditLookup property declarations.


### PR DESCRIPTION
## Summary
- register `d` namespace for EditLookup control
- move menu style into Grid.Resources
- declare custom control namespace in InvoiceEditorView
- close layout tags and repair property declarations
- log progress

## Testing
- `dotnet test Wrecept.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_68632921077c8322a32beaea705f1c4e