### PR TITLE
Fix EditLookup XAML build error

### DIFF
--- a/Wrecept.Wpf/Views/Controls/EditLookup.xaml
+++ b/Wrecept.Wpf/Views/Controls/EditLookup.xaml
@@ -13,6 +13,5 @@
               StaysOpenOnEdit="True"
               IsTextSearchEnabled="False"
               PreviewKeyDown="Box_PreviewKeyDown"
-              CreateCommandParameter="{Binding CreateCommandParameter, RelativeSource={RelativeSource AncestorType=UserControl}}"
               IsSynchronizedWithCurrentItem="True"/>
 </UserControl>

--- a/docs/progress/2025-07-01_00-29-11_code_agent.md
+++ b/docs/progress/2025-07-01_00-29-11_code_agent.md
@@ -1,0 +1,2 @@
+- Fixed XAML compile error in `EditLookup`. Removed nonexistent `CreateCommandParameter` property from internal `ComboBox`.
+- `dotnet` not installed; build/test commands failed.


### PR DESCRIPTION
## Summary
- remove invalid `CreateCommandParameter` usage from `EditLookup`
- log progress for fixing build error

## Testing
- `dotnet --version` *(fails: command not found)*
- `dotnet build Wrecept.sln -c Release` *(fails: command not found)*
- `dotnet test Wrecept.sln -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68632b6de340832280f3631661b3ed15