### PR TITLE
Implement owner info editor

### DIFF
--- a/Wrecept.Core.Tests/Services/UserInfoServiceTests.cs
+++ b/Wrecept.Core.Tests/Services/UserInfoServiceTests.cs
@@ -1,0 +1,67 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Wrecept.Core.Entities;
+using Wrecept.Core.Services;
+using Wrecept.Storage.Services;
+using Xunit;
+
+namespace Wrecept.Core.Tests.Services;
+
+public class UserInfoServiceTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public UserInfoServiceTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(_tempDir);
+        Environment.SetEnvironmentVariable("XDG_CONFIG_HOME", _tempDir);
+        Environment.SetEnvironmentVariable("APPDATA", _tempDir);
+    }
+
+    [Fact]
+    public async Task LoadAsync_ReturnsDefaults_IfFileMissing()
+    {
+        var svc = new UserInfoService();
+        var info = await svc.LoadAsync();
+
+        Assert.Equal(string.Empty, info.CompanyName);
+        Assert.Equal(string.Empty, info.Address);
+        Assert.Equal(string.Empty, info.Phone);
+        Assert.Equal(string.Empty, info.Email);
+    }
+
+    [Fact]
+    public async Task SaveAsync_WritesFile()
+    {
+        var svc = new UserInfoService();
+        var info = new UserInfo { CompanyName = "ACME" };
+        await svc.SaveAsync(info);
+
+        var path = Path.Combine(_tempDir, "Wrecept", "wrecept.json");
+        Assert.True(File.Exists(path));
+    }
+
+    [Fact]
+    public async Task LoadAsync_ReturnsSavedObject()
+    {
+        var svc = new UserInfoService();
+        var info = new UserInfo { CompanyName = "ACME", Address = "Addr", Phone = "123", Email = "a@b.c" };
+        await svc.SaveAsync(info);
+
+        var loaded = await svc.LoadAsync();
+        Assert.Equal(info.CompanyName, loaded.CompanyName);
+        Assert.Equal(info.Address, loaded.Address);
+        Assert.Equal(info.Phone, loaded.Phone);
+        Assert.Equal(info.Email, loaded.Email);
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("XDG_CONFIG_HOME", null);
+        Environment.SetEnvironmentVariable("APPDATA", null);
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, true);
+    }
+}

--- a/Wrecept.Core/Entities/UserInfo.cs
+++ b/Wrecept.Core/Entities/UserInfo.cs
@@ -1,0 +1,9 @@
+namespace Wrecept.Core.Entities;
+
+public class UserInfo
+{
+    public string CompanyName { get; set; } = string.Empty;
+    public string Address { get; set; } = string.Empty;
+    public string Phone { get; set; } = string.Empty;
+    public string Email { get; set; } = string.Empty;
+}

--- a/Wrecept.Core/Services/IUserInfoService.cs
+++ b/Wrecept.Core/Services/IUserInfoService.cs
@@ -1,0 +1,9 @@
+using Wrecept.Core.Entities;
+
+namespace Wrecept.Core.Services;
+
+public interface IUserInfoService
+{
+    Task<UserInfo> LoadAsync();
+    Task SaveAsync(UserInfo info);
+}

--- a/Wrecept.Storage/ServiceCollectionExtensions.cs
+++ b/Wrecept.Storage/ServiceCollectionExtensions.cs
@@ -24,6 +24,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<ITaxRateRepository, TaxRateRepository>();
         services.AddScoped<IUnitRepository, UnitRepository>();
         services.AddSingleton<ILogService, LogService>();
+        services.AddSingleton<IUserInfoService, UserInfoService>();
 
         using var provider = services.BuildServiceProvider();
         var factory = provider.GetRequiredService<IDbContextFactory<AppDbContext>>();

--- a/Wrecept.Storage/Services/UserInfoService.cs
+++ b/Wrecept.Storage/Services/UserInfoService.cs
@@ -1,0 +1,26 @@
+using System.Text.Json;
+using Wrecept.Core.Entities;
+using Wrecept.Core.Services;
+
+namespace Wrecept.Storage.Services;
+
+public class UserInfoService : IUserInfoService
+{
+    private readonly string _path = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+        "Wrecept", "wrecept.json");
+
+    public async Task<UserInfo> LoadAsync()
+    {
+        if (!File.Exists(_path)) return new UserInfo();
+        using var stream = File.OpenRead(_path);
+        return await JsonSerializer.DeserializeAsync<UserInfo>(stream) ?? new UserInfo();
+    }
+
+    public async Task SaveAsync(UserInfo info)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(_path)!);
+        using var stream = File.Create(_path);
+        await JsonSerializer.SerializeAsync(stream, info, new JsonSerializerOptions { WriteIndented = true });
+    }
+}

--- a/Wrecept.Wpf/App.xaml
+++ b/Wrecept.Wpf/App.xaml
@@ -30,6 +30,9 @@
             <DataTemplate DataType="{x:Type vm:UnitMasterViewModel}">
                 <view:UnitMasterView />
             </DataTemplate>
+            <DataTemplate DataType="{x:Type vm:UserInfoViewModel}">
+                <view:UserInfoView />
+            </DataTemplate>
             <DataTemplate DataType="{x:Type vm:AboutViewModel}">
                 <view:AboutView />
             </DataTemplate>

--- a/Wrecept.Wpf/App.xaml.cs
+++ b/Wrecept.Wpf/App.xaml.cs
@@ -46,6 +46,7 @@ public partial class App : Application
         services.AddTransient<TaxRateMasterViewModel>();
         services.AddTransient<PaymentMethodMasterViewModel>();
         services.AddTransient<UnitMasterViewModel>();
+        services.AddTransient<UserInfoViewModel>();
         services.AddTransient<AboutViewModel>();
         services.AddTransient<PlaceholderViewModel>();
         services.AddSingleton<StatusBarViewModel>();
@@ -60,6 +61,7 @@ public partial class App : Application
         services.AddTransient<TaxRateMasterView>();
         services.AddTransient<PaymentMethodMasterView>();
         services.AddTransient<UnitMasterView>();
+        services.AddTransient<UserInfoView>();
         services.AddTransient<AboutView>();
         services.AddTransient<PlaceholderView>();
         services.AddTransient<Views.Controls.StatusBar>();

--- a/Wrecept.Wpf/Resources/Strings.Designer.cs
+++ b/Wrecept.Wpf/Resources/Strings.Designer.cs
@@ -15,6 +15,7 @@ internal static class Strings
     internal static string Stage_UnitViewOpened => _rm.GetString("Stage_UnitViewOpened") ?? string.Empty;
     internal static string Stage_InvoiceEditorOpened => _rm.GetString("Stage_InvoiceEditorOpened") ?? string.Empty;
     internal static string Stage_AboutOpened => _rm.GetString("Stage_AboutOpened") ?? string.Empty;
+    internal static string Stage_UserInfoEditOpened => _rm.GetString("Stage_UserInfoEditOpened") ?? string.Empty;
     internal static string Stage_FunctionNotReady => _rm.GetString("Stage_FunctionNotReady") ?? string.Empty;
     internal static string StatusBar_DefaultMessage => _rm.GetString("StatusBar_DefaultMessage") ?? string.Empty;
     internal static string Load_PaymentMethods => _rm.GetString("Load_PaymentMethods") ?? string.Empty;

--- a/Wrecept.Wpf/Resources/Strings.resx
+++ b/Wrecept.Wpf/Resources/Strings.resx
@@ -36,6 +36,9 @@
   <data name="Stage_AboutOpened" xml:space="preserve">
     <value>Névjegy megjelenítve</value>
   </data>
+  <data name="Stage_UserInfoEditOpened" xml:space="preserve">
+    <value>Tulajdonos adatok szerkesztése</value>
+  </data>
   <data name="Stage_FunctionNotReady" xml:space="preserve">
     <value>Funkció még nincs kész</value>
   </data>

--- a/Wrecept.Wpf/ViewModels/StageViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/StageViewModel.cs
@@ -23,6 +23,7 @@ public enum StageMenuAction
     AfterPowerOutage,
     ScreenSettings,
     PrinterSettings,
+    EditUserInfo,
     UserInfo,
     ExitApplication
 }
@@ -39,11 +40,13 @@ public partial class StageViewModel : ObservableObject
     private readonly TaxRateMasterViewModel _taxRateMaster;
     private readonly PaymentMethodMasterViewModel _paymentMethodMaster;
     private readonly UnitMasterViewModel _unitMaster;
+    private readonly UserInfoViewModel _userInfo;
     private readonly AboutViewModel _about;
     private readonly PlaceholderViewModel _placeholder;
     private readonly StatusBarViewModel _statusBar;
 
     public StatusBarViewModel StatusBar => _statusBar;
+    public UserInfoViewModel UserInfo => _userInfo;
 
     public StageViewModel(
         InvoiceEditorViewModel invoiceEditor,
@@ -53,6 +56,7 @@ public partial class StageViewModel : ObservableObject
         TaxRateMasterViewModel taxRateMaster,
         PaymentMethodMasterViewModel paymentMethodMaster,
         UnitMasterViewModel unitMaster,
+        UserInfoViewModel userInfo,
         AboutViewModel about,
         PlaceholderViewModel placeholder,
         StatusBarViewModel statusBar)
@@ -64,6 +68,7 @@ public partial class StageViewModel : ObservableObject
         _taxRateMaster = taxRateMaster;
         _paymentMethodMaster = paymentMethodMaster;
         _unitMaster = unitMaster;
+        _userInfo = userInfo;
         _about = about;
         _placeholder = placeholder;
         _statusBar = statusBar;
@@ -114,11 +119,18 @@ public partial class StageViewModel : ObservableObject
             case StageMenuAction.AfterPowerOutage:
             case StageMenuAction.ScreenSettings:
             case StageMenuAction.PrinterSettings:
+            case StageMenuAction.EditUserInfo:
             case StageMenuAction.UserInfo:
                 if (action == StageMenuAction.UserInfo)
                 {
                     CurrentViewModel = _about;
                     _statusBar.Message = Resources.Strings.Stage_AboutOpened;
+                }
+                else if (action == StageMenuAction.EditUserInfo)
+                {
+                    CurrentViewModel = _userInfo;
+                    _statusBar.Message = Resources.Strings.Stage_UserInfoEditOpened;
+                    _ = _userInfo.LoadAsync();
                 }
                 else
                 {

--- a/Wrecept.Wpf/ViewModels/UserInfoViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/UserInfoViewModel.cs
@@ -1,0 +1,42 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Wrecept.Core.Entities;
+using Wrecept.Core.Services;
+
+namespace Wrecept.Wpf.ViewModels;
+
+public partial class UserInfoViewModel : ObservableObject
+{
+    private readonly IUserInfoService _service;
+
+    [ObservableProperty] private string companyName = string.Empty;
+    [ObservableProperty] private string address = string.Empty;
+    [ObservableProperty] private string phone = string.Empty;
+    [ObservableProperty] private string email = string.Empty;
+
+    public UserInfoViewModel(IUserInfoService service)
+    {
+        _service = service;
+    }
+
+    public async Task LoadAsync()
+    {
+        var info = await _service.LoadAsync();
+        CompanyName = info.CompanyName;
+        Address = info.Address;
+        Phone = info.Phone;
+        Email = info.Email;
+    }
+
+    [RelayCommand]
+    public async Task SaveAsync()
+    {
+        await _service.SaveAsync(new UserInfo
+        {
+            CompanyName = CompanyName,
+            Address = Address,
+            Phone = Phone,
+            Email = Email
+        });
+    }
+}

--- a/Wrecept.Wpf/Views/StageView.xaml
+++ b/Wrecept.Wpf/Views/StageView.xaml
@@ -75,6 +75,9 @@
                 <MenuItem Header="Nyomtató beállítás"
                           Command="{Binding HandleMenuCommand}"
                           CommandParameter="{x:Static vm:StageMenuAction.PrinterSettings}" />
+                <MenuItem Header="Tulajdonos szerkesztése..."
+                          Command="{Binding HandleMenuCommand}"
+                          CommandParameter="{x:Static vm:StageMenuAction.EditUserInfo}" />
             </MenuItem>
             <MenuItem Header="Névjegy">
                 <MenuItem Header="A program felhasználójának adatai"

--- a/Wrecept.Wpf/Views/UserInfoView.xaml
+++ b/Wrecept.Wpf/Views/UserInfoView.xaml
@@ -1,0 +1,11 @@
+<UserControl x:Class="Wrecept.Wpf.Views.UserInfoView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <StackPanel Margin="20">
+        <TextBox Text="{Binding CompanyName, UpdateSourceTrigger=PropertyChanged}" PlaceholderText="Cégnév" />
+        <TextBox Text="{Binding Address, UpdateSourceTrigger=PropertyChanged}" PlaceholderText="Cím" />
+        <TextBox Text="{Binding Phone, UpdateSourceTrigger=PropertyChanged}" PlaceholderText="Telefonszám" />
+        <TextBox Text="{Binding Email, UpdateSourceTrigger=PropertyChanged}" PlaceholderText="E-mail" />
+        <Button Content="Mentés" Command="{Binding SaveCommand}" Margin="0,10,0,0" />
+    </StackPanel>
+</UserControl>

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -45,6 +45,7 @@ Az adatlekérést repositoryk végzik, amelyek `IInvoiceRepository`, `IProductRe
 Ezek fölött `InvoiceService`, `ProductService` és mostantól `SupplierService` gondoskodik a validálásról és a ViewModel réteg kiszolgálásáról.
 
 Minden hibát az `ILogService` rögzít, amelyet a Storage réteg `LogService` implementációja valósít meg. A naplók a `%AppData%/Wrecept/logs` mappában napi bontású fájlokba kerülnek.
+Az alapvető cégadatokat a `UserInfoService` kezeli. Az adatok a `%AppData%/Wrecept/wrecept.json` fájlban tárolódnak, betöltésük az alkalmazás futása közben történik.
 
 Minden domain modell tartalmaz `CreatedAt` és `UpdatedAt` mezőket. Ezeket a service réteg inicializálja, így naplózható az adat módosításának ideje.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,15 @@
+---
+title: "Felhasználói konfiguráció"
+purpose: "Cégadatok tárolása"
+author: "docs_agent"
+date: "2025-07-01"
+---
+
+A program a felhasználó cégadatait JSON formátumban tárolja a `%AppData%/Wrecept/wrecept.json` fájlban. A fájl a következő mezőket tartalmazza:
+
+- `CompanyName` – a vállalkozás neve
+- `Address` – székhely vagy telephely címe
+- `Phone` – kapcsolattartó telefonszáma
+- `Email` – általános elérhetőség
+
+A `UserInfoService` tölti be és menti az adatokat. Hiányzó fájl esetén üres értékeket használ. A `Tulajdonos szerkesztése...` menüpont megnyit egy űrlapot, amely ezen mezőket módosítja.

--- a/docs/progress/2025-07-01_01-20-52_code_agent.md
+++ b/docs/progress/2025-07-01_01-20-52_code_agent.md
@@ -1,0 +1,5 @@
+- UserInfo entity and service added for owner data.
+- New UserInfo edit view and viewmodel integrated into StageView.
+- Configuration stored in `%AppData%/Wrecept/wrecept.json` with sample file.
+- Documentation updated with configuration section.
+- Tests cover load/save behavior of UserInfoService.

--- a/docs/wrecept.json
+++ b/docs/wrecept.json
@@ -1,0 +1,6 @@
+{
+  "CompanyName": "Példa Kft.",
+  "Address": "1234 Minta utca 1.",
+  "Phone": "+36 30 123 4567",
+  "Email": "info@pelda.hu"
+}


### PR DESCRIPTION
## Summary
- add `UserInfo` entity and `IUserInfoService`
- implement `UserInfoService` for persisting owner data
- create `UserInfoViewModel` and `UserInfoView` for editing
- integrate into `StageViewModel` and menu
- document configuration and update architecture
- add unit tests for `UserInfoService`

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686336d355ac83229e1968e39f62dd96