### PR TITLE
Fix MC3072 error in UserInfoView

### DIFF
--- a/Wrecept.Wpf/Converters/StringNullOrEmptyToVisibilityConverter.cs
+++ b/Wrecept.Wpf/Converters/StringNullOrEmptyToVisibilityConverter.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+
+namespace Wrecept.Wpf.Converters;
+
+public class StringNullOrEmptyToVisibilityConverter : IValueConverter
+{
+    public bool Invert { get; set; }
+
+    public object Convert(object value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        bool empty = value is null || string.IsNullOrEmpty(value.ToString());
+        if (Invert) empty = !empty;
+        return empty ? Visibility.Visible : Visibility.Collapsed;
+    }
+
+    public object ConvertBack(object value, Type targetType, object? parameter, CultureInfo culture)
+        => Binding.DoNothing;
+}

--- a/Wrecept.Wpf/Views/UserInfoView.xaml
+++ b/Wrecept.Wpf/Views/UserInfoView.xaml
@@ -1,11 +1,40 @@
 <UserControl x:Class="Wrecept.Wpf.Views.UserInfoView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:local="clr-namespace:Wrecept.Wpf.Converters">
+    <UserControl.Resources>
+        <local:StringNullOrEmptyToVisibilityConverter x:Key="EmptyToVisibility" />
+        <Style x:Key="PlaceholderTextBox" TargetType="TextBox">
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="TextBox">
+                        <Grid>
+                            <ScrollViewer x:Name="PART_ContentHost"/>
+                            <TextBlock Text="{TemplateBinding Tag}"
+                                       Foreground="Gray"
+                                       IsHitTestVisible="False"
+                                       Margin="{TemplateBinding Padding}"
+                                       VerticalAlignment="Center"
+                                       Visibility="{Binding Text, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource EmptyToVisibility}}"/>
+                        </Grid>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+    </UserControl.Resources>
     <StackPanel Margin="20">
-        <TextBox Text="{Binding CompanyName, UpdateSourceTrigger=PropertyChanged}" PlaceholderText="Cégnév" />
-        <TextBox Text="{Binding Address, UpdateSourceTrigger=PropertyChanged}" PlaceholderText="Cím" />
-        <TextBox Text="{Binding Phone, UpdateSourceTrigger=PropertyChanged}" PlaceholderText="Telefonszám" />
-        <TextBox Text="{Binding Email, UpdateSourceTrigger=PropertyChanged}" PlaceholderText="E-mail" />
+        <TextBox Style="{StaticResource PlaceholderTextBox}"
+                 Tag="Cégnév"
+                 Text="{Binding CompanyName, UpdateSourceTrigger=PropertyChanged}" />
+        <TextBox Style="{StaticResource PlaceholderTextBox}"
+                 Tag="Cím"
+                 Text="{Binding Address, UpdateSourceTrigger=PropertyChanged}" />
+        <TextBox Style="{StaticResource PlaceholderTextBox}"
+                 Tag="Telefonszám"
+                 Text="{Binding Phone, UpdateSourceTrigger=PropertyChanged}" />
+        <TextBox Style="{StaticResource PlaceholderTextBox}"
+                 Tag="E-mail"
+                 Text="{Binding Email, UpdateSourceTrigger=PropertyChanged}" />
         <Button Content="Mentés" Command="{Binding SaveCommand}" Margin="0,10,0,0" />
     </StackPanel>
 </UserControl>

--- a/docs/progress/2025-07-01_01-25-58_ui_agent.md
+++ b/docs/progress/2025-07-01_01-25-58_ui_agent.md
@@ -1,0 +1,2 @@
+- Javítva a UserInfoView PlaceholderText hibája.
+- Új StringNullOrEmptyToVisibilityConverter bevezetve a helyőrző megjelenítéséhez.


### PR DESCRIPTION
## Summary
- add `StringNullOrEmptyToVisibilityConverter` for placeholders
- use `Tag` and custom template in `UserInfoView` to show placeholders
- log progress

## Testing
- `dotnet test --no-build` *(fails: missing WindowsDesktop SDK on Linux)*

------
https://chatgpt.com/codex/tasks/task_e_686338ad79f883229a73ad3cec14c9ee