### PR TITLE
Fix missing Task using in UserInfoViewModel

### DIFF
--- a/Wrecept.Wpf/ViewModels/UserInfoViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/UserInfoViewModel.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Wrecept.Core.Entities;

--- a/docs/progress/2025-07-01_01-30-21_code_agent.md
+++ b/docs/progress/2025-07-01_01-30-21_code_agent.md
@@ -1,0 +1,1 @@
+- Added System.Threading.Tasks using to UserInfoViewModel to fix build errors


### PR DESCRIPTION
## Summary
- add System.Threading.Tasks using so that `Task` resolves
- log progress for code agent

## Testing
- `dotnet build Wrecept.sln -c Release` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_686339c7231083228170296c230a93d1