### PR TITLE
Fix ViewModel using statements and XAML namespace

### DIFF
--- a/Wrecept.Wpf/ViewModels/InvoiceLookupViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/InvoiceLookupViewModel.cs
@@ -1,6 +1,8 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using System.Collections.ObjectModel;
+using System;
+using System.Threading.Tasks;
 using Wrecept.Core.Models;
 using Wrecept.Core.Services;
 

--- a/Wrecept.Wpf/Views/InvoiceEditorView.xaml
+++ b/Wrecept.Wpf/Views/InvoiceEditorView.xaml
@@ -3,6 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
             xmlns:local="clr-namespace:Wrecept.Wpf.Converters"
             xmlns:vm="clr-namespace:Wrecept.Wpf.ViewModels"
+            xmlns:view="clr-namespace:Wrecept.Wpf.Views"
             xmlns:views="clr-namespace:Wrecept.Wpf.Views.InlineCreators"
             xmlns:c="clr-namespace:Wrecept.Wpf.Views.Controls"
             KeyDown="OnKeyDown">
@@ -30,7 +31,7 @@
             <ColumnDefinition Width="*" />
         </Grid.ColumnDefinitions>
 
-        <views:InvoiceLookupView x:Name="LookupView" DataContext="{Binding Lookup}" />
+        <view:InvoiceLookupView x:Name="LookupView" DataContext="{Binding Lookup}" />
 
         <StackPanel Grid.Column="1" Margin="4">
         <TextBlock Text="Számla" FontWeight="Bold" Margin="0,0,0,6" />

--- a/docs/progress/2025-07-01_01-56-47_code_agent.md
+++ b/docs/progress/2025-07-01_01-56-47_code_agent.md
@@ -1,0 +1,3 @@
+- Added missing using statements for DateOnly and Task
+- Corrected namespace reference for InvoiceLookupView in InvoiceEditorView.xaml
+- Build attempted with dotnet but failed due to missing WindowsDesktop pack in container


### PR DESCRIPTION
## Summary
- add missing namespaces for DateOnly and Task
- fix InvoiceLookupView XAML namespace
- log progress

## Testing
- `dotnet build Wrecept.sln -c Debug` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets missing)*

------
https://chatgpt.com/codex/tasks/task_e_68633fbdf3808322aee6b1374e522d07