### PR TITLE
Fix InvoiceLookupView DataContext loading

### DIFF
--- a/Wrecept.Wpf/Views/InvoiceLookupView.xaml.cs
+++ b/Wrecept.Wpf/Views/InvoiceLookupView.xaml.cs
@@ -1,3 +1,4 @@
+using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using Microsoft.Extensions.DependencyInjection;
@@ -15,7 +16,13 @@ public partial class InvoiceLookupView : UserControl
     {
         InitializeComponent();
         DataContext = viewModel;
-        Loaded += async (_, _) => await viewModel.LoadAsync();
+        Loaded += OnLoaded;
+    }
+
+    private async void OnLoaded(object sender, RoutedEventArgs e)
+    {
+        if (DataContext is InvoiceLookupViewModel vm)
+            await vm.LoadAsync();
     }
 
     private void OnKeyDown(object sender, KeyEventArgs e)

--- a/docs/progress/2025-07-01_02-13-25_code_agent.md
+++ b/docs/progress/2025-07-01_02-13-25_code_agent.md
@@ -1,0 +1,2 @@
+- InvoiceLookupView's Load event now uses DataContext instance.
+- Fix ensures Invoice list populates from InvoiceLookupViewModel bound in InvoiceEditorView.


### PR DESCRIPTION
## Summary
- ensure InvoiceLookupView loads invoices from its current DataContext
- log progress

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686343c063e88322975b2255a9d6ee77