### PR TITLE
Fix UserInfo and About displays

### DIFF
--- a/Wrecept.Wpf/ViewModels/AboutViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/AboutViewModel.cs
@@ -1,28 +1,47 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using System.IO;
 using System.Reflection;
+using System.Text;
+using Wrecept.Core.Services;
 
 namespace Wrecept.Wpf.ViewModels;
 
 public partial class AboutViewModel : ObservableObject
 {
+    private readonly IUserInfoService _service;
+
     [ObservableProperty]
     private string aboutText = string.Empty;
 
-    public AboutViewModel()
+    public AboutViewModel(IUserInfoService service)
     {
+        _service = service;
+
         var assembly = Assembly.GetExecutingAssembly();
         var resourceName = "Wrecept.Wpf.Resources.about_hu.md";
         using var stream = assembly.GetManifestResourceStream(resourceName);
+
+        string text = "A Névjegy információ nem található.";
         if (stream is not null)
         {
             using var reader = new StreamReader(stream);
-            AboutText = StripFrontMatter(reader.ReadToEnd());
+            text = StripFrontMatter(reader.ReadToEnd());
         }
-        else
+
+        var info = _service.LoadAsync().GetAwaiter().GetResult();
+        var sb = new StringBuilder(text);
+
+        if (!string.IsNullOrWhiteSpace(info.CompanyName))
         {
-            AboutText = "A Névjegy információ nem található.";
+            sb.AppendLine();
+            sb.AppendLine();
+            sb.AppendLine($"**Cégnév:** {info.CompanyName}");
+            sb.AppendLine($"**Cím:** {info.Address}");
+            sb.AppendLine($"**Telefon:** {info.Phone}");
+            sb.AppendLine($"**E-mail:** {info.Email}");
         }
+
+        AboutText = sb.ToString();
     }
 
     private static string StripFrontMatter(string text)

--- a/Wrecept.Wpf/ViewModels/StageViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/StageViewModel.cs
@@ -1,5 +1,6 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using System.Threading.Tasks;
 using System.Windows;
 using Wrecept.Wpf.Resources;
 
@@ -76,8 +77,8 @@ public partial class StageViewModel : ObservableObject
         _statusBar.ActiveMenu = "Főmenü";
     }
 
-    [RelayCommand]
-    private void HandleMenu(StageMenuAction action)
+[RelayCommand]
+private async Task HandleMenu(StageMenuAction action)
     {
         _statusBar.ActiveMenu = action.ToString();
         switch (action)
@@ -119,24 +120,17 @@ public partial class StageViewModel : ObservableObject
             case StageMenuAction.AfterPowerOutage:
             case StageMenuAction.ScreenSettings:
             case StageMenuAction.PrinterSettings:
+                CurrentViewModel = _placeholder;
+                _statusBar.Message = Resources.Strings.Stage_FunctionNotReady;
+                break;
             case StageMenuAction.EditUserInfo:
+                CurrentViewModel = _userInfo;
+                _statusBar.Message = Resources.Strings.Stage_UserInfoEditOpened;
+                await _userInfo.LoadAsync();
+                break;
             case StageMenuAction.UserInfo:
-                if (action == StageMenuAction.UserInfo)
-                {
-                    CurrentViewModel = _about;
-                    _statusBar.Message = Resources.Strings.Stage_AboutOpened;
-                }
-                else if (action == StageMenuAction.EditUserInfo)
-                {
-                    CurrentViewModel = _userInfo;
-                    _statusBar.Message = Resources.Strings.Stage_UserInfoEditOpened;
-                    _ = _userInfo.LoadAsync();
-                }
-                else
-                {
-                    CurrentViewModel = _placeholder;
-                    _statusBar.Message = Resources.Strings.Stage_FunctionNotReady;
-                }
+                CurrentViewModel = _about;
+                _statusBar.Message = Resources.Strings.Stage_AboutOpened;
                 break;
             case StageMenuAction.ExitApplication:
                 Application.Current.Shutdown();

--- a/docs/progress/2025-07-01_02-24-13_code_agent.md
+++ b/docs/progress/2025-07-01_02-24-13_code_agent.md
@@ -1,0 +1,2 @@
+- Javítva a StageViewModel menükezelője, hogy aszinkron módon töltse be a UserInfo adatokat, és elkülönítve kezelje a Névjegy megjelenítését.
+- AboutViewModel most betölti a felhasználói adatokat a config fájlból és hozzáfűzi a szöveghez.


### PR DESCRIPTION
## Summary
- load user info from config in AboutViewModel
- async user info loading in StageViewModel
- document the fix in progress log

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686345bef0548322b2d954e9efc4e23b