### PR TITLE
Refactor invoice items grid for selective editing

### DIFF
--- a/Wrecept.Wpf/Converters/QuantityToStyleConverter.cs
+++ b/Wrecept.Wpf/Converters/QuantityToStyleConverter.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+using System.Windows.Media;
+
+namespace Wrecept.Wpf.Converters;
+
+public class QuantityToStyleConverter : IValueConverter
+{
+    public Brush NegativeBrush { get; set; } = Brushes.LightPink;
+    public Brush NormalBrush { get; set; } = Brushes.Transparent;
+
+    public object Convert(object value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (value is IConvertible conv)
+        {
+            try
+            {
+                if (conv.ToDecimal(culture) < 0)
+                    return NegativeBrush;
+            }
+            catch (FormatException) { }
+        }
+        return NormalBrush;
+    }
+
+    public object ConvertBack(object value, Type targetType, object? parameter, CultureInfo culture)
+        => Binding.DoNothing;
+}

--- a/Wrecept.Wpf/ViewModels/InvoiceEditorViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/InvoiceEditorViewModel.cs
@@ -36,7 +36,19 @@ public partial class InvoiceItemRowViewModel : ObservableObject
     private Guid taxRateId;
 
     [ObservableProperty]
+    private string taxRateName = string.Empty;
+
+    partial void OnTaxRateIdChanged(Guid value)
+        => TaxRateName = _parent.TaxRates.FirstOrDefault(t => t.Id == value)?.Name ?? string.Empty;
+
+    [ObservableProperty]
     private Guid unitId;
+
+    [ObservableProperty]
+    private string unitName = string.Empty;
+
+    partial void OnUnitIdChanged(Guid value)
+        => UnitName = _parent.Units.FirstOrDefault(u => u.Id == value)?.Name ?? string.Empty;
 
     [ObservableProperty]
     private string productGroup = string.Empty;
@@ -169,8 +181,10 @@ partial void OnSupplierChanged(string value) => UpdateSupplierId(value);
         {
             row.Product = exists.Name;
             row.UnitId = exists.UnitId;
+            row.UnitName = _parent.Units.FirstOrDefault(u => u.Id == exists.UnitId)?.Name ?? string.Empty;
             row.ProductGroup = exists.ProductGroup?.Name ?? string.Empty;
             row.TaxRateId = exists.TaxRateId;
+            row.TaxRateName = _parent.TaxRates.FirstOrDefault(t => t.Id == exists.TaxRateId)?.Name ?? string.Empty;
         }
 
         return Task.CompletedTask;
@@ -244,6 +258,8 @@ private void UpdateSupplierId(string name)
                 UnitPrice = item.UnitPrice,
                 TaxRateId = item.TaxRateId,
                 UnitId = item.Product?.UnitId ?? Guid.Empty,
+                UnitName = item.Product?.Unit?.Name ?? string.Empty,
+                TaxRateName = item.TaxRate?.Name ?? string.Empty,
                 ProductGroup = item.Product?.ProductGroup?.Name ?? string.Empty,
                 IsEditable = false
             };
@@ -260,6 +276,8 @@ private void UpdateSupplierId(string name)
         edit.UnitPrice = selected.UnitPrice;
         edit.TaxRateId = selected.TaxRateId;
         edit.UnitId = selected.UnitId;
+        edit.UnitName = selected.UnitName;
+        edit.TaxRateName = selected.TaxRateName;
         edit.ProductGroup = selected.ProductGroup;
     }
 
@@ -276,6 +294,8 @@ private void UpdateSupplierId(string name)
             UnitPrice = edit.UnitPrice,
             TaxRateId = edit.TaxRateId,
             UnitId = edit.UnitId,
+            UnitName = edit.UnitName,
+            TaxRateName = edit.TaxRateName,
             ProductGroup = edit.ProductGroup,
             IsEditable = false
         };
@@ -286,6 +306,8 @@ private void UpdateSupplierId(string name)
         edit.UnitPrice = 0;
         edit.TaxRateId = Guid.Empty;
         edit.UnitId = Guid.Empty;
+        edit.UnitName = string.Empty;
+        edit.TaxRateName = string.Empty;
         edit.ProductGroup = string.Empty;
     }
 

--- a/Wrecept.Wpf/Views/InvoiceEditorView.xaml
+++ b/Wrecept.Wpf/Views/InvoiceEditorView.xaml
@@ -66,52 +66,7 @@
         </StackPanel>
         <CheckBox Content="Bruttó ár" IsChecked="{Binding IsGross}" Margin="0,0,0,4" IsEnabled="{Binding IsEditable}" />
 
-        <DataGrid x:Name="ItemsGrid" ItemsSource="{Binding Items}" AutoGenerateColumns="False" Height="120" IsEnabled="{Binding IsEditable}">
-            <DataGrid.Columns>
-                <DataGridTemplateColumn Header="Termék" Width="*">
-                    <DataGridTemplateColumn.CellTemplate>
-                        <DataTemplate>
-                            <c:EditLookup ItemsSource="{Binding DataContext.Products, RelativeSource={RelativeSource AncestorType=UserControl}}"
-                                          DisplayMemberPath="Name"
-                                          SelectedValuePath="Name"
-                                          SelectedValue="{Binding Product, Mode=TwoWay}"
-                                          CreateCommand="{Binding DataContext.ShowProductCreatorCommand, RelativeSource={RelativeSource AncestorType=UserControl}}" CreateCommandParameter="{Binding}" />
-                        </DataTemplate>
-                    </DataGridTemplateColumn.CellTemplate>
-                </DataGridTemplateColumn>
-                <DataGridTextColumn Header="Csop." Binding="{Binding ProductGroup}" Width="100" IsReadOnly="True" />
-                <DataGridTemplateColumn Header="Me.e.">
-                    <DataGridTemplateColumn.CellTemplate>
-                        <DataTemplate>
-                            <c:EditLookup ItemsSource="{Binding DataContext.Units, RelativeSource={RelativeSource AncestorType=UserControl}}"
-                                          DisplayMemberPath="Name"
-                                          SelectedValuePath="Id"
-                                          SelectedValue="{Binding UnitId, Mode=TwoWay}"
-                                          CreateCommand="{Binding DataContext.ShowUnitCreatorCommand, RelativeSource={RelativeSource AncestorType=UserControl}}" />
-                        </DataTemplate>
-                    </DataGridTemplateColumn.CellTemplate>
-                </DataGridTemplateColumn>
-                <DataGridTextColumn Header="Menny." Binding="{Binding Quantity}" Width="80">
-                    <DataGridTextColumn.ElementStyle>
-                        <Style TargetType="TextBlock">
-                            <Setter Property="Foreground" Value="{Binding Quantity, Converter={StaticResource NegativeForegroundConverter}}" />
-                        </Style>
-                    </DataGridTextColumn.ElementStyle>
-                </DataGridTextColumn>
-                <DataGridTextColumn Header="Ár" Binding="{Binding UnitPrice}" Width="80" />
-                <DataGridTemplateColumn Header="ÁFA">
-                    <DataGridTemplateColumn.CellTemplate>
-                        <DataTemplate>
-                            <c:EditLookup ItemsSource="{Binding DataContext.TaxRates, RelativeSource={RelativeSource AncestorType=UserControl}}"
-                                          DisplayMemberPath="Name"
-                                          SelectedValuePath="Id"
-                                          SelectedValue="{Binding TaxRateId, Mode=TwoWay}"
-                                          CreateCommand="{Binding DataContext.ShowTaxRateCreatorCommand, RelativeSource={RelativeSource AncestorType=UserControl}}" />
-                        </DataTemplate>
-                    </DataGridTemplateColumn.CellTemplate>
-                </DataGridTemplateColumn>
-            </DataGrid.Columns>
-        </DataGrid>
+        <view:InvoiceItemsGrid x:Name="ItemsGrid" />
         <ContentControl Content="{Binding InlineCreator}" Margin="0,4,0,0" />
         <TextBlock Text="Negatív mennyiség visszárut jelez." FontStyle="Italic" Margin="0,4,0,0"/>
     </StackPanel>

--- a/Wrecept.Wpf/Views/InvoiceEditorView.xaml.cs
+++ b/Wrecept.Wpf/Views/InvoiceEditorView.xaml.cs
@@ -42,22 +42,6 @@ public partial class InvoiceEditorView : UserControl
             e.Handled = true;
             return;
         }
-        var dg = ItemsGrid;
-        if (e.Key == Key.Enter && dg.SelectedIndex == 0)
-        {
-            if (DataContext is InvoiceEditorViewModel vm)
-                vm.AddLineItemCommand.Execute(null);
-            e.Handled = true;
-            return;
-        }
-        if (e.Key == Key.Enter && dg.SelectedIndex > 0)
-        {
-            if (DataContext is InvoiceEditorViewModel vm && dg.SelectedItem is InvoiceItemRowViewModel row)
-                vm.EditLineFromSelection(row);
-            dg.SelectedIndex = 0;
-            e.Handled = true;
-            return;
-        }
         NavigationHelper.Handle(e);
     }
 }

--- a/Wrecept.Wpf/Views/InvoiceItemsGrid.xaml
+++ b/Wrecept.Wpf/Views/InvoiceItemsGrid.xaml
@@ -1,0 +1,135 @@
+<UserControl x:Class="Wrecept.Wpf.Views.InvoiceItemsGrid"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:c="clr-namespace:Wrecept.Wpf.Views.Controls"
+             xmlns:local="clr-namespace:Wrecept.Wpf.Converters">
+    <UserControl.Resources>
+        <local:QuantityToStyleConverter x:Key="QuantityToStyleConverter" />
+        <local:NegativeValueForegroundConverter x:Key="NegativeForegroundConverter" />
+    </UserControl.Resources>
+    <DataGrid x:Name="Grid" ItemsSource="{Binding Items}" AutoGenerateColumns="False" IsEnabled="{Binding IsEditable}"
+              KeyDown="OnKeyDown">
+        <DataGrid.RowStyle>
+            <Style TargetType="DataGridRow">
+                <Setter Property="Background" Value="{Binding Quantity, Converter={StaticResource QuantityToStyleConverter}}" />
+                <Style.Triggers>
+                    <DataTrigger Binding="{Binding IsEditable}" Value="True">
+                        <Setter Property="BorderBrush" Value="Blue" />
+                        <Setter Property="BorderThickness" Value="1" />
+                    </DataTrigger>
+                </Style.Triggers>
+            </Style>
+        </DataGrid.RowStyle>
+        <DataGrid.Columns>
+            <DataGridTemplateColumn Header="Termék" Width="*">
+                <DataGridTemplateColumn.CellTemplate>
+                    <DataTemplate>
+                        <Grid>
+                            <c:EditLookup x:Name="Editor"
+                                         ItemsSource="{Binding DataContext.Products, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                         DisplayMemberPath="Name"
+                                         SelectedValuePath="Name"
+                                         SelectedValue="{Binding Product, Mode=TwoWay}"
+                                         CreateCommand="{Binding DataContext.ShowProductCreatorCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                         CreateCommandParameter="{Binding}" />
+                            <TextBlock x:Name="Text" Text="{Binding Product}" VerticalAlignment="Center" />
+                        </Grid>
+                        <DataTemplate.Triggers>
+                            <DataTrigger Binding="{Binding IsEditable}" Value="False">
+                                <Setter TargetName="Editor" Property="Visibility" Value="Collapsed" />
+                            </DataTrigger>
+                            <DataTrigger Binding="{Binding IsEditable}" Value="True">
+                                <Setter TargetName="Text" Property="Visibility" Value="Collapsed" />
+                            </DataTrigger>
+                        </DataTemplate.Triggers>
+                    </DataTemplate>
+                </DataGridTemplateColumn.CellTemplate>
+            </DataGridTemplateColumn>
+            <DataGridTextColumn Header="Csop." Binding="{Binding ProductGroup}" Width="100" IsReadOnly="True" />
+            <DataGridTemplateColumn Header="Me.e.">
+                <DataGridTemplateColumn.CellTemplate>
+                    <DataTemplate>
+                        <Grid>
+                            <c:EditLookup x:Name="Editor"
+                                         ItemsSource="{Binding DataContext.Units, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                         DisplayMemberPath="Name"
+                                         SelectedValuePath="Id"
+                                         SelectedValue="{Binding UnitId, Mode=TwoWay}"
+                                         CreateCommand="{Binding DataContext.ShowUnitCreatorCommand, RelativeSource={RelativeSource AncestorType=UserControl}}" />
+                            <TextBlock x:Name="Text" Text="{Binding UnitName}" />
+                        </Grid>
+                        <DataTemplate.Triggers>
+                            <DataTrigger Binding="{Binding IsEditable}" Value="False">
+                                <Setter TargetName="Editor" Property="Visibility" Value="Collapsed" />
+                            </DataTrigger>
+                            <DataTrigger Binding="{Binding IsEditable}" Value="True">
+                                <Setter TargetName="Text" Property="Visibility" Value="Collapsed" />
+                            </DataTrigger>
+                        </DataTemplate.Triggers>
+                    </DataTemplate>
+                </DataGridTemplateColumn.CellTemplate>
+            </DataGridTemplateColumn>
+            <DataGridTemplateColumn Header="Menny." Width="80">
+                <DataGridTemplateColumn.CellTemplate>
+                    <DataTemplate>
+                        <Grid>
+                            <TextBox x:Name="Editor" Text="{Binding Quantity, Mode=TwoWay}"
+                                     Foreground="{Binding Quantity, Converter={StaticResource NegativeForegroundConverter}}"/>
+                            <TextBlock x:Name="Text" Text="{Binding Quantity}" VerticalAlignment="Center"
+                                       Foreground="{Binding Quantity, Converter={StaticResource NegativeForegroundConverter}}"/>
+                        </Grid>
+                        <DataTemplate.Triggers>
+                            <DataTrigger Binding="{Binding IsEditable}" Value="False">
+                                <Setter TargetName="Editor" Property="Visibility" Value="Collapsed" />
+                            </DataTrigger>
+                            <DataTrigger Binding="{Binding IsEditable}" Value="True">
+                                <Setter TargetName="Text" Property="Visibility" Value="Collapsed" />
+                            </DataTrigger>
+                        </DataTemplate.Triggers>
+                    </DataTemplate>
+                </DataGridTemplateColumn.CellTemplate>
+            </DataGridTemplateColumn>
+            <DataGridTemplateColumn Header="Ár" Width="80">
+                <DataGridTemplateColumn.CellTemplate>
+                    <DataTemplate>
+                        <Grid>
+                            <TextBox x:Name="Editor" Text="{Binding UnitPrice, Mode=TwoWay}" />
+                            <TextBlock x:Name="Text" Text="{Binding UnitPrice}" VerticalAlignment="Center" />
+                        </Grid>
+                        <DataTemplate.Triggers>
+                            <DataTrigger Binding="{Binding IsEditable}" Value="False">
+                                <Setter TargetName="Editor" Property="Visibility" Value="Collapsed" />
+                            </DataTrigger>
+                            <DataTrigger Binding="{Binding IsEditable}" Value="True">
+                                <Setter TargetName="Text" Property="Visibility" Value="Collapsed" />
+                            </DataTrigger>
+                        </DataTemplate.Triggers>
+                    </DataTemplate>
+                </DataGridTemplateColumn.CellTemplate>
+            </DataGridTemplateColumn>
+            <DataGridTemplateColumn Header="ÁFA">
+                <DataGridTemplateColumn.CellTemplate>
+                    <DataTemplate>
+                        <Grid>
+                            <c:EditLookup x:Name="Editor"
+                                         ItemsSource="{Binding DataContext.TaxRates, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                         DisplayMemberPath="Name"
+                                         SelectedValuePath="Id"
+                                         SelectedValue="{Binding TaxRateId, Mode=TwoWay}"
+                                         CreateCommand="{Binding DataContext.ShowTaxRateCreatorCommand, RelativeSource={RelativeSource AncestorType=UserControl}}" />
+                            <TextBlock x:Name="Text" Text="{Binding TaxRateName}" />
+                        </Grid>
+                        <DataTemplate.Triggers>
+                            <DataTrigger Binding="{Binding IsEditable}" Value="False">
+                                <Setter TargetName="Editor" Property="Visibility" Value="Collapsed" />
+                            </DataTrigger>
+                            <DataTrigger Binding="{Binding IsEditable}" Value="True">
+                                <Setter TargetName="Text" Property="Visibility" Value="Collapsed" />
+                            </DataTrigger>
+                        </DataTemplate.Triggers>
+                    </DataTemplate>
+                </DataGridTemplateColumn.CellTemplate>
+            </DataGridTemplateColumn>
+        </DataGrid.Columns>
+    </DataGrid>
+</UserControl>

--- a/Wrecept.Wpf/Views/InvoiceItemsGrid.xaml.cs
+++ b/Wrecept.Wpf/Views/InvoiceItemsGrid.xaml.cs
@@ -1,0 +1,35 @@
+using System.Windows.Controls;
+using System.Windows.Input;
+using Wrecept.Wpf.ViewModels;
+
+namespace Wrecept.Wpf.Views;
+
+public partial class InvoiceItemsGrid : UserControl
+{
+    public InvoiceItemsGrid()
+    {
+        InitializeComponent();
+    }
+
+    private void OnKeyDown(object sender, KeyEventArgs e)
+    {
+        if (DataContext is not InvoiceEditorViewModel vm)
+            return;
+        if (e.Key == Key.Enter && Grid.SelectedIndex == 0)
+        {
+            vm.AddLineItemCommand.Execute(null);
+            e.Handled = true;
+        }
+        else if (e.Key == Key.Enter && Grid.SelectedIndex > 0 && Grid.SelectedItem is InvoiceItemRowViewModel row)
+        {
+            vm.EditLineFromSelection(row);
+            Grid.SelectedIndex = 0;
+            e.Handled = true;
+        }
+        else if (e.Key == Key.Down && Grid.SelectedIndex == 0 && Grid.Items.Count > 1)
+        {
+            Grid.SelectedIndex = 1;
+            e.Handled = true;
+        }
+    }
+}

--- a/docs/progress/2025-07-01_02-36-30_code_agent.md
+++ b/docs/progress/2025-07-01_02-36-30_code_agent.md
@@ -1,0 +1,4 @@
+- Frissítve az InvoiceEditorView: InvoiceItemsGrid komponens bevezetése csak az első sor szerkeszthetőségével.
+- Új QuantityToStyleConverter a negatív mennyiségek sorainak háttérszínezéséhez.
+- InvoiceItemRowViewModel kibővítve UnitName és TaxRateName mezőkkel.
+- Módosított billentyűkezelés az InvoiceItemsGrid-ben.


### PR DESCRIPTION
## Summary
- create `InvoiceItemsGrid` user control with inline editing only on the first row
- add `QuantityToStyleConverter` for negative quantity highlighting
- extend `InvoiceItemRowViewModel` with `UnitName` and `TaxRateName`
- integrate new grid into `InvoiceEditorView`
- document progress

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863482041648322956954d217a46d8b