### PR TITLE
Fix invoice editor build error

### DIFF
--- a/Wrecept.Wpf/ViewModels/InvoiceEditorViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/InvoiceEditorViewModel.cs
@@ -181,10 +181,10 @@ partial void OnSupplierChanged(string value) => UpdateSupplierId(value);
         {
             row.Product = exists.Name;
             row.UnitId = exists.UnitId;
-            row.UnitName = _parent.Units.FirstOrDefault(u => u.Id == exists.UnitId)?.Name ?? string.Empty;
+            row.UnitName = Units.FirstOrDefault(u => u.Id == exists.UnitId)?.Name ?? string.Empty;
             row.ProductGroup = exists.ProductGroup?.Name ?? string.Empty;
             row.TaxRateId = exists.TaxRateId;
-            row.TaxRateName = _parent.TaxRates.FirstOrDefault(t => t.Id == exists.TaxRateId)?.Name ?? string.Empty;
+            row.TaxRateName = TaxRates.FirstOrDefault(t => t.Id == exists.TaxRateId)?.Name ?? string.Empty;
         }
 
         return Task.CompletedTask;

--- a/docs/progress/2025-07-01_02-43-36_code_agent.md
+++ b/docs/progress/2025-07-01_02-43-36_code_agent.md
@@ -1,0 +1,2 @@
+- Fix CS0103 in InvoiceEditorViewModel by referencing local collections instead of undefined _parent field.
+- dotnet build failed: command not found in container.


### PR DESCRIPTION
## Summary
- fix `_parent` reference inside `InvoiceEditorViewModel`
- log progress

## Testing
- `dotnet build --no-restore Wrecept.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68634aad4b5c83229c3bebeda0471ebf