### PR TITLE
Implement invoice line validation with tests

### DIFF
--- a/Wrecept.Wpf/Resources/Strings.Designer.cs
+++ b/Wrecept.Wpf/Resources/Strings.Designer.cs
@@ -24,4 +24,8 @@ internal static class Strings
     internal static string Load_Products => _rm.GetString("Load_Products") ?? string.Empty;
     internal static string Load_Units => _rm.GetString("Load_Units") ?? string.Empty;
     internal static string Load_Complete => _rm.GetString("Load_Complete") ?? string.Empty;
+    internal static string InvoiceLine_InvalidQuantity => _rm.GetString("InvoiceLine_InvalidQuantity") ?? string.Empty;
+    internal static string InvoiceLine_InvalidPrice => _rm.GetString("InvoiceLine_InvalidPrice") ?? string.Empty;
+    internal static string InvoiceLine_TaxRequired => _rm.GetString("InvoiceLine_TaxRequired") ?? string.Empty;
+    internal static string InvoiceEditor_ReadOnly => _rm.GetString("InvoiceEditor_ReadOnly") ?? string.Empty;
 }

--- a/Wrecept.Wpf/Resources/Strings.resx
+++ b/Wrecept.Wpf/Resources/Strings.resx
@@ -63,4 +63,16 @@
   <data name="Load_Complete" xml:space="preserve">
     <value>Betöltés kész.</value>
   </data>
+  <data name="InvoiceLine_InvalidQuantity" xml:space="preserve">
+    <value>Mennyiségnek 0-nál nagyobbnak kell lennie</value>
+  </data>
+  <data name="InvoiceLine_InvalidPrice" xml:space="preserve">
+    <value>Az ár nem lehet negatív</value>
+  </data>
+  <data name="InvoiceLine_TaxRequired" xml:space="preserve">
+    <value>ÁFA kulcs megadása kötelező</value>
+  </data>
+  <data name="InvoiceEditor_ReadOnly" xml:space="preserve">
+    <value>A lezárt számla nem módosítható</value>
+  </data>
 </root>

--- a/Wrecept.Wpf/ViewModels/ProductCreatorViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/ProductCreatorViewModel.cs
@@ -57,7 +57,8 @@ public partial class ProductCreatorViewModel : ObservableObject
         _parent.Products.Add(product);
         _row.Product = product.Name;
         _parent.InlineCreator = null;
-        _parent.AddLineItemCommand.Execute(null);
+        if (_parent.IsEditable)
+            _parent.AddLineItemCommand.Execute(null);
     }
 
     [RelayCommand]

--- a/Wrecept.Wpf/Views/InvoiceItemsGrid.xaml
+++ b/Wrecept.Wpf/Views/InvoiceItemsGrid.xaml
@@ -17,6 +17,11 @@
                         <Setter Property="BorderBrush" Value="Blue" />
                         <Setter Property="BorderThickness" Value="1" />
                     </DataTrigger>
+                    <DataTrigger Binding="{Binding HasError}" Value="True">
+                        <Setter Property="BorderBrush" Value="Red" />
+                        <Setter Property="BorderThickness" Value="2" />
+                        <Setter Property="ToolTip" Value="{Binding ErrorMessage}" />
+                    </DataTrigger>
                 </Style.Triggers>
             </Style>
         </DataGrid.RowStyle>

--- a/Wrecept.Wpf/Views/InvoiceItemsGrid.xaml.cs
+++ b/Wrecept.Wpf/Views/InvoiceItemsGrid.xaml.cs
@@ -15,6 +15,8 @@ public partial class InvoiceItemsGrid : UserControl
     {
         if (DataContext is not InvoiceEditorViewModel vm)
             return;
+        if (!vm.IsEditable)
+            return;
         if (e.Key == Key.Enter && Grid.SelectedIndex == 0)
         {
             vm.AddLineItemCommand.Execute(null);

--- a/docs/progress/2025-07-01_11-19-12_code_agent.md
+++ b/docs/progress/2025-07-01_11-19-12_code_agent.md
@@ -1,0 +1,4 @@
+- Line item validation added to InvoiceEditorViewModel with inline error feedback.
+- Commands now respect IsEditable flag and show message on attempt when archived.
+- InvoiceItemsGrid highlights invalid rows with red border and tooltip.
+- Added unit tests for viewmodel behaviors under tests/viewmodels.

--- a/tests/viewmodels/InvoiceEditorViewModelTests.cs
+++ b/tests/viewmodels/InvoiceEditorViewModelTests.cs
@@ -1,0 +1,165 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+using Wrecept.Wpf.ViewModels;
+using Wrecept.Core.Models;
+using Wrecept.Core.Services;
+using System.Collections.ObjectModel;
+
+namespace Wrecept.Tests.ViewModels;
+
+public class InvoiceEditorViewModelTests
+{
+    private class FakeInvoiceService : IInvoiceService
+    {
+        public readonly List<Invoice> Invoices = new();
+        public readonly List<InvoiceItem> Items = new();
+        private int _id = 1;
+        public Task<bool> CreateAsync(Invoice invoice, System.Threading.CancellationToken ct = default)
+        {
+            invoice.Id = _id++;
+            Invoices.Add(invoice);
+            return Task.FromResult(true);
+        }
+        public Task<int> CreateHeaderAsync(Invoice invoice, System.Threading.CancellationToken ct = default)
+        {
+            invoice.Id = _id++;
+            Invoices.Add(invoice);
+            return Task.FromResult(invoice.Id);
+        }
+        public Task<int> AddItemAsync(InvoiceItem item, System.Threading.CancellationToken ct = default)
+        {
+            item.Id = _id++;
+            Items.Add(item);
+            return Task.FromResult(item.Id);
+        }
+        public Task<Invoice?> GetAsync(int id, System.Threading.CancellationToken ct = default) => Task.FromResult<Invoice?>(null);
+        public Task<List<Invoice>> GetRecentAsync(int count, System.Threading.CancellationToken ct = default) => Task.FromResult(new List<Invoice>(Invoices));
+    }
+
+    private class FakeProductService : IProductService
+    {
+        public readonly List<Product> Products = new();
+        public Task<List<Product>> GetAllAsync(System.Threading.CancellationToken ct = default) => Task.FromResult(new List<Product>(Products));
+        public Task<List<Product>> GetActiveAsync(System.Threading.CancellationToken ct = default) => Task.FromResult(new List<Product>(Products));
+        public Task<int> AddAsync(Product product, System.Threading.CancellationToken ct = default)
+        {
+            product.Id = Products.Count + 1;
+            Products.Add(product);
+            return Task.FromResult(product.Id);
+        }
+        public Task UpdateAsync(Product product, System.Threading.CancellationToken ct = default) => Task.CompletedTask;
+    }
+
+    private class DummyService<T> : IPaymentMethodService, ITaxRateService, ISupplierService, IUnitService
+        where T : class
+    {
+        public Task<List<PaymentMethod>> GetActiveAsync(System.Threading.CancellationToken ct = default) => Task.FromResult(new List<PaymentMethod>());
+        public Task<List<PaymentMethod>> GetAllAsync(System.Threading.CancellationToken ct = default) => Task.FromResult(new List<PaymentMethod>());
+        public Task<Guid> AddAsync(PaymentMethod method, System.Threading.CancellationToken ct = default) => Task.FromResult(Guid.NewGuid());
+        public Task UpdateAsync(PaymentMethod method, System.Threading.CancellationToken ct = default) => Task.CompletedTask;
+
+        public Task<List<TaxRate>> GetAllAsync(System.Threading.CancellationToken ct = default) => Task.FromResult(new List<TaxRate>());
+        public Task<List<TaxRate>> GetActiveAsync(DateTime asOf, System.Threading.CancellationToken ct = default) => Task.FromResult(new List<TaxRate>());
+        public Task<Guid> AddAsync(TaxRate taxRate, System.Threading.CancellationToken ct = default) => Task.FromResult(Guid.NewGuid());
+        public Task UpdateAsync(TaxRate taxRate, System.Threading.CancellationToken ct = default) => Task.CompletedTask;
+
+        public Task<List<Supplier>> GetAllAsync(System.Threading.CancellationToken ct = default) => Task.FromResult(new List<Supplier>());
+        public Task<List<Supplier>> GetActiveAsync(System.Threading.CancellationToken ct = default) => Task.FromResult(new List<Supplier>());
+        public Task<int> AddAsync(Supplier supplier, System.Threading.CancellationToken ct = default) => Task.FromResult(1);
+        public Task UpdateAsync(Supplier supplier, System.Threading.CancellationToken ct = default) => Task.CompletedTask;
+
+        public Task<List<Unit>> GetAllAsync(System.Threading.CancellationToken ct = default) => Task.FromResult(new List<Unit>());
+        public Task<List<Unit>> GetActiveAsync(System.Threading.CancellationToken ct = default) => Task.FromResult(new List<Unit>());
+        public Task<Guid> AddAsync(Unit unit, System.Threading.CancellationToken ct = default) => Task.FromResult(Guid.NewGuid());
+        public Task UpdateAsync(Unit unit, System.Threading.CancellationToken ct = default) => Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task InlinePrompt_CreatesInvoice()
+    {
+        var invoiceSvc = new FakeInvoiceService();
+        var lookup = new InvoiceLookupViewModel(invoiceSvc);
+        var prompt = new InvoiceCreatePromptViewModel(lookup, "INV1");
+
+        await prompt.ConfirmAsyncCommand.ExecuteAsync(null);
+
+        Assert.Single(invoiceSvc.Invoices);
+        Assert.Null(lookup.InlinePrompt);
+    }
+
+    [Fact]
+    public async Task AddLineItem_InvalidQuantity_Rejected()
+    {
+        var invoiceSvc = new FakeInvoiceService();
+        var productSvc = new FakeProductService();
+        productSvc.Products.Add(new Product { Id = 1, Name = "Test", TaxRateId = Guid.NewGuid() });
+        var payment = new DummyService<object>();
+        var tax = new DummyService<object>();
+        var supplier = new DummyService<object>();
+        var unit = new DummyService<object>();
+        var lookup = new InvoiceLookupViewModel(invoiceSvc);
+        var vm = new InvoiceEditorViewModel(payment, tax, supplier, productSvc, unit, invoiceSvc, lookup);
+
+        var row = vm.Items[0];
+        row.Product = "Test";
+        row.Quantity = 0;
+        row.TaxRateId = productSvc.Products[0].TaxRateId;
+
+        await vm.AddLineItemAsync();
+
+        Assert.Equal(0, invoiceSvc.Items.Count);
+        Assert.True(row.HasError);
+    }
+
+    [Fact]
+    public async Task Commands_Ignored_When_ReadOnly()
+    {
+        var invoiceSvc = new FakeInvoiceService();
+        var productSvc = new FakeProductService();
+        productSvc.Products.Add(new Product { Id = 1, Name = "Test", TaxRateId = Guid.NewGuid() });
+        var dummy = new DummyService<object>();
+        var lookup = new InvoiceLookupViewModel(invoiceSvc);
+        var vm = new InvoiceEditorViewModel(dummy, dummy, dummy, productSvc, dummy, invoiceSvc, lookup)
+        {
+            IsArchived = true
+        };
+
+        var row = vm.Items[0];
+        row.Product = "Test";
+        row.Quantity = 1;
+        row.TaxRateId = productSvc.Products[0].TaxRateId;
+
+        await vm.AddLineItemAsync();
+        Assert.Empty(invoiceSvc.Items);
+        Assert.True(row.HasError);
+
+        vm.EditLineFromSelection(new InvoiceItemRowViewModel(vm) { Product = "X" });
+        Assert.Equal(string.Empty, vm.Items[0].Product);
+    }
+
+    [Fact]
+    public async Task InlineProductCreation_AddsLineAutomatically()
+    {
+        var invoiceSvc = new FakeInvoiceService();
+        var productSvc = new FakeProductService();
+        var dummy = new DummyService<object>();
+        var lookup = new InvoiceLookupViewModel(invoiceSvc);
+        var vm = new InvoiceEditorViewModel(dummy, dummy, dummy, productSvc, dummy, invoiceSvc, lookup);
+
+        var row = vm.Items[0];
+        var creator = new ProductCreatorViewModel(vm, row, productSvc)
+        {
+            Name = "NewProd",
+            UnitId = Guid.NewGuid(),
+            TaxRateId = Guid.NewGuid()
+        };
+
+        await creator.ConfirmAsync();
+
+        Assert.Single(invoiceSvc.Items);
+        Assert.Null(vm.InlineCreator);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add validation messages for invoice lines
- prevent editing archived invoices
- highlight validation failures on the grid
- update ProductCreator and grid key handling to respect `IsEditable`
- add viewmodel unit tests
- log progress

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863c2e120588322ad450e45425b946e