### PR TITLE
Fix InvoiceLookupView layout

### DIFF
--- a/Wrecept.Wpf/Views/InvoiceLookupView.xaml
+++ b/Wrecept.Wpf/Views/InvoiceLookupView.xaml
@@ -9,19 +9,25 @@
             <prompt:InvoiceCreatePromptView />
         </DataTemplate>
     </UserControl.Resources>
-    <ListBox x:Name="InvoiceList"
-             ItemsSource="{Binding Invoices}"
-             SelectedItem="{Binding SelectedInvoice}"
-             Margin="4">
-        <ListBox.ItemTemplate>
-            <DataTemplate>
-                <StackPanel Orientation="Horizontal">
-                    <TextBlock Text="{Binding Number}" Width="80"/>
-                    <TextBlock Text="{Binding Date}" Width="90"/>
-                    <TextBlock Text="{Binding Supplier}" />
-                </StackPanel>
-            </DataTemplate>
-        </ListBox.ItemTemplate>
-    </ListBox>
-    <ContentControl Content="{Binding InlinePrompt}" Margin="4" />
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+        <ListBox x:Name="InvoiceList"
+                 ItemsSource="{Binding Invoices}"
+                 SelectedItem="{Binding SelectedInvoice}"
+                 Margin="4">
+            <ListBox.ItemTemplate>
+                <DataTemplate>
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock Text="{Binding Number}" Width="80"/>
+                        <TextBlock Text="{Binding Date}" Width="90"/>
+                        <TextBlock Text="{Binding Supplier}" />
+                    </StackPanel>
+                </DataTemplate>
+            </ListBox.ItemTemplate>
+        </ListBox>
+        <ContentControl Content="{Binding InlinePrompt}" Margin="4" Grid.Row="1" />
+    </Grid>
 </UserControl>

--- a/docs/progress/2025-07-01_12-37-38_code_agent.md
+++ b/docs/progress/2025-07-01_12-37-38_code_agent.md
@@ -1,0 +1,2 @@
+- Fixed InvoiceLookupView layout by wrapping ListBox and InlinePrompt in Grid.
+- Build-time error due to multiple root children is resolved.


### PR DESCRIPTION
## Summary
- fix build-time XAML error by wrapping InvoiceLookupView children in a Grid
- log progress

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863d622793483228482364f94ad04da