### PR TITLE
Fix InvoiceRepository AddItemAsync mismatch

### DIFF
--- a/Wrecept.Storage/Repositories/InvoiceRepository.cs
+++ b/Wrecept.Storage/Repositories/InvoiceRepository.cs
@@ -21,7 +21,10 @@ public class InvoiceRepository : IInvoiceRepository
         return invoice.Id;
     }
 
-    public async Task<int> AddItemAsync(InvoiceItem item, CancellationToken ct = default)
+    async Task<int> IInvoiceRepository.AddItemAsync(InvoiceItem item, CancellationToken ct)
+        => await AddItemInternalAsync(item, ct);
+
+    private async Task<int> AddItemInternalAsync(InvoiceItem item, CancellationToken ct = default)
     {
         _db.InvoiceItems.Add(item);
         await _db.SaveChangesAsync(ct);

--- a/docs/progress/2025-07-01_12-46-02_code_agent.md
+++ b/docs/progress/2025-07-01_12-46-02_code_agent.md
@@ -1,0 +1,2 @@
+- Implemented AddItemAsync as explicit interface method in InvoiceRepository.
+- Builds and tests pass with new method.


### PR DESCRIPTION
## Summary
- implement `IInvoiceRepository.AddItemAsync` explicitly
- log progress

## Testing
- `dotnet build Wrecept.Storage/Wrecept.Storage.csproj`
- `dotnet test Wrecept.Core.Tests/Wrecept.Core.Tests.csproj --verbosity normal`


------
https://chatgpt.com/codex/tasks/task_e_6863d735f9188322be3b8ecf138b6b6a