### PR TITLE
Fix invoice editor command access

### DIFF
--- a/Wrecept.Core.Tests/Services/InvoiceServiceTests.cs
+++ b/Wrecept.Core.Tests/Services/InvoiceServiceTests.cs
@@ -25,6 +25,9 @@ public class InvoiceServiceTests
         public Task<Invoice?> GetAsync(int id, CancellationToken ct = default) => Task.FromResult<Invoice?>(null);
         public Task<List<Invoice>> GetRecentAsync(int count, CancellationToken ct = default) => Task.FromResult(new List<Invoice>());
 
+        public Task<LastUsageData?> GetLastUsageDataAsync(int supplierId, int productId, CancellationToken ct = default)
+            => Task.FromResult<LastUsageData?>(null);
+
         public int UpdatedId;
         public bool Archived;
     }

--- a/Wrecept.Wpf/ViewModels/InvoiceEditorViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/InvoiceEditorViewModel.cs
@@ -389,7 +389,7 @@ private void UpdateSupplierId(string name)
     }
 
     [RelayCommand]
-    private async Task AddLineItemAsync()
+    internal async Task AddLineItemAsync()
     {
         if (!IsEditable)
         {
@@ -484,7 +484,7 @@ private void UpdateSupplierId(string name)
     }
 
     [RelayCommand]
-    private async Task ArchiveAsync()
+    internal async Task ArchiveAsync()
     {
         if (IsArchived)
             return;

--- a/docs/progress/2025-07-01_16-31-03_code_agent.md
+++ b/docs/progress/2025-07-01_16-31-03_code_agent.md
@@ -1,0 +1,3 @@
+- InvoiceEditorViewModel: AddLineItemAsync és ArchiveAsync módosítva internal hozzáférésűre, hogy más ViewModel-ek hívhassák
+- FakeInvoiceRepository bővítve GetLastUsageDataAsync stub implementációval
+- Core tesztek sikeresen lefutnak


### PR DESCRIPTION
## Summary
- make AddLineItemAsync and ArchiveAsync internal so prompt VMs can call them
- stub GetLastUsageDataAsync in InvoiceServiceTests
- log progress

## Testing
- `dotnet test Wrecept.Core.Tests/Wrecept.Core.Tests.csproj --no-restore`
- `dotnet build Wrecept.sln --no-restore` *(fails: Microsoft.NET.Sdk.WindowsDesktop)*

------
https://chatgpt.com/codex/tasks/task_e_68640c57a7f88322869425e407c474a2