### PR TITLE
Fix SaveLinePrompt XAML alias

### DIFF
--- a/Wrecept.Wpf/Views/InvoiceEditorView.xaml
+++ b/Wrecept.Wpf/Views/InvoiceEditorView.xaml
@@ -5,6 +5,7 @@
             xmlns:vm="clr-namespace:Wrecept.Wpf.ViewModels"
             xmlns:view="clr-namespace:Wrecept.Wpf.Views"
             xmlns:views="clr-namespace:Wrecept.Wpf.Views.InlineCreators"
+            xmlns:prompt="clr-namespace:Wrecept.Wpf.Views.InlinePrompts"
             xmlns:c="clr-namespace:Wrecept.Wpf.Views.Controls"
             KeyDown="OnKeyDown">
     <UserControl.Resources>
@@ -25,10 +26,10 @@
             <views:PaymentMethodCreatorView/>
         </DataTemplate>
         <DataTemplate DataType="{x:Type vm:SaveLinePromptViewModel}">
-            <views:SaveLinePromptView/>
+            <prompt:SaveLinePromptView/>
         </DataTemplate>
         <DataTemplate DataType="{x:Type vm:ArchivePromptViewModel}">
-            <views:ArchivePromptView/>
+            <prompt:ArchivePromptView/>
         </DataTemplate>
     </UserControl.Resources>
     <Grid>

--- a/docs/progress/2025-07-01_16-36-32_code_agent.md
+++ b/docs/progress/2025-07-01_16-36-32_code_agent.md
@@ -1,0 +1,3 @@
+- InvoiceEditorView.xaml: új 'prompt' névtér alias és használat az archív és mentési promptokhoz
+- dotnet-sdk telepítve a tesztek futtatásához
+- Core tesztek sikeresen lefutnak


### PR DESCRIPTION
## Summary
- add proper namespace alias for InlinePrompts in InvoiceEditorView
- update DataTemplates for SaveLine and Archive prompts
- document changes in progress log

## Testing
- `dotnet build Wrecept.Core.Tests/Wrecept.Core.Tests.csproj -v minimal`
- `dotnet test Wrecept.Core.Tests/Wrecept.Core.Tests.csproj -v minimal --no-build`

------
https://chatgpt.com/codex/tasks/task_e_68640dbfb8008322b383039a3324092e