### PR TITLE
Improve keyboard navigation in invoice editor

### DIFF
--- a/Wrecept.Core/Utilities/NumberToWordsConverter.cs
+++ b/Wrecept.Core/Utilities/NumberToWordsConverter.cs
@@ -1,0 +1,50 @@
+using System.Collections.Generic;
+
+namespace Wrecept.Core.Utilities;
+
+public static class NumberToWordsConverter
+{
+    private static readonly string[] Ones = { "nul", "egy", "kettő", "három", "négy", "öt", "hat", "hét", "nyolc", "kilenc" };
+    private static readonly string[] Tens = { "", "tíz", "húsz", "harminc", "negyven", "ötven", "hatvan", "hetven", "nyolcvan", "kilencven" };
+
+    public static string Convert(long number)
+    {
+        if (number == 0) return "nulla";
+        if (number < 0) return "mínusz " + Convert(-number);
+        var parts = new List<string>();
+        if (number / 1000000 > 0)
+        {
+            parts.Add(Convert(number / 1000000) + " millió");
+            number %= 1000000;
+        }
+        if (number / 1000 > 0)
+        {
+            parts.Add(Convert(number / 1000) + " ezer");
+            number %= 1000;
+        }
+        if (number / 100 > 0)
+        {
+            if (number / 100 == 1)
+                parts.Add("száz");
+            else
+                parts.Add(Ones[number / 100] + "száz");
+            number %= 100;
+        }
+        if (number >= 10)
+        {
+            var t = number / 10;
+            var o = number % 10;
+            if (o == 0)
+                parts.Add(Tens[t]);
+            else if (t == 1)
+                parts.Add("tizen" + Ones[o]);
+            else
+                parts.Add(Tens[t] + "" + Ones[o]);
+        }
+        else if (number > 0)
+        {
+            parts.Add(Ones[number]);
+        }
+        return string.Join(" ", parts);
+    }
+}

--- a/Wrecept.Wpf/Converters/IsReadOnlyBindingConverter.cs
+++ b/Wrecept.Wpf/Converters/IsReadOnlyBindingConverter.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace Wrecept.Wpf.Converters;
+
+public class IsReadOnlyBindingConverter : IValueConverter
+{
+    public bool Invert { get; set; }
+
+    public object Convert(object value, Type targetType, object? parameter, CultureInfo culture)
+        => value is bool b && (Invert ? !b : b);
+
+    public object ConvertBack(object value, Type targetType, object? parameter, CultureInfo culture)
+        => Binding.DoNothing;
+}

--- a/Wrecept.Wpf/Services/MessageBoxNotificationService.NonWindows.cs
+++ b/Wrecept.Wpf/Services/MessageBoxNotificationService.NonWindows.cs
@@ -1,0 +1,12 @@
+#if !WINDOWS
+using Wrecept.Core.Services;
+
+namespace Wrecept.Wpf.Services;
+
+public class MessageBoxNotificationService : INotificationService
+{
+    public void ShowError(string message) { }
+    public void ShowInfo(string message) { }
+    public bool Confirm(string message) => true;
+}
+#endif

--- a/Wrecept.Wpf/Views/InvoiceEditorView.xaml
+++ b/Wrecept.Wpf/Views/InvoiceEditorView.xaml
@@ -10,6 +10,7 @@
             KeyDown="OnKeyDown">
     <UserControl.Resources>
         <local:NegativeValueForegroundConverter x:Key="NegativeForegroundConverter" />
+        <local:IsReadOnlyBindingConverter x:Key="IsReadOnlyConverter" />
         <DataTemplate DataType="{x:Type vm:ProductCreatorViewModel}">
             <views:ProductCreatorView/>
         </DataTemplate>
@@ -86,6 +87,19 @@
         </Button>
 
         <view:InvoiceItemsGrid x:Name="ItemsGrid" />
+        <ItemsControl ItemsSource="{Binding VatSummaries}" Margin="0,4,0,0">
+            <ItemsControl.ItemTemplate>
+                <DataTemplate>
+                    <TextBlock>
+                        <Run Text="{Binding Rate}" />
+                        <Run Text=" - nettó " />
+                        <Run Text="{Binding Net}" />
+                        <Run Text=" ÁFA " />
+                        <Run Text="{Binding Vat}" />
+                    </TextBlock>
+                </DataTemplate>
+            </ItemsControl.ItemTemplate>
+        </ItemsControl>
         <StackPanel Orientation="Horizontal" Margin="0,4,0,0">
             <TextBlock Text="Nettó:" Width="60" />
             <TextBlock Text="{Binding NetTotal}" Width="80" />
@@ -94,6 +108,7 @@
             <TextBlock Text="Bruttó:" Width="60" Margin="20,0,0,0" />
             <TextBlock Text="{Binding GrossTotal}" Width="80" />
         </StackPanel>
+        <TextBlock Text="Azaz: {Binding AmountInWords}" Margin="0,0,0,4" />
         <TextBlock Text="Negatív mennyiség visszárut jelez." FontStyle="Italic" Margin="0,4,0,0"/>
         <ContentControl Content="{Binding SavePrompt}" Visibility="{Binding IsSavePromptVisible, Converter={StaticResource BooleanToVisibilityConverter}}" />
         <ContentControl Content="{Binding ArchivePrompt}" Visibility="{Binding IsArchivePromptVisible, Converter={StaticResource BooleanToVisibilityConverter}}" />

--- a/Wrecept.Wpf/Views/InvoiceItemsGrid.xaml
+++ b/Wrecept.Wpf/Views/InvoiceItemsGrid.xaml
@@ -7,8 +7,9 @@
         <local:QuantityToStyleConverter x:Key="QuantityToStyleConverter" />
         <local:NegativeValueForegroundConverter x:Key="NegativeForegroundConverter" />
     </UserControl.Resources>
-    <DataGrid x:Name="Grid" ItemsSource="{Binding Items}" AutoGenerateColumns="False" IsEnabled="{Binding IsEditable}"
-              KeyDown="OnKeyDown" RowDetailsVisibilityMode="Collapsed">
+    <DataGrid x:Name="Grid" ItemsSource="{Binding Items}" AutoGenerateColumns="False"
+             IsReadOnly="{Binding IsArchived, Converter={StaticResource IsReadOnlyConverter}}"
+             KeyDown="OnKeyDown" RowDetailsVisibilityMode="Collapsed">
         <DataGrid.RowStyle>
             <Style TargetType="DataGridRow">
                 <Setter Property="Background" Value="{Binding Quantity, Converter={StaticResource QuantityToStyleConverter}}" />
@@ -57,30 +58,6 @@
                     </DataTemplate>
                 </DataGridTemplateColumn.CellTemplate>
             </DataGridTemplateColumn>
-            <DataGridTextColumn Header="Csop." Binding="{Binding ProductGroup}" Width="100" IsReadOnly="True" />
-            <DataGridTemplateColumn Header="Me.e.">
-                <DataGridTemplateColumn.CellTemplate>
-                    <DataTemplate>
-                        <Grid>
-                            <c:EditLookup x:Name="Editor"
-                                         ItemsSource="{Binding DataContext.Units, RelativeSource={RelativeSource AncestorType=UserControl}}"
-                                         DisplayMemberPath="Name"
-                                         SelectedValuePath="Id"
-                                         SelectedValue="{Binding UnitId, Mode=TwoWay}"
-                                         CreateCommand="{Binding DataContext.ShowUnitCreatorCommand, RelativeSource={RelativeSource AncestorType=UserControl}}" />
-                            <TextBlock x:Name="Text" Text="{Binding UnitName}" />
-                        </Grid>
-                        <DataTemplate.Triggers>
-                            <DataTrigger Binding="{Binding IsEditable}" Value="False">
-                                <Setter TargetName="Editor" Property="Visibility" Value="Collapsed" />
-                            </DataTrigger>
-                            <DataTrigger Binding="{Binding IsEditable}" Value="True">
-                                <Setter TargetName="Text" Property="Visibility" Value="Collapsed" />
-                            </DataTrigger>
-                        </DataTemplate.Triggers>
-                    </DataTemplate>
-                </DataGridTemplateColumn.CellTemplate>
-            </DataGridTemplateColumn>
             <DataGridTemplateColumn Header="Menny." Width="80">
                 <DataGridTemplateColumn.CellTemplate>
                     <DataTemplate>
@@ -100,6 +77,29 @@
                             <DataTrigger Binding="{Binding IsAutofilled}" Value="True">
                                 <Setter TargetName="Editor" Property="FontStyle" Value="Italic" />
                                 <Setter TargetName="Text" Property="FontStyle" Value="Italic" />
+                            </DataTrigger>
+                        </DataTemplate.Triggers>
+                    </DataTemplate>
+                </DataGridTemplateColumn.CellTemplate>
+            </DataGridTemplateColumn>
+            <DataGridTemplateColumn Header="Me.e.">
+                <DataGridTemplateColumn.CellTemplate>
+                    <DataTemplate>
+                        <Grid>
+                            <c:EditLookup x:Name="Editor"
+                                         ItemsSource="{Binding DataContext.Units, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                         DisplayMemberPath="Name"
+                                         SelectedValuePath="Id"
+                                         SelectedValue="{Binding UnitId, Mode=TwoWay}"
+                                         CreateCommand="{Binding DataContext.ShowUnitCreatorCommand, RelativeSource={RelativeSource AncestorType=UserControl}}" />
+                            <TextBlock x:Name="Text" Text="{Binding UnitName}" />
+                        </Grid>
+                        <DataTemplate.Triggers>
+                            <DataTrigger Binding="{Binding IsEditable}" Value="False">
+                                <Setter TargetName="Editor" Property="Visibility" Value="Collapsed" />
+                            </DataTrigger>
+                            <DataTrigger Binding="{Binding IsEditable}" Value="True">
+                                <Setter TargetName="Text" Property="Visibility" Value="Collapsed" />
                             </DataTrigger>
                         </DataTemplate.Triggers>
                     </DataTemplate>
@@ -154,6 +154,7 @@
                     </DataTemplate>
                 </DataGridTemplateColumn.CellTemplate>
             </DataGridTemplateColumn>
+            <DataGridTextColumn Header="Csop." Binding="{Binding ProductGroup}" Width="100" IsReadOnly="True" />
         </DataGrid.Columns>
         <DataGrid.RowDetailsTemplate>
             <DataTemplate>

--- a/Wrecept.Wpf/Views/InvoiceLookupView.xaml.cs
+++ b/Wrecept.Wpf/Views/InvoiceLookupView.xaml.cs
@@ -4,6 +4,7 @@ using System.Windows.Controls;
 using System.Windows.Input;
 using Microsoft.Extensions.DependencyInjection;
 using Wrecept.Wpf.ViewModels;
+using Wrecept.Wpf;
 
 namespace Wrecept.Wpf.Views;
 
@@ -28,15 +29,25 @@ public partial class InvoiceLookupView : UserControl
 
     private void OnKeyDown(object sender, KeyEventArgs e)
     {
-        if (DataContext is InvoiceLookupViewModel vm && e.Key == Key.Up && InvoiceList.SelectedIndex == 0)
+        if (DataContext is InvoiceLookupViewModel vm)
         {
-            if (vm.InlinePrompt is null)
+            if (e.Key == Key.Up && InvoiceList.SelectedIndex == 0)
             {
-                var number = DateTime.Now.ToString("yyyyMMddHHmmss");
-                vm.InlinePrompt = new InvoiceCreatePromptViewModel(vm, number);
+                if (vm.InlinePrompt is null)
+                {
+                    var number = DateTime.Now.ToString("yyyyMMddHHmmss");
+                    vm.InlinePrompt = new InvoiceCreatePromptViewModel(vm, number);
+                }
+                e.Handled = true;
+                return;
             }
-            e.Handled = true;
-            return;
+            if (e.Key == Key.Enter)
+            {
+                if (this.FindAncestor<InvoiceEditorView>()?.DataContext is InvoiceEditorViewModel parent)
+                    parent.OpenSelectedInvoiceCommand.Execute(null);
+                e.Handled = true;
+                return;
+            }
         }
         NavigationHelper.Handle(e);
     }

--- a/Wrecept.Wpf/VisualTreeExtensions.cs
+++ b/Wrecept.Wpf/VisualTreeExtensions.cs
@@ -1,0 +1,15 @@
+using System.Windows;
+using System.Windows.Media;
+
+namespace Wrecept.Wpf;
+
+public static class VisualTreeExtensions
+{
+    public static T? FindAncestor<T>(this DependencyObject obj) where T : DependencyObject
+    {
+        DependencyObject? parent = VisualTreeHelper.GetParent(obj);
+        while (parent != null && parent is not T)
+            parent = VisualTreeHelper.GetParent(parent);
+        return parent as T;
+    }
+}

--- a/docs/progress/2025-07-01_19-02-28_code_agent.md
+++ b/docs/progress/2025-07-01_19-02-28_code_agent.md
@@ -1,0 +1,8 @@
+- InvoiceEditorViewModel frissítve: kiválasztott számla csak Enterre nyílik meg
+  (OpenSelectedInvoiceCommand).
+- InvoiceLookupView KeyDown most Enter esetén parent parancsot hív.
+- InvoiceItemsGrid oszlopai átrendezve a specifikus sorrendre.
+- Összesítés VAT kulcsonként megjelenik (VatSummaries, AmountInWords).
+- Új konverterek és helper osztályok hozzáadva (NumberToWordsConverter,
+  IsReadOnlyBindingConverter, VisualTreeExtensions).
+- MessageBoxNotificationService stub készült nem-Windows környezethez.


### PR DESCRIPTION
## Summary
- fix invoice list handling: open selected entry only on Enter
- rearrange invoice item columns to match expected order
- show per-VAT summaries and amount in words
- add helper utilities and converters for keyboard-only workflow
- provide notification service stub for non-Windows builds
- document progress

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68642ec40e108322ba549cadbb66299a