### PR TITLE
Fix build warnings

### DIFF
--- a/Wrecept.Storage/Repositories/InvoiceRepository.cs
+++ b/Wrecept.Storage/Repositories/InvoiceRepository.cs
@@ -75,8 +75,8 @@ public class InvoiceRepository : IInvoiceRepository
     {
         return await _db.InvoiceItems
             .Include(i => i.Invoice)
-            .Where(i => i.Invoice.SupplierId == supplierId && i.ProductId == productId)
-            .OrderByDescending(i => i.Invoice.Date)
+            .Where(i => i.Invoice!.SupplierId == supplierId && i.ProductId == productId)
+            .OrderByDescending(i => i.Invoice!.Date)
             .Select(i => new LastUsageData
             {
                 Quantity = i.Quantity,

--- a/Wrecept.Wpf/App.xaml.cs
+++ b/Wrecept.Wpf/App.xaml.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Wrecept.Core;
+using Wrecept.Core.Services;
 using Wrecept.Storage;
 using Wrecept.Wpf.ViewModels;
 using Wrecept.Wpf.Views;

--- a/docs/progress/2025-07-01_19-19-49_code_agent.md
+++ b/docs/progress/2025-07-01_19-19-49_code_agent.md
@@ -1,0 +1,2 @@
+- Kompilációs hibák javítva: App.xaml.cs-ben hiányzó using beillesztve (Wrecept.Core.Services).
+- InvoiceRepository nullérzékeny figyelmeztetései megszüntetve (! operátor használatával).


### PR DESCRIPTION
## Summary
- import INotificationService namespace
- fix nullability warnings in InvoiceRepository
- log compilation fix

## Testing
- `dotnet build Wrecept.Core/Wrecept.Core.csproj --no-restore`
- `dotnet build Wrecept.Storage/Wrecept.Storage.csproj --no-restore`
- `dotnet build Wrecept.Wpf/Wrecept.Wpf.csproj --no-restore` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*
- `dotnet test Wrecept.Core.Tests/Wrecept.Core.Tests.csproj --no-build` *(fails: invalid argument)*

------
https://chatgpt.com/codex/tasks/task_e_68643417add4832284f8ce628a812bd7