### PR TITLE
Fix IsReadOnlyConverter resource

### DIFF
--- a/Wrecept.Wpf/Views/InvoiceItemsGrid.xaml
+++ b/Wrecept.Wpf/Views/InvoiceItemsGrid.xaml
@@ -6,6 +6,7 @@
     <UserControl.Resources>
         <local:QuantityToStyleConverter x:Key="QuantityToStyleConverter" />
         <local:NegativeValueForegroundConverter x:Key="NegativeForegroundConverter" />
+        <local:IsReadOnlyBindingConverter x:Key="IsReadOnlyConverter" />
     </UserControl.Resources>
     <DataGrid x:Name="Grid" ItemsSource="{Binding Items}" AutoGenerateColumns="False"
              IsReadOnly="{Binding IsArchived, Converter={StaticResource IsReadOnlyConverter}}"

--- a/docs/progress/2025-07-01_19-24-46_code_agent.md
+++ b/docs/progress/2025-07-01_19-24-46_code_agent.md
@@ -1,0 +1,1 @@
+- InvoiceItemsGrid XAML now includes IsReadOnlyBindingConverter resource to avoid runtime errors.


### PR DESCRIPTION
## Summary
- ensure InvoiceItemsGrid can resolve `IsReadOnlyConverter`
- log progress

## Testing
- `dotnet test tests/Wrecept.Tests/Wrecept.Tests.csproj --no-build` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_686435967e78832299c4569637bfa032