### PR TITLE
Refactor InvoiceEditor layout

### DIFF
--- a/Wrecept.Wpf/Converters/InvoiceLineTotalsConverter.cs
+++ b/Wrecept.Wpf/Converters/InvoiceLineTotalsConverter.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Windows.Data;
+using Wrecept.Core.Models;
+
+namespace Wrecept.Wpf.Converters;
+
+public class InvoiceLineTotalsConverter : IMultiValueConverter
+{
+    public InvoiceLineTotalsConverterMode Mode { get; set; } = InvoiceLineTotalsConverterMode.Net;
+
+    public object Convert(object[] values, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (values.Length < 5)
+            return Binding.DoNothing;
+        if (values[0] is not decimal qty ||
+            values[1] is not decimal price ||
+            values[2] is not Guid taxId ||
+            values[3] is not bool isGross ||
+            values[4] is not IEnumerable<TaxRate> taxes)
+            return Binding.DoNothing;
+
+        var rate = taxes.FirstOrDefault(t => t.Id == taxId)?.Percentage ?? 0m;
+        var netUnit = isGross ? price / (1 + rate / 100m) : price;
+        var net = qty * netUnit;
+        var vat = net * rate / 100m;
+        var gross = net + vat;
+        return Mode switch
+        {
+            InvoiceLineTotalsConverterMode.Net => net,
+            InvoiceLineTotalsConverterMode.Vat => vat,
+            InvoiceLineTotalsConverterMode.Gross => gross,
+            _ => net,
+        };
+    }
+
+    public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
+        => throw new NotImplementedException();
+}
+
+public enum InvoiceLineTotalsConverterMode
+{
+    Net,
+    Vat,
+    Gross
+}

--- a/Wrecept.Wpf/Views/Controls/TotalsPanel.xaml
+++ b/Wrecept.Wpf/Views/Controls/TotalsPanel.xaml
@@ -1,0 +1,28 @@
+<UserControl x:Class="Wrecept.Wpf.Views.Controls.TotalsPanel"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <StackPanel>
+        <ItemsControl ItemsSource="{Binding VatSummaries}">
+            <ItemsControl.ItemTemplate>
+                <DataTemplate>
+                    <TextBlock>
+                        <Run Text="{Binding Rate}" />
+                        <Run Text=" - nettó " />
+                        <Run Text="{Binding Net}" />
+                        <Run Text=" ÁFA " />
+                        <Run Text="{Binding Vat}" />
+                    </TextBlock>
+                </DataTemplate>
+            </ItemsControl.ItemTemplate>
+        </ItemsControl>
+        <StackPanel Orientation="Horizontal" Margin="0,4,0,0">
+            <TextBlock Text="Nettó:" Width="60" />
+            <TextBlock Text="{Binding NetTotal}" Width="80" TextAlignment="Right" />
+            <TextBlock Text="ÁFA:" Width="40" Margin="20,0,0,0" />
+            <TextBlock Text="{Binding VatTotal}" Width="80" TextAlignment="Right" />
+            <TextBlock Text="Bruttó:" Width="60" Margin="20,0,0,0" />
+            <TextBlock Text="{Binding GrossTotal}" Width="80" TextAlignment="Right" />
+        </StackPanel>
+        <TextBlock Text="{Binding AmountInWords, StringFormat=Azaz: {0}}" Margin="0,0,0,4" />
+    </StackPanel>
+</UserControl>

--- a/Wrecept.Wpf/Views/Controls/TotalsPanel.xaml.cs
+++ b/Wrecept.Wpf/Views/Controls/TotalsPanel.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace Wrecept.Wpf.Views.Controls;
+
+public partial class TotalsPanel : UserControl
+{
+    public TotalsPanel()
+    {
+        InitializeComponent();
+    }
+}

--- a/Wrecept.Wpf/Views/InvoiceEditorView.xaml
+++ b/Wrecept.Wpf/Views/InvoiceEditorView.xaml
@@ -42,76 +42,90 @@
         <view:InvoiceLookupView x:Name="LookupView" DataContext="{Binding Lookup}" />
 
         <StackPanel Grid.Column="1" Margin="4">
-        <TextBlock Text="Számla" FontWeight="Bold" Margin="0,0,0,6" />
+            <StackPanel>
+                <TextBlock Text="Számla" FontWeight="Bold" Margin="0,0,0,6" />
 
-        <StackPanel Orientation="Horizontal" Margin="0,0,0,4">
-            <TextBlock Text="Szállító" Width="70" />
-            <c:EditLookup Width="200"
-                          ItemsSource="{Binding Suppliers}"
-                          DisplayMemberPath="Name"
-                          SelectedValuePath="Id"
-                          SelectedValue="{Binding SupplierId}"
-                          CreateCommand="{Binding ShowSupplierCreatorCommand}"
-                          IsEnabled="{Binding IsEditable}" />
-        </StackPanel>
-        <StackPanel Orientation="Horizontal" Margin="0,0,0,4">
-            <TextBlock Text="Dátum" Width="70" />
-            <DatePicker SelectedDate="{Binding InvoiceDate}" Width="120" IsEnabled="{Binding IsEditable}" />
-        </StackPanel>
-        <StackPanel Orientation="Horizontal" Margin="0,0,0,4">
-            <TextBlock Text="Szám" Width="70" />
-            <TextBox Width="120" Text="{Binding Number}" IsEnabled="{Binding IsNew}" />
-        </StackPanel>
-        <StackPanel Orientation="Horizontal" Margin="0,0,0,4">
-            <TextBlock Text="Fiz. mód" Width="70" />
-            <c:EditLookup Width="200"
-                          ItemsSource="{Binding PaymentMethods}"
-                          DisplayMemberPath="Name"
-                          SelectedValuePath="Id"
-                          SelectedValue="{Binding PaymentMethodId}"
-                          CreateCommand="{Binding ShowPaymentMethodCreatorCommand}"
-                          IsEnabled="{Binding IsEditable}" />
-        </StackPanel>
-        <CheckBox Content="Bruttó ár" IsChecked="{Binding IsGross}" Margin="0,0,0,4" IsEnabled="{Binding IsEditable}" />
+                <StackPanel Orientation="Horizontal" Margin="0,0,0,4">
+                    <TextBlock Text="Szállító" Width="70" />
+                    <c:EditLookup Width="200"
+                                  ItemsSource="{Binding Suppliers}"
+                                  DisplayMemberPath="Name"
+                                  SelectedValuePath="Id"
+                                  SelectedValue="{Binding SupplierId}"
+                                  CreateCommand="{Binding ShowSupplierCreatorCommand}"
+                                  IsEnabled="{Binding IsEditable}" />
+                </StackPanel>
+                <StackPanel Orientation="Horizontal" Margin="0,0,0,4">
+                    <TextBlock Text="Dátum" Width="70" />
+                    <DatePicker SelectedDate="{Binding InvoiceDate}" Width="120" IsEnabled="{Binding IsEditable}" />
+                </StackPanel>
+                <StackPanel Orientation="Horizontal" Margin="0,0,0,4">
+                    <TextBlock Text="Szám" Width="70" />
+                    <TextBox Width="120" Text="{Binding Number}" IsEnabled="{Binding IsNew}" />
+                </StackPanel>
+                <StackPanel Orientation="Horizontal" Margin="0,0,0,4">
+                    <TextBlock Text="Fiz. mód" Width="70" />
+                    <c:EditLookup Width="200"
+                                  ItemsSource="{Binding PaymentMethods}"
+                                  DisplayMemberPath="Name"
+                                  SelectedValuePath="Id"
+                                  SelectedValue="{Binding PaymentMethodId}"
+                                  CreateCommand="{Binding ShowPaymentMethodCreatorCommand}"
+                                  IsEnabled="{Binding IsEditable}" />
+                </StackPanel>
+                <CheckBox Content="Bruttó ár" IsChecked="{Binding IsGross}" Margin="0,0,0,4" IsEnabled="{Binding IsEditable}" />
+            </StackPanel>
+            <Separator Margin="0,6" />
 
-        <Button Content="📦 Véglegesítés" Command="{Binding ShowArchivePromptCommand}">
-            <Button.Style>
-                <Style TargetType="Button">
-                    <Style.Triggers>
-                        <DataTrigger Binding="{Binding IsArchived}" Value="True">
-                            <Setter Property="Visibility" Value="Collapsed" />
-                        </DataTrigger>
-                    </Style.Triggers>
-                </Style>
-            </Button.Style>
-        </Button>
+            <StackPanel Orientation="Horizontal" DataContext="{Binding Items[0]}" KeyDown="OnEntryKeyDown" Margin="0,0,0,4">
+                <c:EditLookup x:Name="EntryProduct" Width="200"
+                              ItemsSource="{Binding DataContext.Products, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                              DisplayMemberPath="Name"
+                              SelectedValuePath="Name"
+                              SelectedValue="{Binding Product, Mode=TwoWay}"/>
+                <TextBox x:Name="EntryQuantity" Width="60" Margin="4,0" Text="{Binding Quantity, Mode=TwoWay}"/>
+                <c:EditLookup x:Name="EntryUnit" Width="80"
+                              ItemsSource="{Binding DataContext.Units, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                              DisplayMemberPath="Name"
+                              SelectedValuePath="Id"
+                              SelectedValue="{Binding UnitId, Mode=TwoWay}"/>
+                <TextBox x:Name="EntryPrice" Width="80" Margin="4,0" Text="{Binding UnitPrice, Mode=TwoWay}"/>
+                <c:EditLookup x:Name="EntryTax" Width="100"
+                              ItemsSource="{Binding DataContext.TaxRates, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                              DisplayMemberPath="Name"
+                              SelectedValuePath="Id"
+                              SelectedValue="{Binding TaxRateId, Mode=TwoWay}"/>
+            </StackPanel>
 
-        <view:InvoiceItemsGrid x:Name="ItemsGrid" />
-        <ItemsControl ItemsSource="{Binding VatSummaries}" Margin="0,4,0,0">
-            <ItemsControl.ItemTemplate>
-                <DataTemplate>
-                    <TextBlock>
-                        <Run Text="{Binding Rate}" />
-                        <Run Text=" - nettó " />
-                        <Run Text="{Binding Net}" />
-                        <Run Text=" ÁFA " />
-                        <Run Text="{Binding Vat}" />
-                    </TextBlock>
-                </DataTemplate>
-            </ItemsControl.ItemTemplate>
-        </ItemsControl>
-        <StackPanel Orientation="Horizontal" Margin="0,4,0,0">
-            <TextBlock Text="Nettó:" Width="60" />
-            <TextBlock Text="{Binding NetTotal}" Width="80" />
-            <TextBlock Text="ÁFA:" Width="40" Margin="20,0,0,0" />
-            <TextBlock Text="{Binding VatTotal}" Width="80" />
-            <TextBlock Text="Bruttó:" Width="60" Margin="20,0,0,0" />
-            <TextBlock Text="{Binding GrossTotal}" Width="80" />
+            <Separator Margin="0,6" />
+
+            <view:InvoiceItemsGrid x:Name="ItemsGrid" Margin="0,4,0,0" />
+
+            <Separator Margin="0,6" />
+
+            <c:TotalsPanel />
+
+            <TextBlock Text="Negatív mennyiség visszárut jelez." FontStyle="Italic" Margin="0,4" />
+
+            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,6">
+                <Button Content="Mentés" Command="{Binding SaveCommand}" Margin="0,0,4,0" />
+                <Button Content="Nyomtatás" IsEnabled="{Binding IsArchived}" Margin="0,0,4,0" />
+                <Button Content="Bezárás" Command="{Binding CloseCommand}" Margin="0,0,4,0" />
+                <Button Content="📦 Véglegesítés" Command="{Binding ShowArchivePromptCommand}">
+                    <Button.Style>
+                        <Style TargetType="Button">
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding IsArchived}" Value="True">
+                                    <Setter Property="Visibility" Value="Collapsed" />
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </Button.Style>
+                </Button>
+            </StackPanel>
+
+            <ContentControl Content="{Binding SavePrompt}" Visibility="{Binding IsSavePromptVisible, Converter={StaticResource BooleanToVisibilityConverter}}" />
+            <ContentControl Content="{Binding ArchivePrompt}" Visibility="{Binding IsArchivePromptVisible, Converter={StaticResource BooleanToVisibilityConverter}}" />
         </StackPanel>
-        <TextBlock Text="Azaz: {Binding AmountInWords}" Margin="0,0,0,4" />
-        <TextBlock Text="Negatív mennyiség visszárut jelez." FontStyle="Italic" Margin="0,4,0,0"/>
-        <ContentControl Content="{Binding SavePrompt}" Visibility="{Binding IsSavePromptVisible, Converter={StaticResource BooleanToVisibilityConverter}}" />
-        <ContentControl Content="{Binding ArchivePrompt}" Visibility="{Binding IsArchivePromptVisible, Converter={StaticResource BooleanToVisibilityConverter}}" />
-    </StackPanel>
     </Grid>
 </UserControl>

--- a/Wrecept.Wpf/Views/InvoiceEditorView.xaml.cs
+++ b/Wrecept.Wpf/Views/InvoiceEditorView.xaml.cs
@@ -44,4 +44,19 @@ public partial class InvoiceEditorView : UserControl
         }
         NavigationHelper.Handle(e);
     }
+
+    private void OnEntryKeyDown(object sender, KeyEventArgs e)
+    {
+        if (DataContext is not InvoiceEditorViewModel vm)
+            return;
+        if (e.Key == Key.Enter && e.OriginalSource is FrameworkElement { Name: "EntryTax" })
+        {
+            vm.AddLineItemCommand.Execute(null);
+            e.Handled = true;
+        }
+        else
+        {
+            NavigationHelper.Handle(e);
+        }
+    }
 }

--- a/Wrecept.Wpf/Views/InvoiceItemsGrid.xaml
+++ b/Wrecept.Wpf/Views/InvoiceItemsGrid.xaml
@@ -7,30 +7,25 @@
         <local:QuantityToStyleConverter x:Key="QuantityToStyleConverter" />
         <local:NegativeValueForegroundConverter x:Key="NegativeForegroundConverter" />
         <local:IsReadOnlyBindingConverter x:Key="IsReadOnlyConverter" />
+        <local:InvoiceLineTotalsConverter x:Key="NetConverter" Mode="Net" />
+        <local:InvoiceLineTotalsConverter x:Key="VatConverter" Mode="Vat" />
+        <local:InvoiceLineTotalsConverter x:Key="GrossConverter" Mode="Gross" />
     </UserControl.Resources>
     <DataGrid x:Name="Grid" ItemsSource="{Binding Items}" AutoGenerateColumns="False"
-             IsReadOnly="{Binding IsArchived, Converter={StaticResource IsReadOnlyConverter}}"
+             IsReadOnly="True"
              KeyDown="OnKeyDown" RowDetailsVisibilityMode="Collapsed">
         <DataGrid.RowStyle>
             <Style TargetType="DataGridRow">
                 <Setter Property="Background" Value="{Binding Quantity, Converter={StaticResource QuantityToStyleConverter}}" />
                 <Style.Triggers>
-                    <DataTrigger Binding="{Binding IsEditable}" Value="True">
-                        <Setter Property="BorderBrush" Value="Blue" />
-                        <Setter Property="BorderThickness" Value="1" />
-                    </DataTrigger>
                     <DataTrigger Binding="{Binding HasError}" Value="True">
                         <Setter Property="BorderBrush" Value="Red" />
                         <Setter Property="BorderThickness" Value="2" />
                         <Setter Property="ToolTip" Value="{Binding ErrorMessage}" />
                     </DataTrigger>
-                    <MultiDataTrigger>
-                        <MultiDataTrigger.Conditions>
-                            <Condition Binding="{Binding IsFirstRow}" Value="True" />
-                            <Condition Binding="{Binding DataContext.IsInlineCreatorVisible, RelativeSource={RelativeSource AncestorType=UserControl}}" Value="True" />
-                        </MultiDataTrigger.Conditions>
-                        <Setter Property="DetailsVisibility" Value="Visible" />
-                    </MultiDataTrigger>
+                    <DataTrigger Binding="{Binding IsFirstRow}" Value="True">
+                        <Setter Property="Visibility" Value="Collapsed" />
+                    </DataTrigger>
                 </Style.Triggers>
             </Style>
         </DataGrid.RowStyle>
@@ -156,6 +151,39 @@
                 </DataGridTemplateColumn.CellTemplate>
             </DataGridTemplateColumn>
             <DataGridTextColumn Header="Csop." Binding="{Binding ProductGroup}" Width="100" IsReadOnly="True" />
+            <DataGridTextColumn Header="Nettó" Width="90" IsReadOnly="True">
+                <DataGridTextColumn.Binding>
+                    <MultiBinding Converter="{StaticResource NetConverter}" StringFormat="F2">
+                        <Binding Path="Quantity" />
+                        <Binding Path="UnitPrice" />
+                        <Binding Path="TaxRateId" />
+                        <Binding Path="DataContext.IsGross" RelativeSource="{RelativeSource AncestorType=UserControl}" />
+                        <Binding Path="DataContext.TaxRates" RelativeSource="{RelativeSource AncestorType=UserControl}" />
+                    </MultiBinding>
+                </DataGridTextColumn.Binding>
+            </DataGridTextColumn>
+            <DataGridTextColumn Header="ÁFA érték" Width="90" IsReadOnly="True">
+                <DataGridTextColumn.Binding>
+                    <MultiBinding Converter="{StaticResource VatConverter}" StringFormat="F2">
+                        <Binding Path="Quantity" />
+                        <Binding Path="UnitPrice" />
+                        <Binding Path="TaxRateId" />
+                        <Binding Path="DataContext.IsGross" RelativeSource="{RelativeSource AncestorType=UserControl}" />
+                        <Binding Path="DataContext.TaxRates" RelativeSource="{RelativeSource AncestorType=UserControl}" />
+                    </MultiBinding>
+                </DataGridTextColumn.Binding>
+            </DataGridTextColumn>
+            <DataGridTextColumn Header="Bruttó" Width="90" IsReadOnly="True">
+                <DataGridTextColumn.Binding>
+                    <MultiBinding Converter="{StaticResource GrossConverter}" StringFormat="F2">
+                        <Binding Path="Quantity" />
+                        <Binding Path="UnitPrice" />
+                        <Binding Path="TaxRateId" />
+                        <Binding Path="DataContext.IsGross" RelativeSource="{RelativeSource AncestorType=UserControl}" />
+                        <Binding Path="DataContext.TaxRates" RelativeSource="{RelativeSource AncestorType=UserControl}" />
+                    </MultiBinding>
+                </DataGridTextColumn.Binding>
+            </DataGridTextColumn>
         </DataGrid.Columns>
         <DataGrid.RowDetailsTemplate>
             <DataTemplate>

--- a/Wrecept.Wpf/Views/InvoiceItemsGrid.xaml.cs
+++ b/Wrecept.Wpf/Views/InvoiceItemsGrid.xaml.cs
@@ -17,21 +17,14 @@ public partial class InvoiceItemsGrid : UserControl
             return;
         if (!vm.IsEditable)
             return;
-        if (e.Key == Key.Enter && Grid.SelectedIndex == 0)
-        {
-            vm.ShowSavePromptCommand.Execute(null);
-            e.Handled = true;
-        }
-        else if (e.Key == Key.Enter && Grid.SelectedIndex > 0 && Grid.SelectedItem is InvoiceItemRowViewModel row)
+        if (e.Key == Key.Enter && Grid.SelectedItem is InvoiceItemRowViewModel row)
         {
             vm.EditLineFromSelection(row);
-            Grid.SelectedIndex = 0;
             e.Handled = true;
         }
-        else if (e.Key == Key.Down && Grid.SelectedIndex == 0 && Grid.Items.Count > 1)
+        else
         {
-            Grid.SelectedIndex = 1;
-            e.Handled = true;
+            NavigationHelper.Handle(e);
         }
     }
 }

--- a/docs/progress/2025-07-01_19-40-19_ui_agent.md
+++ b/docs/progress/2025-07-01_19-40-19_ui_agent.md
@@ -1,0 +1,3 @@
+- InvoiceEditorView layout refactor started
+- InvoiceEditorView új szakaszokra bontva, TotalsPanel bevezetve
+- InvoiceItemsGrid readonly és sorösszeg konverter


### PR DESCRIPTION
## Summary
- refactor InvoiceEditorView layout into logical blocks
- move line entry out of InvoiceItemsGrid
- add TotalsPanel user control for VAT and totals
- show read-only lines in InvoiceItemsGrid and compute line totals
- log progress

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864387e4aec8322a7e0f892e08fbb8c