### PR TITLE
Refine invoice editor layout

### DIFF
--- a/Wrecept.Wpf/Views/Controls/TotalsPanel.xaml
+++ b/Wrecept.Wpf/Views/Controls/TotalsPanel.xaml
@@ -5,7 +5,7 @@
         <ItemsControl ItemsSource="{Binding VatSummaries}">
             <ItemsControl.ItemTemplate>
                 <DataTemplate>
-                    <TextBlock>
+                    <TextBlock Margin="0,0,0,2">
                         <Run Text="{Binding Rate}" />
                         <Run Text=" - nettó " />
                         <Run Text="{Binding Net}" />
@@ -23,6 +23,6 @@
             <TextBlock Text="Bruttó:" Width="60" Margin="20,0,0,0" />
             <TextBlock Text="{Binding GrossTotal}" Width="80" TextAlignment="Right" />
         </StackPanel>
-        <TextBlock Text="{Binding AmountInWords, StringFormat=Azaz: {0}}" Margin="0,0,0,4" />
+        <TextBlock Text="{Binding AmountInWords, StringFormat=Azaz: {0}}" FontWeight="Bold" Margin="0,2,0,4" />
     </StackPanel>
 </UserControl>

--- a/Wrecept.Wpf/Views/InvoiceEditorView.xaml
+++ b/Wrecept.Wpf/Views/InvoiceEditorView.xaml
@@ -32,6 +32,15 @@
         <DataTemplate DataType="{x:Type vm:ArchivePromptViewModel}">
             <prompt:ArchivePromptView/>
         </DataTemplate>
+        <Style x:Key="GoldFocusVisual" TargetType="Control">
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate>
+                        <Rectangle Stroke="#FFD700" StrokeThickness="1" StrokeDashArray="2" Margin="2" />
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
     </UserControl.Resources>
     <Grid>
         <Grid.ColumnDefinitions>
@@ -42,42 +51,50 @@
         <view:InvoiceLookupView x:Name="LookupView" DataContext="{Binding Lookup}" />
 
         <StackPanel Grid.Column="1" Margin="4">
-            <StackPanel>
-                <TextBlock Text="Számla" FontWeight="Bold" Margin="0,0,0,6" />
-
-                <StackPanel Orientation="Horizontal" Margin="0,0,0,4">
-                    <TextBlock Text="Szállító" Width="70" />
-                    <c:EditLookup Width="200"
+            <GroupBox Header="Számlafejléc" Margin="0,0,0,6">
+                <Grid Margin="4">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="70" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <Grid.RowDefinitions>
+                        <RowDefinition />
+                        <RowDefinition />
+                        <RowDefinition />
+                        <RowDefinition />
+                        <RowDefinition />
+                    </Grid.RowDefinitions>
+                    <TextBlock Grid.Row="0" Grid.Column="0" Text="Szállító" VerticalAlignment="Center" />
+                    <c:EditLookup Grid.Row="0" Grid.Column="1" Width="200"
                                   ItemsSource="{Binding Suppliers}"
                                   DisplayMemberPath="Name"
                                   SelectedValuePath="Id"
                                   SelectedValue="{Binding SupplierId}"
                                   CreateCommand="{Binding ShowSupplierCreatorCommand}"
                                   IsEnabled="{Binding IsEditable}" />
-                </StackPanel>
-                <StackPanel Orientation="Horizontal" Margin="0,0,0,4">
-                    <TextBlock Text="Dátum" Width="70" />
-                    <DatePicker SelectedDate="{Binding InvoiceDate}" Width="120" IsEnabled="{Binding IsEditable}" />
-                </StackPanel>
-                <StackPanel Orientation="Horizontal" Margin="0,0,0,4">
-                    <TextBlock Text="Szám" Width="70" />
-                    <TextBox Width="120" Text="{Binding Number}" IsEnabled="{Binding IsNew}" />
-                </StackPanel>
-                <StackPanel Orientation="Horizontal" Margin="0,0,0,4">
-                    <TextBlock Text="Fiz. mód" Width="70" />
-                    <c:EditLookup Width="200"
+
+                    <TextBlock Grid.Row="1" Grid.Column="0" Text="Dátum" VerticalAlignment="Center" />
+                    <DatePicker Grid.Row="1" Grid.Column="1" SelectedDate="{Binding InvoiceDate}" Width="120" IsEnabled="{Binding IsEditable}" />
+
+                    <TextBlock Grid.Row="2" Grid.Column="0" Text="Szám" VerticalAlignment="Center" />
+                    <TextBox Grid.Row="2" Grid.Column="1" Width="120" Text="{Binding Number}" IsEnabled="{Binding IsNew}" />
+
+                    <TextBlock Grid.Row="3" Grid.Column="0" Text="Fiz. mód" VerticalAlignment="Center" />
+                    <c:EditLookup Grid.Row="3" Grid.Column="1" Width="200"
                                   ItemsSource="{Binding PaymentMethods}"
                                   DisplayMemberPath="Name"
                                   SelectedValuePath="Id"
                                   SelectedValue="{Binding PaymentMethodId}"
                                   CreateCommand="{Binding ShowPaymentMethodCreatorCommand}"
                                   IsEnabled="{Binding IsEditable}" />
-                </StackPanel>
-                <CheckBox Content="Bruttó ár" IsChecked="{Binding IsGross}" Margin="0,0,0,4" IsEnabled="{Binding IsEditable}" />
-            </StackPanel>
+
+                    <CheckBox Grid.Row="4" Grid.Column="1" Content="Bruttó ár" IsChecked="{Binding IsGross}" IsEnabled="{Binding IsEditable}" />
+                </Grid>
+            </GroupBox>
             <Separator Margin="0,6" />
 
-            <StackPanel Orientation="Horizontal" DataContext="{Binding Items[0]}" KeyDown="OnEntryKeyDown" Margin="0,0,0,4">
+            <StackPanel Orientation="Horizontal" DataContext="{Binding Items[0]}" KeyDown="OnEntryKeyDown"
+                        Background="{DynamicResource ControlBackgroundBrush}" FontStyle="Italic" Margin="0,0,0,4">
                 <c:EditLookup x:Name="EntryProduct" Width="200"
                               ItemsSource="{Binding DataContext.Products, RelativeSource={RelativeSource AncestorType=UserControl}}"
                               DisplayMemberPath="Name"
@@ -108,10 +125,10 @@
             <TextBlock Text="Negatív mennyiség visszárut jelez." FontStyle="Italic" Margin="0,4" />
 
             <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,6">
-                <Button Content="Mentés" Command="{Binding SaveCommand}" Margin="0,0,4,0" />
-                <Button Content="Nyomtatás" IsEnabled="{Binding IsArchived}" Margin="0,0,4,0" />
-                <Button Content="Bezárás" Command="{Binding CloseCommand}" Margin="0,0,4,0" />
-                <Button Content="📦 Véglegesítés" Command="{Binding ShowArchivePromptCommand}">
+                <Button Content="Mentés" Command="{Binding SaveCommand}" Margin="0,0,4,0" FocusVisualStyle="{StaticResource GoldFocusVisual}" />
+                <Button Content="Nyomtatás" IsEnabled="{Binding IsArchived}" Margin="0,0,4,0" FocusVisualStyle="{StaticResource GoldFocusVisual}" />
+                <Button Content="Bezárás" Command="{Binding CloseCommand}" Margin="0,0,4,0" FocusVisualStyle="{StaticResource GoldFocusVisual}" />
+                <Button Content="📦 Véglegesítés" Command="{Binding ShowArchivePromptCommand}" FocusVisualStyle="{StaticResource GoldFocusVisual}">
                     <Button.Style>
                         <Style TargetType="Button">
                             <Style.Triggers>

--- a/docs/progress/2025-07-01_20-09-44_ui_agent.md
+++ b/docs/progress/2025-07-01_20-09-44_ui_agent.md
@@ -1,0 +1,4 @@
+- InvoiceEditorView header grouped into two-column layout
+- Entry row styled for clarity
+- TotalsPanel spacing and bold amount text
+- Action buttons highlight focus and respect invoice state


### PR DESCRIPTION
## Summary
- group invoice header fields in a GroupBox with grid layout
- style entry row with background and italic font
- highlight focus on action buttons and keep Print/Archive states
- space out VAT summary and bold amount in TotalsPanel
- log progress

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68643e4d2ed88322a1aaaf15a2b10415