### PR TITLE
Fix MC3061 error in InvoiceItemsGrid

### DIFF
--- a/Wrecept.Wpf/Views/InvoiceItemsGrid.xaml
+++ b/Wrecept.Wpf/Views/InvoiceItemsGrid.xaml
@@ -86,7 +86,7 @@
                                     CellTemplate="{StaticResource ProductDisplayTemplate}"
                                     CellEditingTemplate="{StaticResource ProductEditTemplate}"
                                     CellStyle="{StaticResource EditableCellStyle}" />
-            <DataGridTemplateColumn Header="Menny." Width="80">
+            <DataGridTemplateColumn Header="Menny." Width="80"
                                     CellTemplate="{StaticResource QuantityDisplayTemplate}"
                                     CellEditingTemplate="{StaticResource QuantityEditTemplate}"
                                     CellStyle="{StaticResource EditableCellStyle}" />

--- a/docs/BUILD_RUNTIME_NOTES.md
+++ b/docs/BUILD_RUNTIME_NOTES.md
@@ -16,6 +16,7 @@ Ez a jegyzet a fejlesztés során tapasztalt fordítási és futásidejű probl�
 - **Nem támogatott `{x:Int32}` jelölés** – a Tag attribútumnál az egyszerű numerikus érték használata biztosítja a kompatibilitást.
 - **Hiányzó using direktíva** – a `StageView.xaml.cs` állományban a `System.Windows` névtér hiánya CS0246 hibát okozott.
 - **Elgépelés vagy hiányzó záró tag** – az `InvoiceEditorView.xaml` fájlban egy fölösleges `</StackPanel>` tag miatt a build meghiúsult.
+- **Önzáró `DataGridTemplateColumn` hiánya** – ha a nyitó tag `>` jellel zárul és az attribútumok külön sorban szerepelnek, a parser MC3061 hibát dob.
 - **Teszt futtatásához szükséges csomag** – a `Xunit.StaFact` hiánya tesztfutási hibát eredményezhet Windows környezetben.
 
 ## Javaslatok

--- a/docs/progress/2025-07-01_21-29-21_ui_agent.md
+++ b/docs/progress/2025-07-01_21-29-21_ui_agent.md
@@ -1,0 +1,2 @@
+- Fixed MC3061 parse error by making Quantity column self-closing.
+- Added reminder in BUILD_RUNTIME_NOTES.md about improper DataGridTemplateColumn closure.


### PR DESCRIPTION
## Summary
- correct XAML tag for Quantity column
- document cause in BUILD_RUNTIME_NOTES
- log change

## Testing
- `dotnet build` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6864529ecaf8832287e558b92f2656d8