### PR TITLE
Implement keyboard-centric product maintenance

### DIFF
--- a/Wrecept.Wpf/App.xaml
+++ b/Wrecept.Wpf/App.xaml
@@ -2,13 +2,15 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="clr-namespace:Wrecept.Wpf.ViewModels"
-             xmlns:view="clr-namespace:Wrecept.Wpf.Views">
+            xmlns:view="clr-namespace:Wrecept.Wpf.Views"
+            xmlns:converters="clr-namespace:Wrecept.Wpf.Converters">
     <Application.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="Themes/RetroTheme.xaml" />
             </ResourceDictionary.MergedDictionaries>
             <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter"/>
+            <converters:BooleanToRowDetailsConverter x:Key="BooleanToRowDetailsConverter" />
             <DataTemplate DataType="{x:Type vm:InvoiceEditorViewModel}">
                 <view:InvoiceEditorView />
             </DataTemplate>

--- a/Wrecept.Wpf/Converters/BooleanToRowDetailsConverter.cs
+++ b/Wrecept.Wpf/Converters/BooleanToRowDetailsConverter.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Globalization;
+using System.Windows.Controls;
+using System.Windows.Data;
+
+namespace Wrecept.Wpf.Converters;
+
+public class BooleanToRowDetailsConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object? parameter, CultureInfo culture)
+        => value is bool b && b
+            ? DataGridRowDetailsVisibilityMode.Visible
+            : DataGridRowDetailsVisibilityMode.Collapsed;
+
+    public object ConvertBack(object value, Type targetType, object? parameter, CultureInfo culture)
+        => value is DataGridRowDetailsVisibilityMode mode && mode != DataGridRowDetailsVisibilityMode.Collapsed;
+}

--- a/Wrecept.Wpf/ViewModels/ProductMasterViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/ProductMasterViewModel.cs
@@ -1,5 +1,6 @@
 using System.Collections.ObjectModel;
 using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
 using Wrecept.Core.Models;
 using Wrecept.Core.Services;
 using System.Threading.Tasks;
@@ -12,9 +13,30 @@ public partial class ProductMasterViewModel : ObservableObject
 
     private readonly IProductService _service;
 
+    [ObservableProperty]
+    private Product? selectedProduct;
+
+    [ObservableProperty]
+    private bool isEditing;
+
+    public IRelayCommand EditSelectedCommand { get; }
+    public IRelayCommand DeleteSelectedCommand { get; }
+    public IRelayCommand CloseDetailsCommand { get; }
+
     public ProductMasterViewModel(IProductService service)
     {
         _service = service;
+        EditSelectedCommand = new RelayCommand(() => IsEditing = !IsEditing, () => SelectedProduct != null);
+        DeleteSelectedCommand = new RelayCommand(async () =>
+        {
+            if (SelectedProduct != null)
+            {
+                SelectedProduct.IsArchived = true;
+                await _service.UpdateAsync(SelectedProduct);
+                await LoadAsync();
+            }
+        }, () => SelectedProduct != null);
+        CloseDetailsCommand = new RelayCommand(() => IsEditing = false);
     }
 
     public async Task LoadAsync()

--- a/Wrecept.Wpf/Views/ProductMasterView.xaml
+++ b/Wrecept.Wpf/Views/ProductMasterView.xaml
@@ -2,5 +2,49 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              KeyDown="OnKeyDown">
-    <ListBox ItemsSource="{Binding Products}" DisplayMemberPath="Name" Margin="4" />
+    <UserControl.InputBindings>
+        <KeyBinding Key="Enter" Command="{Binding EditSelectedCommand}" />
+        <KeyBinding Key="Delete" Command="{Binding DeleteSelectedCommand}" />
+        <KeyBinding Key="Escape" Command="{Binding CloseDetailsCommand}" />
+    </UserControl.InputBindings>
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <DataGrid x:Name="Grid"
+                  ItemsSource="{Binding Products}"
+                  SelectedItem="{Binding SelectedProduct, Mode=TwoWay}"
+                  AutoGenerateColumns="False"
+                  RowDetailsVisibilityMode="{Binding IsEditing, Converter={StaticResource BooleanToRowDetailsConverter}}"
+                  Margin="4">
+            <DataGrid.Columns>
+                <DataGridTextColumn Header="Név" Binding="{Binding Name}" Width="*" />
+                <DataGridTextColumn Header="Nettó" Binding="{Binding Net}" Width="80" />
+                <DataGridTextColumn Header="Bruttó" Binding="{Binding Gross}" Width="80" />
+                <DataGridTextColumn Header="ÁFA" Binding="{Binding TaxRateId}" Width="90" />
+            </DataGrid.Columns>
+            <DataGrid.RowDetailsTemplate>
+                <DataTemplate>
+                    <StackPanel Margin="4">
+                        <StackPanel Orientation="Horizontal">
+                            <TextBlock Width="80" Text="Név"/>
+                            <TextBox Text="{Binding Name, Mode=TwoWay}" Width="200"/>
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal" Margin="0,4,0,0">
+                            <TextBlock Width="80" Text="Nettó"/>
+                            <TextBox Text="{Binding Net, Mode=TwoWay}" Width="80"/>
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal" Margin="0,4,0,0">
+                            <TextBlock Width="80" Text="Bruttó"/>
+                            <TextBox Text="{Binding Gross, Mode=TwoWay}" Width="80"/>
+                        </StackPanel>
+                    </StackPanel>
+                </DataTemplate>
+            </DataGrid.RowDetailsTemplate>
+        </DataGrid>
+
+        <TextBlock Grid.Row="1" Text="[Enter] Szerkesztés  [Del] Törlés  [Esc] Vissza" HorizontalAlignment="Center" Margin="4"/>
+    </Grid>
 </UserControl>

--- a/Wrecept.Wpf/Views/ProductMasterView.xaml.cs
+++ b/Wrecept.Wpf/Views/ProductMasterView.xaml.cs
@@ -15,7 +15,11 @@ public partial class ProductMasterView : UserControl
     {
         InitializeComponent();
         DataContext = viewModel;
-        Loaded += async (_, _) => await viewModel.LoadAsync();
+        Loaded += async (_, _) =>
+        {
+            await viewModel.LoadAsync();
+            Grid.Focus();
+        };
     }
 
     private void OnKeyDown(object sender, KeyEventArgs e)

--- a/docs/progress/2025-07-01_21-56-19_ui_agent.md
+++ b/docs/progress/2025-07-01_21-56-19_ui_agent.md
@@ -1,0 +1,4 @@
+- ProductMasterView átdolgozva DataGrid alapúra, sor részletekkel.
+- Billentyűparancsok hozzáadva (Enter szerkeszt, Del töröl, Esc vissza).
+- BooleanToRowDetailsConverter új konverterként bevezetve.
+- ViewModel bővítve SelectedProduct és IsEditing kezeléssel.


### PR DESCRIPTION
## Summary
- refactor ProductMasterView to keyboard-friendly DataGrid with RowDetails
- add BooleanToRowDetailsConverter and use from App.xaml
- extend ProductMasterViewModel with selection and editing commands
- keep focus on list after loading
- document progress

## Testing
- `dotnet build Wrecept.sln -clp:ErrorsOnly` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864585a37b0832283369d172adf7e96