### PR TITLE
Improve product edit UI

### DIFF
--- a/Wrecept.Wpf/ViewModels/ProductMasterViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/ProductMasterViewModel.cs
@@ -4,14 +4,17 @@ using CommunityToolkit.Mvvm.Input;
 using Wrecept.Core.Models;
 using Wrecept.Core.Services;
 using System.Threading.Tasks;
+using System;
 
 namespace Wrecept.Wpf.ViewModels;
 
 public partial class ProductMasterViewModel : ObservableObject
 {
     public ObservableCollection<Product> Products { get; } = new();
+    public ObservableCollection<TaxRate> TaxRates { get; } = new();
 
     private readonly IProductService _service;
+    private readonly ITaxRateService _taxRates;
 
     [ObservableProperty]
     private Product? selectedProduct;
@@ -23,9 +26,10 @@ public partial class ProductMasterViewModel : ObservableObject
     public IRelayCommand DeleteSelectedCommand { get; }
     public IRelayCommand CloseDetailsCommand { get; }
 
-    public ProductMasterViewModel(IProductService service)
+    public ProductMasterViewModel(IProductService service, ITaxRateService taxRates)
     {
         _service = service;
+        _taxRates = taxRates;
         EditSelectedCommand = new RelayCommand(() => IsEditing = !IsEditing, () => SelectedProduct != null);
         DeleteSelectedCommand = new RelayCommand(async () =>
         {
@@ -42,8 +46,12 @@ public partial class ProductMasterViewModel : ObservableObject
     public async Task LoadAsync()
     {
         var items = await _service.GetActiveAsync();
+        var rates = await _taxRates.GetActiveAsync(DateTime.UtcNow);
         Products.Clear();
         foreach (var item in items)
             Products.Add(item);
+        TaxRates.Clear();
+        foreach (var r in rates)
+            TaxRates.Add(r);
     }
 }

--- a/Wrecept.Wpf/Views/ProductMasterView.xaml
+++ b/Wrecept.Wpf/Views/ProductMasterView.xaml
@@ -18,27 +18,48 @@
                   SelectedItem="{Binding SelectedProduct, Mode=TwoWay}"
                   AutoGenerateColumns="False"
                   RowDetailsVisibilityMode="{Binding IsEditing, Converter={StaticResource BooleanToRowDetailsConverter}}"
+                  RowDetailsVisibilityChanged="Grid_RowDetailsVisibilityChanged"
                   Margin="4">
+            <DataGrid.RowStyle>
+                <Style TargetType="DataGridRow">
+                    <Setter Property="Background" Value="#1A1A1A" />
+                    <Setter Property="Foreground" Value="White" />
+                    <Style.Triggers>
+                        <Trigger Property="IsSelected" Value="True">
+                            <Setter Property="Background" Value="#FFD700" />
+                            <Setter Property="Foreground" Value="Black" />
+                        </Trigger>
+                    </Style.Triggers>
+                </Style>
+            </DataGrid.RowStyle>
             <DataGrid.Columns>
                 <DataGridTextColumn Header="Név" Binding="{Binding Name}" Width="*" />
                 <DataGridTextColumn Header="Nettó" Binding="{Binding Net}" Width="80" />
                 <DataGridTextColumn Header="Bruttó" Binding="{Binding Gross}" Width="80" />
-                <DataGridTextColumn Header="ÁFA" Binding="{Binding TaxRateId}" Width="90" />
+                <DataGridTextColumn Header="ÁFA" Binding="{Binding TaxRate.Name}" Width="90" />
             </DataGrid.Columns>
             <DataGrid.RowDetailsTemplate>
                 <DataTemplate>
                     <StackPanel Margin="4">
                         <StackPanel Orientation="Horizontal">
                             <TextBlock Width="80" Text="Név"/>
-                            <TextBox Text="{Binding Name, Mode=TwoWay}" Width="200"/>
+                            <TextBox x:Name="NameBox" Text="{Binding Name, Mode=TwoWay}" Width="200"/>
                         </StackPanel>
                         <StackPanel Orientation="Horizontal" Margin="0,4,0,0">
-                            <TextBlock Width="80" Text="Nettó"/>
+                            <TextBlock Width="80" Text="Nettó" Foreground="Red"/>
                             <TextBox Text="{Binding Net, Mode=TwoWay}" Width="80"/>
                         </StackPanel>
                         <StackPanel Orientation="Horizontal" Margin="0,4,0,0">
-                            <TextBlock Width="80" Text="Bruttó"/>
+                            <TextBlock Width="80" Text="Bruttó" Foreground="Red"/>
                             <TextBox Text="{Binding Gross, Mode=TwoWay}" Width="80"/>
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal" Margin="0,4,0,0">
+                            <TextBlock Width="80" Text="ÁFA"/>
+                            <ComboBox Width="120"
+                                      ItemsSource="{Binding DataContext.TaxRates, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                      SelectedValuePath="Id"
+                                      DisplayMemberPath="Name"
+                                      SelectedValue="{Binding TaxRateId, Mode=TwoWay}" />
                         </StackPanel>
                     </StackPanel>
                 </DataTemplate>

--- a/Wrecept.Wpf/Views/ProductMasterView.xaml.cs
+++ b/Wrecept.Wpf/Views/ProductMasterView.xaml.cs
@@ -1,3 +1,4 @@
+using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using Microsoft.Extensions.DependencyInjection;
@@ -24,4 +25,16 @@ public partial class ProductMasterView : UserControl
 
     private void OnKeyDown(object sender, KeyEventArgs e)
         => NavigationHelper.Handle(e);
+
+    private void Grid_RowDetailsVisibilityChanged(object sender, DataGridRowDetailsEventArgs e)
+    {
+        if (e.DetailsElement.FindName("NameBox") is TextBox box && e.Row.DetailsVisibility == Visibility.Visible)
+        {
+            box.Focus();
+        }
+        else if (e.Row.DetailsVisibility != Visibility.Visible)
+        {
+            Grid.Focus();
+        }
+    }
 }

--- a/docs/progress/2025-07-01_22-11-31_ui_agent.md
+++ b/docs/progress/2025-07-01_22-11-31_ui_agent.md
@@ -1,0 +1,4 @@
+- ProductMasterView: ÁFA legördülő és automatikus fókusz hozzáadva.
+- Sor részletek megjelenésekor a "Név" mező kap fókuszt, Esc után vissza a rácsra.
+- Dark DataGrid stílus sárga kijelöléssel és piros szám mező címkékkel.
+- TaxRate nevek jelennek meg a táblázatban.

--- a/docs/themes.md
+++ b/docs/themes.md
@@ -15,5 +15,7 @@ A Retro UI hangs on warm yellows and oranges reminiscent of classic terminals. T
 - **HighlightBrush:** Gold for active elements and focus rings.
 - **ControlBackgroundBrush:** Pale yellow surface for controls.
 
+DataGrid sorok fekete háttérrel és arany kiemeléssel jelennek meg a DOS-hatást erősítve. A mennyiségi vagy ár mezők címkéi piros színt kapnak, hogy gyorsabban felismerhetők legyenek.
+
 Every control style sets `FocusVisualStyle` to display a dashed border so keyboard navigation is obvious.
 - The StatusBar uses `ControlBackgroundBrush` with subtle text to avoid distraction while conveying state.


### PR DESCRIPTION
## Summary
- extend `ProductMasterViewModel` with tax rate lookup
- style `ProductMasterView` for DOS-like keyboard editing
- auto-focus name field when editing
- document new theme tweaks
- log progress

## Testing
- `dotnet test --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_68645c01be24832286fe5fbbbaf07882