### PR TITLE
Apply DOS palette and footer hints

### DIFF
--- a/Wrecept.Wpf/Resources/Strings.resx
+++ b/Wrecept.Wpf/Resources/Strings.resx
@@ -43,7 +43,7 @@
     <value>Funkció még nincs kész</value>
   </data>
   <data name="StatusBar_DefaultMessage" xml:space="preserve">
-    <value>&#x2191;/&#x2193; navigál, Enter aktivál, Esc vissza</value>
+    <value>[Esc] Kilépés  [Enter] Jóváhagy</value>
   </data>
   <data name="Load_PaymentMethods" xml:space="preserve">
     <value>Fizetési módok betöltése...</value>

--- a/Wrecept.Wpf/Themes/RetroTheme.Dark.xaml
+++ b/Wrecept.Wpf/Themes/RetroTheme.Dark.xaml
@@ -4,8 +4,9 @@
     <!-- Dark retro palette -->
     <Color x:Key="BackgroundColor">#1A1A1A</Color>
     <Color x:Key="ForegroundColor">#FFE187</Color>
-    <Color x:Key="HighlightColor">#C00000</Color>
-    <Color x:Key="SelectionColor">#0D00B0</Color>
+    <Color x:Key="HighlightColor">#0000aa</Color>
+    <Color x:Key="SelectionColor">#000055</Color>
+    <Color x:Key="HeaderFooterColor">#403000</Color>
 
     <Color x:Key="StageBackgroundColor">#1A1A1A</Color>
 
@@ -14,7 +15,8 @@
     <SolidColorBrush x:Key="HighlightBrush" Color="{StaticResource HighlightColor}" />
     <SolidColorBrush x:Key="SelectionBrush" Color="{StaticResource SelectionColor}" />
     <SolidColorBrush x:Key="StageBackground" Color="{StaticResource StageBackgroundColor}" />
-    <SolidColorBrush x:Key="ControlBackgroundBrush" Color="#2A2A2A" />
+    <SolidColorBrush x:Key="ControlBackgroundBrush" Color="#4f4f20" />
+    <SolidColorBrush x:Key="HeaderFooterBrush" Color="{StaticResource HeaderFooterColor}" />
 
     <sys:Double x:Key="FontSizeNormal">16</sys:Double>
     <sys:Double x:Key="FontSizeLarge">18</sys:Double>
@@ -35,21 +37,21 @@
 
     <Style TargetType="Button">
         <Setter Property="Background" Value="{StaticResource HighlightBrush}" />
-        <Setter Property="Foreground" Value="{StaticResource ControlBackgroundBrush}" />
+        <Setter Property="Foreground" Value="White" />
         <Setter Property="BorderBrush" Value="{StaticResource ForegroundBrush}" />
         <Setter Property="FontFamily" Value="Consolas" />
         <Setter Property="FontSize" Value="{StaticResource FontSizeLarge}" />
     </Style>
 
     <Style TargetType="Menu">
-        <Setter Property="Background" Value="{StaticResource BackgroundBrush}" />
+        <Setter Property="Background" Value="{StaticResource HeaderFooterBrush}" />
         <Setter Property="Foreground" Value="{StaticResource ForegroundBrush}" />
         <Setter Property="FontFamily" Value="Consolas" />
         <Setter Property="FontSize" Value="{StaticResource FontSizeLarge}" />
     </Style>
 
     <Style TargetType="MenuItem">
-        <Setter Property="Background" Value="{StaticResource BackgroundBrush}" />
+        <Setter Property="Background" Value="{StaticResource HeaderFooterBrush}" />
         <Setter Property="Foreground" Value="{StaticResource ForegroundBrush}" />
         <Setter Property="FontFamily" Value="Consolas" />
         <Setter Property="FontSize" Value="{StaticResource FontSizeLarge}" />
@@ -72,8 +74,8 @@
         <Setter Property="FontSize" Value="{StaticResource FontSizeLarge}" />
         <Style.Triggers>
             <Trigger Property="IsSelected" Value="True">
-                <Setter Property="Background" Value="{StaticResource HighlightBrush}" />
-                <Setter Property="Foreground" Value="{StaticResource ControlBackgroundBrush}" />
+                <Setter Property="Background" Value="{StaticResource SelectionBrush}" />
+                <Setter Property="Foreground" Value="White" />
             </Trigger>
         </Style.Triggers>
     </Style>

--- a/Wrecept.Wpf/Themes/RetroTheme.xaml
+++ b/Wrecept.Wpf/Themes/RetroTheme.xaml
@@ -2,12 +2,13 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:sys="clr-namespace:System;assembly=mscorlib">
     <!-- Light retro palette -->
-    <Color x:Key="BackgroundColor">#9D941D</Color>
+    <Color x:Key="BackgroundColor">#9b8b20</Color>
     <Color x:Key="ForegroundColor">#000000</Color>
-    <Color x:Key="HighlightColor">#0D00B0</Color>
-    <Color x:Key="SelectionColor">#C00000</Color>
+    <Color x:Key="HighlightColor">#0000aa</Color>
+    <Color x:Key="SelectionColor">#000055</Color>
+    <Color x:Key="HeaderFooterColor">#806000</Color>
 
-    <Color x:Key="StageBackgroundColor">#9D941D</Color>
+    <Color x:Key="StageBackgroundColor">#9b8b20</Color>
 
     <SolidColorBrush x:Key="StageBackground" Color="{StaticResource StageBackgroundColor}" />
 
@@ -15,7 +16,8 @@
     <SolidColorBrush x:Key="ForegroundBrush" Color="{StaticResource ForegroundColor}" />
     <SolidColorBrush x:Key="HighlightBrush" Color="{StaticResource HighlightColor}" />
     <SolidColorBrush x:Key="SelectionBrush" Color="{StaticResource SelectionColor}" />
-    <SolidColorBrush x:Key="ControlBackgroundBrush" Color="#FFE187" />
+    <SolidColorBrush x:Key="ControlBackgroundBrush" Color="#c7bb4f" />
+    <SolidColorBrush x:Key="HeaderFooterBrush" Color="{StaticResource HeaderFooterColor}" />
 
     <sys:Double x:Key="FontSizeNormal">16</sys:Double>
     <sys:Double x:Key="FontSizeLarge">18</sys:Double>
@@ -36,21 +38,21 @@
 
     <Style TargetType="Button">
         <Setter Property="Background" Value="{StaticResource HighlightBrush}" />
-        <Setter Property="Foreground" Value="{StaticResource ControlBackgroundBrush}" />
+        <Setter Property="Foreground" Value="White" />
         <Setter Property="BorderBrush" Value="{StaticResource ForegroundBrush}" />
         <Setter Property="FontFamily" Value="Consolas" />
         <Setter Property="FontSize" Value="{StaticResource FontSizeLarge}" />
     </Style>
 
     <Style TargetType="Menu">
-        <Setter Property="Background" Value="{StaticResource BackgroundBrush}" />
+        <Setter Property="Background" Value="{StaticResource HeaderFooterBrush}" />
         <Setter Property="Foreground" Value="{StaticResource ForegroundBrush}" />
         <Setter Property="FontFamily" Value="Consolas" />
         <Setter Property="FontSize" Value="{StaticResource FontSizeLarge}" />
     </Style>
 
     <Style TargetType="MenuItem">
-        <Setter Property="Background" Value="{StaticResource BackgroundBrush}" />
+        <Setter Property="Background" Value="{StaticResource HeaderFooterBrush}" />
         <Setter Property="Foreground" Value="{StaticResource ForegroundBrush}" />
         <Setter Property="FontFamily" Value="Consolas" />
         <Setter Property="FontSize" Value="{StaticResource FontSizeLarge}" />
@@ -73,8 +75,8 @@
         <Setter Property="FontSize" Value="{StaticResource FontSizeLarge}" />
         <Style.Triggers>
             <Trigger Property="IsSelected" Value="True">
-                <Setter Property="Background" Value="{StaticResource HighlightBrush}" />
-                <Setter Property="Foreground" Value="{StaticResource ControlBackgroundBrush}" />
+                <Setter Property="Background" Value="{StaticResource SelectionBrush}" />
+                <Setter Property="Foreground" Value="White" />
             </Trigger>
         </Style.Triggers>
     </Style>

--- a/Wrecept.Wpf/Views/Controls/StatusBar.xaml
+++ b/Wrecept.Wpf/Views/Controls/StatusBar.xaml
@@ -1,7 +1,7 @@
 <UserControl x:Class="Wrecept.Wpf.Views.Controls.StatusBar"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-    <Border Background="{DynamicResource ControlBackgroundBrush}" Padding="2">
+    <Border Background="{DynamicResource HeaderFooterBrush}" Padding="2">
         <Grid>
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="150" />

--- a/Wrecept.Wpf/Views/StageView.xaml
+++ b/Wrecept.Wpf/Views/StageView.xaml
@@ -19,7 +19,7 @@
                 <EventSetter Event="Click" Handler="MenuItem_Click"/>
             </Style>
         </Grid.Resources>
-        <Menu>
+        <Menu Background="{DynamicResource HeaderFooterBrush}">
             <MenuItem Header="Számlák">
                 <MenuItem Header="Bejövő szállítólevelek"
                           Command="{Binding HandleMenuCommand}"

--- a/docs/progress/2025-07-01_22-54-28_ui_agent.md
+++ b/docs/progress/2025-07-01_22-54-28_ui_agent.md
@@ -1,0 +1,3 @@
+- RetroTheme színei átállítva DOS-stílusú palettára.
+- StatusBar most a HeaderFooterBrush-t használja.
+- Alapértelmezett billentyűs súgó módosítva: "[Esc] Kilépés  [Enter] Jóváhagy".

--- a/docs/themes.md
+++ b/docs/themes.md
@@ -7,15 +7,15 @@ date: "2025-06-27"
 
 # 🎨 Retro Theme Overview
 
-A Retro UI hangs on warm yellows and oranges reminiscent of classic terminals. The XAML resource dictionary defines global styles for common controls and ensures consistent keyboard focus cues. The main colors are `#FFE187`, `#FFD700`, and `#FFA726` against darker text.
+A Retro UI hangs on a 16 színű DOS-palettán. A XAML erőforrás szótár egységesíti a vezérlők megjelenését. A fő színek: háttér `#9b8b20`, mezők `#c7bb4f`, gombok `#0000aa` fehér felirattal és kiemelés `#000055`.
 
 2025 júliusától a `RetroTheme.xaml` két változatban érhető el: világos és sötét. A váltást a `ThemeManager.ApplyDarkTheme(bool)` hívással lehet vezérelni, ami a megfelelő `ResourceDictionary` betöltését végzi.
 
-- **StageBackground:** Warm yellow base for all windows and dialogs.
-- **HoverBrush:** `#F5A623` on mouse-over states.
-- **AccentBrush:** Orange used for pressed actions.
-- **HighlightBrush:** Gold for active elements and focus rings.
-- **ControlBackgroundBrush:** Pale yellow surface for controls.
+- **StageBackground:** Mustár sárga (`#9b8b20`) alap minden ablakhoz.
+- **HighlightBrush:** `#0000aa` a gombokhoz és aktív elemekhez.
+- **SelectionBrush:** `#000055` kijelölt sorokhoz.
+- **ControlBackgroundBrush:** Olívzöld (`#c7bb4f`) mezők alapja.
+- **HeaderFooterBrush:** Sötétebb sárga (`#806000`) fejléc és lábléc szín.
 
 Betűméretek:
 - **FontSizeNormal:** 16 px, általános szövegekhez és űrlapmezőkhöz.


### PR DESCRIPTION
## Summary
- switch retro theme colors to a DOS-like palette
- update status bar color and default hints
- document new theme colors

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68646630a8b0832285e95f24205aff2b