### PR TITLE
Fix XAML view root class definitions

### DIFF
--- a/Wrecept.Wpf/Views/Controls/BaseMasterView.xaml
+++ b/Wrecept.Wpf/Views/Controls/BaseMasterView.xaml
@@ -1,7 +1,7 @@
 <UserControl x:Class="Wrecept.Wpf.Views.Controls.BaseMasterView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             x:ClassModifier="public abstract"
+             x:ClassModifier="public"
              KeyDown="OnKeyDown">
     <UserControl.InputBindings>
         <KeyBinding Key="Enter" Command="{Binding EditSelectedCommand}" />

--- a/Wrecept.Wpf/Views/PaymentMethodMasterView.xaml
+++ b/Wrecept.Wpf/Views/PaymentMethodMasterView.xaml
@@ -1,12 +1,12 @@
-<views:Controls.BaseMasterView x:Class="Wrecept.Wpf.Views.PaymentMethodMasterView"
-                               xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                               xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                               xmlns:views="clr-namespace:Wrecept.Wpf.Views"
-                               xmlns:viewsControls="clr-namespace:Wrecept.Wpf.Views.Controls">
+<viewsControls:BaseMasterView x:Class="Wrecept.Wpf.Views.PaymentMethodMasterView"
+                              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                              xmlns:views="clr-namespace:Wrecept.Wpf.Views"
+                              xmlns:viewsControls="clr-namespace:Wrecept.Wpf.Views.Controls">
     <viewsControls:BaseMasterView.Columns>
         <DataGridTextColumn Binding="{Binding Name}" Header="Név" />
         <DataGridTextColumn Binding="{Binding DueInDays}" Header="Határidő" />
         <DataGridCheckBoxColumn Binding="{Binding IsArchived}" Header="Archivált" />
         <DataGridTextColumn Binding="{Binding UpdatedAt}" Header="Módosítva" />
     </viewsControls:BaseMasterView.Columns>
-</views:Controls.BaseMasterView>
+</viewsControls:BaseMasterView>

--- a/Wrecept.Wpf/Views/ProductGroupMasterView.xaml
+++ b/Wrecept.Wpf/Views/ProductGroupMasterView.xaml
@@ -1,11 +1,11 @@
-<views:Controls.BaseMasterView x:Class="Wrecept.Wpf.Views.ProductGroupMasterView"
-                               xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                               xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                               xmlns:views="clr-namespace:Wrecept.Wpf.Views"
-                               xmlns:viewsControls="clr-namespace:Wrecept.Wpf.Views.Controls">
+<viewsControls:BaseMasterView x:Class="Wrecept.Wpf.Views.ProductGroupMasterView"
+                              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                              xmlns:views="clr-namespace:Wrecept.Wpf.Views"
+                              xmlns:viewsControls="clr-namespace:Wrecept.Wpf.Views.Controls">
     <viewsControls:BaseMasterView.Columns>
         <DataGridTextColumn Binding="{Binding Name}" Header="Név" />
         <DataGridCheckBoxColumn Binding="{Binding IsArchived}" Header="Archivált" />
         <DataGridTextColumn Binding="{Binding UpdatedAt}" Header="Módosítva" />
     </viewsControls:BaseMasterView.Columns>
-</views:Controls.BaseMasterView>
+</viewsControls:BaseMasterView>

--- a/Wrecept.Wpf/Views/ProductMasterView.xaml
+++ b/Wrecept.Wpf/Views/ProductMasterView.xaml
@@ -1,9 +1,9 @@
-<views:Controls.BaseMasterView x:Class="Wrecept.Wpf.Views.ProductMasterView"
-                               xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                               xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                               xmlns:views="clr-namespace:Wrecept.Wpf.Views"
-                               xmlns:viewsControls="clr-namespace:Wrecept.Wpf.Views.Controls"
-                               xmlns:vm="clr-namespace:Wrecept.Wpf.ViewModels">
+<viewsControls:BaseMasterView x:Class="Wrecept.Wpf.Views.ProductMasterView"
+                              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                              xmlns:views="clr-namespace:Wrecept.Wpf.Views"
+                              xmlns:viewsControls="clr-namespace:Wrecept.Wpf.Views.Controls"
+                              xmlns:vm="clr-namespace:Wrecept.Wpf.ViewModels">
     <viewsControls:BaseMasterView.Columns>
         <DataGridTextColumn Header="Név" Binding="{Binding Name}" Width="*" />
         <DataGridTextColumn Header="Nettó" Binding="{Binding Net}" Width="80" />
@@ -36,4 +36,4 @@
             </StackPanel>
         </DataTemplate>
     </viewsControls:BaseMasterView.RowDetailsTemplate>
-</views:Controls.BaseMasterView>
+</viewsControls:BaseMasterView>

--- a/Wrecept.Wpf/Views/SupplierMasterView.xaml
+++ b/Wrecept.Wpf/Views/SupplierMasterView.xaml
@@ -1,9 +1,9 @@
-<views:Controls.BaseMasterView x:Class="Wrecept.Wpf.Views.SupplierMasterView"
-                               xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                               xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                               xmlns:views="clr-namespace:Wrecept.Wpf.Views"
-                               xmlns:viewsControls="clr-namespace:Wrecept.Wpf.Views.Controls">
+<viewsControls:BaseMasterView x:Class="Wrecept.Wpf.Views.SupplierMasterView"
+                              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                              xmlns:views="clr-namespace:Wrecept.Wpf.Views"
+                              xmlns:viewsControls="clr-namespace:Wrecept.Wpf.Views.Controls">
     <viewsControls:BaseMasterView.Columns>
         <DataGridTextColumn Header="Név" Binding="{Binding Name}" Width="*" />
     </viewsControls:BaseMasterView.Columns>
-</views:Controls.BaseMasterView>
+</viewsControls:BaseMasterView>

--- a/Wrecept.Wpf/Views/TaxRateMasterView.xaml
+++ b/Wrecept.Wpf/Views/TaxRateMasterView.xaml
@@ -1,8 +1,8 @@
-<views:Controls.BaseMasterView x:Class="Wrecept.Wpf.Views.TaxRateMasterView"
-                               xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                               xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                               xmlns:views="clr-namespace:Wrecept.Wpf.Views"
-                               xmlns:viewsControls="clr-namespace:Wrecept.Wpf.Views.Controls">
+<viewsControls:BaseMasterView x:Class="Wrecept.Wpf.Views.TaxRateMasterView"
+                              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                              xmlns:views="clr-namespace:Wrecept.Wpf.Views"
+                              xmlns:viewsControls="clr-namespace:Wrecept.Wpf.Views.Controls">
     <viewsControls:BaseMasterView.Columns>
         <DataGridTextColumn Binding="{Binding Code}" Header="Kód" />
         <DataGridTextColumn Binding="{Binding Name}" Header="Név" />
@@ -17,4 +17,4 @@
             </DataGridCheckBoxColumn.ElementStyle>
         </DataGridCheckBoxColumn>
     </viewsControls:BaseMasterView.Columns>
-</views:Controls.BaseMasterView>
+</viewsControls:BaseMasterView>

--- a/Wrecept.Wpf/Views/UnitMasterView.xaml
+++ b/Wrecept.Wpf/Views/UnitMasterView.xaml
@@ -1,8 +1,8 @@
-<views:Controls.BaseMasterView x:Class="Wrecept.Wpf.Views.UnitMasterView"
-                               xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                               xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                               xmlns:views="clr-namespace:Wrecept.Wpf.Views"
-                               xmlns:viewsControls="clr-namespace:Wrecept.Wpf.Views.Controls">
+<viewsControls:BaseMasterView x:Class="Wrecept.Wpf.Views.UnitMasterView"
+                              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                              xmlns:views="clr-namespace:Wrecept.Wpf.Views"
+                              xmlns:viewsControls="clr-namespace:Wrecept.Wpf.Views.Controls">
     <viewsControls:BaseMasterView.Columns>
         <DataGridTextColumn Binding="{Binding Code}" Header="Kód" />
         <DataGridTextColumn Binding="{Binding Name}" Header="Név" />
@@ -15,4 +15,4 @@
         </DataGridCheckBoxColumn>
         <DataGridTextColumn Binding="{Binding UpdatedAt}" Header="Módosítva" />
     </viewsControls:BaseMasterView.Columns>
-</views:Controls.BaseMasterView>
+</viewsControls:BaseMasterView>

--- a/docs/progress/2025-07-01_23-18-18_ui_agent.md
+++ b/docs/progress/2025-07-01_23-18-18_ui_agent.md
@@ -1,0 +1,2 @@
+- XAML fordítási hibák javítva: root elem aliases helyrehozva, `x:ClassModifier` értéke most csak `public`.
+- Minden MasterView a `viewsControls:BaseMasterView` típust használja.


### PR DESCRIPTION
## Summary
- fix xaml error in `BaseMasterView` by using `x:ClassModifier="public"`
- correct master views to use `viewsControls:BaseMasterView` as root
- add progress log

## Testing
- `dotnet build Wrecept.sln -c Release` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*
- `dotnet test tests/Wrecept.Tests/Wrecept.Tests.csproj` *(fails: Wrecept.Wpf not compatible with net8.0)*

------
https://chatgpt.com/codex/tasks/task_e_68646bf1d4988322af3afab4b3cda4e8