### PR TITLE
Fix xaml root generics

### DIFF
--- a/Wrecept.Wpf/ViewModels/ProductMasterViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/ProductMasterViewModel.cs
@@ -5,6 +5,7 @@ using Wrecept.Core.Models;
 using Wrecept.Core.Services;
 using System.Threading.Tasks;
 using System;
+using System.Collections.Generic;
 
 namespace Wrecept.Wpf.ViewModels;
 

--- a/Wrecept.Wpf/Views/PaymentMethodMasterView.xaml
+++ b/Wrecept.Wpf/Views/PaymentMethodMasterView.xaml
@@ -2,7 +2,9 @@
                               xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                               xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                               xmlns:views="clr-namespace:Wrecept.Wpf.Views"
-                              xmlns:viewsControls="clr-namespace:Wrecept.Wpf.Views.Controls">
+                              xmlns:viewsControls="clr-namespace:Wrecept.Wpf.Views.Controls"
+                              xmlns:vm="clr-namespace:Wrecept.Wpf.ViewModels"
+                              x:TypeArguments="vm:PaymentMethodMasterViewModel">
     <viewsControls:BaseMasterView.Columns>
         <DataGridTextColumn Binding="{Binding Name}" Header="Név" />
         <DataGridTextColumn Binding="{Binding DueInDays}" Header="Határidő" />

--- a/Wrecept.Wpf/Views/ProductGroupMasterView.xaml
+++ b/Wrecept.Wpf/Views/ProductGroupMasterView.xaml
@@ -2,7 +2,9 @@
                               xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                               xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                               xmlns:views="clr-namespace:Wrecept.Wpf.Views"
-                              xmlns:viewsControls="clr-namespace:Wrecept.Wpf.Views.Controls">
+                              xmlns:viewsControls="clr-namespace:Wrecept.Wpf.Views.Controls"
+                              xmlns:vm="clr-namespace:Wrecept.Wpf.ViewModels"
+                              x:TypeArguments="vm:ProductGroupMasterViewModel">
     <viewsControls:BaseMasterView.Columns>
         <DataGridTextColumn Binding="{Binding Name}" Header="Név" />
         <DataGridCheckBoxColumn Binding="{Binding IsArchived}" Header="Archivált" />

--- a/Wrecept.Wpf/Views/ProductMasterView.xaml
+++ b/Wrecept.Wpf/Views/ProductMasterView.xaml
@@ -3,7 +3,8 @@
                               xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                               xmlns:views="clr-namespace:Wrecept.Wpf.Views"
                               xmlns:viewsControls="clr-namespace:Wrecept.Wpf.Views.Controls"
-                              xmlns:vm="clr-namespace:Wrecept.Wpf.ViewModels">
+                              xmlns:vm="clr-namespace:Wrecept.Wpf.ViewModels"
+                              x:TypeArguments="vm:ProductMasterViewModel">
     <viewsControls:BaseMasterView.Columns>
         <DataGridTextColumn Header="Név" Binding="{Binding Name}" Width="*" />
         <DataGridTextColumn Header="Nettó" Binding="{Binding Net}" Width="80" />

--- a/Wrecept.Wpf/Views/SupplierMasterView.xaml
+++ b/Wrecept.Wpf/Views/SupplierMasterView.xaml
@@ -2,7 +2,9 @@
                               xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                               xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                               xmlns:views="clr-namespace:Wrecept.Wpf.Views"
-                              xmlns:viewsControls="clr-namespace:Wrecept.Wpf.Views.Controls">
+                              xmlns:viewsControls="clr-namespace:Wrecept.Wpf.Views.Controls"
+                              xmlns:vm="clr-namespace:Wrecept.Wpf.ViewModels"
+                              x:TypeArguments="vm:SupplierMasterViewModel">
     <viewsControls:BaseMasterView.Columns>
         <DataGridTextColumn Header="Név" Binding="{Binding Name}" Width="*" />
     </viewsControls:BaseMasterView.Columns>

--- a/Wrecept.Wpf/Views/TaxRateMasterView.xaml
+++ b/Wrecept.Wpf/Views/TaxRateMasterView.xaml
@@ -2,7 +2,9 @@
                               xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                               xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                               xmlns:views="clr-namespace:Wrecept.Wpf.Views"
-                              xmlns:viewsControls="clr-namespace:Wrecept.Wpf.Views.Controls">
+                              xmlns:viewsControls="clr-namespace:Wrecept.Wpf.Views.Controls"
+                              xmlns:vm="clr-namespace:Wrecept.Wpf.ViewModels"
+                              x:TypeArguments="vm:TaxRateMasterViewModel">
     <viewsControls:BaseMasterView.Columns>
         <DataGridTextColumn Binding="{Binding Code}" Header="Kód" />
         <DataGridTextColumn Binding="{Binding Name}" Header="Név" />

--- a/Wrecept.Wpf/Views/UnitMasterView.xaml
+++ b/Wrecept.Wpf/Views/UnitMasterView.xaml
@@ -2,7 +2,9 @@
                               xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                               xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                               xmlns:views="clr-namespace:Wrecept.Wpf.Views"
-                              xmlns:viewsControls="clr-namespace:Wrecept.Wpf.Views.Controls">
+                              xmlns:viewsControls="clr-namespace:Wrecept.Wpf.Views.Controls"
+                              xmlns:vm="clr-namespace:Wrecept.Wpf.ViewModels"
+                              x:TypeArguments="vm:UnitMasterViewModel">
     <viewsControls:BaseMasterView.Columns>
         <DataGridTextColumn Binding="{Binding Code}" Header="Kód" />
         <DataGridTextColumn Binding="{Binding Name}" Header="Név" />

--- a/docs/progress/2025-07-01_23-36-03_code_agent.md
+++ b/docs/progress/2025-07-01_23-36-03_code_agent.md
@@ -1,0 +1,2 @@
+- Build hibák javítva: generic BaseMasterView XAML-ben `x:TypeArguments` hozzáadva, így a partial deklarációk egységesek.
+- ProductMasterViewModelhez hiányzó `List` using került.


### PR DESCRIPTION
## Summary
- set x:TypeArguments on master views so code-behind generics match
- add missing `List` using for ProductMasterViewModel
- log build fix progress

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop missing)*
- `dotnet test tests/Wrecept.Tests/Wrecept.Tests.csproj` *(fails: Project Wrecept.Wpf not compatible)*

------
https://chatgpt.com/codex/tasks/task_e_68646ff56e0c8322bc5bbbeebe902b6a