### PR TITLE
Implement screen mode manager with scaling options

### DIFF
--- a/Wrecept.Core/Entities/AppSettings.cs
+++ b/Wrecept.Core/Entities/AppSettings.cs
@@ -1,0 +1,6 @@
+namespace Wrecept.Core.Entities;
+
+public class AppSettings
+{
+    public ScreenMode ScreenMode { get; set; } = ScreenMode.Large;
+}

--- a/Wrecept.Core/ScreenMode.cs
+++ b/Wrecept.Core/ScreenMode.cs
@@ -1,0 +1,9 @@
+namespace Wrecept.Core;
+
+public enum ScreenMode
+{
+    Small,
+    Medium,
+    Large,
+    ExtraLarge
+}

--- a/Wrecept.Core/Services/ISettingsService.cs
+++ b/Wrecept.Core/Services/ISettingsService.cs
@@ -1,0 +1,9 @@
+using Wrecept.Core.Entities;
+
+namespace Wrecept.Core.Services;
+
+public interface ISettingsService
+{
+    Task<AppSettings> LoadAsync();
+    Task SaveAsync(AppSettings settings);
+}

--- a/Wrecept.Storage/ServiceCollectionExtensions.cs
+++ b/Wrecept.Storage/ServiceCollectionExtensions.cs
@@ -25,6 +25,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IUnitRepository, UnitRepository>();
         services.AddSingleton<ILogService, LogService>();
         services.AddSingleton<IUserInfoService, UserInfoService>();
+        services.AddSingleton<ISettingsService, SettingsService>();
 
         using var provider = services.BuildServiceProvider();
         var factory = provider.GetRequiredService<IDbContextFactory<AppDbContext>>();

--- a/Wrecept.Storage/Services/SettingsService.cs
+++ b/Wrecept.Storage/Services/SettingsService.cs
@@ -1,0 +1,26 @@
+using System.Text.Json;
+using Wrecept.Core.Entities;
+using Wrecept.Core.Services;
+
+namespace Wrecept.Storage.Services;
+
+public class SettingsService : ISettingsService
+{
+    private readonly string _path = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+        "Wrecept", "settings.json");
+
+    public async Task<AppSettings> LoadAsync()
+    {
+        if (!File.Exists(_path)) return new AppSettings();
+        using var stream = File.OpenRead(_path);
+        return await JsonSerializer.DeserializeAsync<AppSettings>(stream) ?? new AppSettings();
+    }
+
+    public async Task SaveAsync(AppSettings settings)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(_path)!);
+        using var stream = File.Create(_path);
+        await JsonSerializer.SerializeAsync(stream, settings, new JsonSerializerOptions { WriteIndented = true });
+    }
+}

--- a/Wrecept.Wpf/App.xaml.cs
+++ b/Wrecept.Wpf/App.xaml.cs
@@ -51,12 +51,15 @@ public partial class App : Application
         services.AddTransient<PaymentMethodMasterViewModel>();
         services.AddTransient<UnitMasterViewModel>();
         services.AddTransient<UserInfoViewModel>();
+        services.AddTransient<ScreenModeViewModel>();
         services.AddTransient<AboutViewModel>();
         services.AddTransient<PlaceholderViewModel>();
         services.AddSingleton<StatusBarViewModel>();
         services.AddSingleton<INotificationService, MessageBoxNotificationService>();
+        services.AddSingleton<ScreenModeManager>();
         services.AddTransient<ProgressViewModel>();
         services.AddTransient<StartupWindow>();
+        services.AddTransient<ScreenModeWindow>();
         services.AddTransient<StartupOrchestrator>();
         services.AddTransient<StageView>();
         services.AddTransient<InvoiceEditorView>();

--- a/Wrecept.Wpf/MainWindow.xaml.cs
+++ b/Wrecept.Wpf/MainWindow.xaml.cs
@@ -1,13 +1,15 @@
 using System.Windows;
 using Wrecept.Wpf.Views;
+using Wrecept.Wpf.Services;
 
 namespace Wrecept.Wpf;
 
 public partial class MainWindow : Window
 {
-    public MainWindow(StageView stageView)
+    public MainWindow(StageView stageView, ScreenModeManager screenModeManager)
     {
         InitializeComponent();
         ContentHost.Content = stageView;
+        Loaded += async (_, _) => await screenModeManager.ApplySavedAsync(this);
     }
 }

--- a/Wrecept.Wpf/Services/ScreenModeManager.cs
+++ b/Wrecept.Wpf/Services/ScreenModeManager.cs
@@ -1,0 +1,47 @@
+using Wrecept.Core;
+using Wrecept.Core.Entities;
+using Wrecept.Core.Services;
+
+namespace Wrecept.Wpf.Services;
+
+public class ScreenModeManager
+{
+    private readonly ISettingsService _settings;
+
+    public ScreenModeManager(ISettingsService settings)
+    {
+        _settings = settings;
+    }
+
+    public ScreenMode CurrentMode { get; private set; } = ScreenMode.Large;
+
+    public async Task ApplySavedAsync(MainWindow window)
+    {
+        var config = await _settings.LoadAsync();
+        CurrentMode = config.ScreenMode;
+        Apply(window, CurrentMode);
+    }
+
+    public async Task ChangeModeAsync(MainWindow window, ScreenMode mode)
+    {
+        if (mode == CurrentMode) return;
+        CurrentMode = mode;
+        Apply(window, mode);
+        await _settings.SaveAsync(new AppSettings { ScreenMode = mode });
+    }
+
+    private static void Apply(MainWindow window, ScreenMode mode)
+    {
+        ThemeSizing.Apply(mode);
+        var (w, h) = mode switch
+        {
+            ScreenMode.Small => (800d, 600d),
+            ScreenMode.Medium => (1024d, 768d),
+            ScreenMode.Large => (1280d, 1024d),
+            ScreenMode.ExtraLarge => (1920d, 1080d),
+            _ => (1280d, 1024d)
+        };
+        window.Width = w;
+        window.Height = h;
+    }
+}

--- a/Wrecept.Wpf/ThemeSizing.cs
+++ b/Wrecept.Wpf/ThemeSizing.cs
@@ -1,0 +1,31 @@
+using System.Windows;
+using Wrecept.Core;
+
+namespace Wrecept.Wpf;
+
+public static class ThemeSizing
+{
+    public static void Apply(ScreenMode mode)
+    {
+        var res = Application.Current.Resources;
+        switch (mode)
+        {
+            case ScreenMode.Small:
+                res["FontSizeNormal"] = 12d;
+                res["FontSizeLarge"] = 14d;
+                break;
+            case ScreenMode.Medium:
+                res["FontSizeNormal"] = 14d;
+                res["FontSizeLarge"] = 16d;
+                break;
+            case ScreenMode.Large:
+                res["FontSizeNormal"] = 16d;
+                res["FontSizeLarge"] = 18d;
+                break;
+            case ScreenMode.ExtraLarge:
+                res["FontSizeNormal"] = 18d;
+                res["FontSizeLarge"] = 20d;
+                break;
+        }
+    }
+}

--- a/Wrecept.Wpf/ViewModels/ScreenModeViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/ScreenModeViewModel.cs
@@ -1,0 +1,33 @@
+using System.Collections.ObjectModel;
+using System.Windows;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Wrecept.Core;
+using Wrecept.Wpf.Services;
+
+namespace Wrecept.Wpf.ViewModels;
+
+public partial class ScreenModeViewModel : ObservableObject
+{
+    private readonly ScreenModeManager _manager;
+
+    public ObservableCollection<ScreenMode> Modes { get; } = new(Enum.GetValues<ScreenMode>());
+
+    [ObservableProperty]
+    private ScreenMode selectedMode;
+
+    public ScreenModeViewModel(ScreenModeManager manager)
+    {
+        _manager = manager;
+        SelectedMode = manager.CurrentMode;
+    }
+
+    [RelayCommand]
+    private async Task Apply(Window window)
+    {
+        if (App.Current.MainWindow is MainWindow main)
+            await _manager.ChangeModeAsync(main, SelectedMode);
+        window.DialogResult = true;
+        window.Close();
+    }
+}

--- a/Wrecept.Wpf/ViewModels/StageViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/StageViewModel.cs
@@ -118,10 +118,15 @@ private async Task HandleMenu(StageMenuAction action)
             case StageMenuAction.InventoryCard:
             case StageMenuAction.CheckFiles:
             case StageMenuAction.AfterPowerOutage:
-            case StageMenuAction.ScreenSettings:
             case StageMenuAction.PrinterSettings:
                 CurrentViewModel = _placeholder;
                 _statusBar.Message = Resources.Strings.Stage_FunctionNotReady;
+                break;
+            case StageMenuAction.ScreenSettings:
+                var win = App.Provider.GetRequiredService<ScreenModeWindow>();
+                win.Owner = App.Current.MainWindow;
+                win.ShowDialog();
+                _statusBar.Message = "Képernyő mód frissítve";
                 break;
             case StageMenuAction.EditUserInfo:
                 CurrentViewModel = _userInfo;

--- a/Wrecept.Wpf/Views/ScreenModeWindow.xaml
+++ b/Wrecept.Wpf/Views/ScreenModeWindow.xaml
@@ -1,0 +1,13 @@
+<Window x:Class="Wrecept.Wpf.Views.ScreenModeWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Képernyőbeállítás" Height="250" Width="300"
+        WindowStartupLocation="CenterOwner" KeyDown="OnKeyDown">
+    <StackPanel Margin="10">
+        <ListBox ItemsSource="{Binding Modes}" SelectedItem="{Binding SelectedMode}"/>
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
+            <Button Content="OK" Width="80" Margin="0,0,8,0" Command="{Binding ApplyCommand}" CommandParameter="{Binding RelativeSource={RelativeSource AncestorType=Window}}"/>
+            <Button Content="Mégse" Width="80" IsCancel="True"/>
+        </StackPanel>
+    </StackPanel>
+</Window>

--- a/Wrecept.Wpf/Views/ScreenModeWindow.xaml.cs
+++ b/Wrecept.Wpf/Views/ScreenModeWindow.xaml.cs
@@ -1,0 +1,17 @@
+using System.Windows;
+using System.Windows.Input;
+using Wrecept.Wpf.ViewModels;
+
+namespace Wrecept.Wpf.Views;
+
+public partial class ScreenModeWindow : Window
+{
+    public ScreenModeWindow(ScreenModeViewModel viewModel)
+    {
+        InitializeComponent();
+        DataContext = viewModel;
+    }
+
+    private void OnKeyDown(object sender, KeyEventArgs e)
+        => NavigationHelper.Handle(e);
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -48,6 +48,7 @@ Az `InvoiceService` kezeli a fejléc frissítését (`UpdateInvoiceHeaderAsync`)
 Minden hibát az `ILogService` rögzít, amelyet a Storage réteg `LogService` implementációja valósít meg. A naplók a `%AppData%/Wrecept/logs` mappában napi bontású fájlokba kerülnek.
 Felhasználói üzenetekhez az `INotificationService` ad egységes felületet. WPF alatt a `MessageBoxNotificationService` jeleníti meg a dialógusokat, míg a tesztekben egy csonk "MockNotificationService" működik.
 Az alapvető cégadatokat a `UserInfoService` kezeli. Az adatok a `%AppData%/Wrecept/wrecept.json` fájlban tárolódnak, betöltésük az alkalmazás futása közben történik.
+Az aktuális képernyőmódot a `SettingsService` tartja nyilván `settings.json` fájlban, amit a `ScreenModeManager` olvas be induláskor.
 
 Minden domain modell tartalmaz `CreatedAt` és `UpdatedAt` mezőket. Ezeket a service réteg inicializálja, így naplózható az adat módosításának ideje.
 

--- a/docs/progress/2025-07-02_00-03-44_code_agent.md
+++ b/docs/progress/2025-07-02_00-03-44_code_agent.md
@@ -1,0 +1,5 @@
+- ScreenMode enum és AppSettings létrehozva.
+- SettingsService JSON fájlba menti a képernyőmódot.
+- ScreenModeManager alkalmazza az ablakméretet és betűméreteket.
+- Képernyőbeállítás ablak hozzáadva menüből elérhetően.
+- themes.md frissült a képernyőmódok dokumentálásával.

--- a/docs/themes.md
+++ b/docs/themes.md
@@ -25,3 +25,10 @@ DataGrid sorok fekete háttérrel és arany kiemeléssel jelennek meg a DOS-hat�
 
 Every control style sets `FocusVisualStyle` to display a dashed border so keyboard navigation is obvious.
 - The StatusBar uses `ControlBackgroundBrush` with subtle text to avoid distraction while conveying state.
+
+## Screen Modes
+
+A `ScreenModeManager` négy előre definiált profil közül választ:
+Small (800x600), Medium (1024x768), Large (1280x1024) és ExtraLarge (1920x1080).
+Az ablakméret és a betűméret a kiválasztott mód szerint frissül, az értékek a
+`%AppData%/Wrecept/settings.json` fájlban tárolódnak.


### PR DESCRIPTION
## Summary
- add `ScreenMode` enum and `AppSettings`
- persist selected screen mode in `SettingsService`
- introduce `ScreenModeManager` and `ThemeSizing` for runtime scaling
- enable screen size selection via new `ScreenModeWindow`
- document screen modes and update architecture

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686475c72b5c83229f729cb4e5e4a0bb