### PR TITLE
Fix build-time errors in ScreenModeManager and converter

### DIFF
--- a/Wrecept.Wpf/Converters/InvoiceLineTotalsConverter.cs
+++ b/Wrecept.Wpf/Converters/InvoiceLineTotalsConverter.cs
@@ -37,7 +37,11 @@ public class InvoiceLineTotalsConverter : IMultiValueConverter
     }
 
     public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
-        => throw new NotImplementedException();
+    {
+        // A visszairányú konverzióra jelenleg nincs szükség, ezért "DoNothing" jelzés
+        // mellett üres tömbbel térünk vissza, hogy a binding ne okozzon hibát.
+        return Array.Empty<object>();
+    }
 }
 
 public enum InvoiceLineTotalsConverterMode

--- a/Wrecept.Wpf/Services/ScreenModeManager.cs
+++ b/Wrecept.Wpf/Services/ScreenModeManager.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using Wrecept.Core;
 using Wrecept.Core.Entities;
 using Wrecept.Core.Services;

--- a/Wrecept.Wpf/ViewModels/ScreenModeViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/ScreenModeViewModel.cs
@@ -1,5 +1,6 @@
 using System.Collections.ObjectModel;
 using System.Windows;
+using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Wrecept.Core;

--- a/docs/progress/2025-07-02_00-21-21_code_agent.md
+++ b/docs/progress/2025-07-02_00-21-21_code_agent.md
@@ -1,0 +1,2 @@
+- Build hibajavítás: ScreenModeViewModel és ScreenModeManager 'Task' using hozzáadva.
+- InvoiceLineTotalsConverter ConvertBack implementálva, üres tömbbel tér vissza.


### PR DESCRIPTION
## Summary
- add missing `System.Threading.Tasks` usings in `ScreenModeManager` and `ScreenModeViewModel`
- implement `ConvertBack` for `InvoiceLineTotalsConverter`
- document progress

## Testing
- `dotnet build Wrecept.Core/Wrecept.Core.csproj`
- `dotnet build Wrecept.Wpf/Wrecept.Wpf.csproj` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_68647acc18448322b8fd5cd86116f4c2