### PR TITLE
Fix missing using directives

### DIFF
--- a/Wrecept.Wpf/ViewModels/ScreenModeViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/ScreenModeViewModel.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.ObjectModel;
 using System.Windows;
 using System.Threading.Tasks;

--- a/Wrecept.Wpf/ViewModels/StageViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/StageViewModel.cs
@@ -1,8 +1,10 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Microsoft.Extensions.DependencyInjection;
 using System.Threading.Tasks;
 using System.Windows;
 using Wrecept.Wpf.Resources;
+using Wrecept.Wpf.Views;
 
 namespace Wrecept.Wpf.ViewModels;
 

--- a/docs/progress/2025-07-02_00-26-22_code_agent.md
+++ b/docs/progress/2025-07-02_00-26-22_code_agent.md
@@ -1,0 +1,3 @@
+- Added missing `using System` to ScreenModeViewModel for Enum access.
+- Included Microsoft.Extensions.DependencyInjection and view namespace in StageViewModel.
+- Build still fails due to missing WindowsDesktop SDK.


### PR DESCRIPTION
## Summary
- fix ScreenModeViewModel missing System namespace
- inject view namespace and DI extension usage in StageViewModel
- log progress

## Testing
- `dotnet build Wrecept.sln -c Release` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_68647c23beac832293899bdb73d60caf