### PR TITLE
Refactor invoice layout and add edit dialog base

### DIFF
--- a/Wrecept.Wpf/Dialogs/DialogHelper.cs
+++ b/Wrecept.Wpf/Dialogs/DialogHelper.cs
@@ -1,0 +1,33 @@
+using System.Windows;
+using System.Windows.Input;
+using CommunityToolkit.Mvvm.Input;
+
+namespace Wrecept.Wpf.Dialogs;
+
+public static class DialogHelper
+{
+    public static void CenterToOwner(Window dialog, Window owner)
+    {
+        dialog.WindowStartupLocation = WindowStartupLocation.Manual;
+        dialog.Owner = owner;
+        dialog.Left = owner.Left + (owner.Width - dialog.Width) / 2;
+        dialog.Top = owner.Top + (owner.Height - dialog.Height) / 2;
+    }
+
+    public static void MapKeys(Window dialog, IRelayCommand ok, IRelayCommand cancel)
+    {
+        dialog.PreviewKeyDown += (_, e) =>
+        {
+            if (e.Key == Key.Enter)
+            {
+                ok.Execute(null);
+                e.Handled = true;
+            }
+            else if (e.Key == Key.Escape)
+            {
+                cancel.Execute(null);
+                e.Handled = true;
+            }
+        };
+    }
+}

--- a/Wrecept.Wpf/Dialogs/EditEntityDialog.cs
+++ b/Wrecept.Wpf/Dialogs/EditEntityDialog.cs
@@ -1,0 +1,26 @@
+using System.Windows;
+using CommunityToolkit.Mvvm.Input;
+
+namespace Wrecept.Wpf.Dialogs;
+
+public class EditEntityDialog<TView, TViewModel> : Window
+    where TView : FrameworkElement, new()
+    where TViewModel : class
+{
+    public TViewModel ViewModel { get; }
+
+    public EditEntityDialog(TViewModel viewModel)
+    {
+        ViewModel = viewModel;
+        var view = new TView { DataContext = viewModel };
+        Content = view;
+        WindowStyle = WindowStyle.ToolWindow;
+        SizeToContent = SizeToContent.WidthAndHeight;
+    }
+
+    public void Initialize(IRelayCommand ok, IRelayCommand cancel)
+    {
+        DialogHelper.CenterToOwner(this, Application.Current.MainWindow!);
+        DialogHelper.MapKeys(this, ok, cancel);
+    }
+}

--- a/Wrecept.Wpf/Services/DialogService.cs
+++ b/Wrecept.Wpf/Services/DialogService.cs
@@ -1,0 +1,17 @@
+using CommunityToolkit.Mvvm.Input;
+using Wrecept.Wpf.Dialogs;
+
+namespace Wrecept.Wpf.Services;
+
+public static class DialogService
+{
+    public static bool EditEntity<TView, TViewModel>(TViewModel viewModel,
+        IRelayCommand okCommand, IRelayCommand cancelCommand)
+        where TView : System.Windows.FrameworkElement, new()
+        where TViewModel : class
+    {
+        var dlg = new EditEntityDialog<TView, TViewModel>(viewModel);
+        dlg.Initialize(okCommand, cancelCommand);
+        return NavigationService.ShowCenteredDialog(dlg);
+    }
+}

--- a/Wrecept.Wpf/Services/NavigationService.cs
+++ b/Wrecept.Wpf/Services/NavigationService.cs
@@ -1,0 +1,14 @@
+using System.Windows;
+using Wrecept.Wpf.Dialogs;
+
+namespace Wrecept.Wpf.Services;
+
+public static class NavigationService
+{
+    public static bool ShowCenteredDialog(Window dialog)
+    {
+        if (Application.Current.MainWindow is { } owner)
+            DialogHelper.CenterToOwner(dialog, owner);
+        return dialog.ShowDialog() == true;
+    }
+}

--- a/Wrecept.Wpf/ViewModels/ProductEditorViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/ProductEditorViewModel.cs
@@ -1,0 +1,25 @@
+using System;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+
+namespace Wrecept.Wpf.ViewModels;
+
+public partial class ProductEditorViewModel : ObservableObject
+{
+    [ObservableProperty] private string name = string.Empty;
+    [ObservableProperty] private decimal net;
+    [ObservableProperty] private decimal gross;
+    [ObservableProperty] private Guid taxRateId;
+
+    public IRelayCommand OkCommand { get; }
+    public IRelayCommand CancelCommand { get; }
+
+    public ProductEditorViewModel()
+    {
+        OkCommand = new RelayCommand(() => OnOk?.Invoke(this));
+        CancelCommand = new RelayCommand(() => OnCancel?.Invoke());
+    }
+
+    public Action<ProductEditorViewModel>? OnOk;
+    public Action? OnCancel;
+}

--- a/Wrecept.Wpf/ViewModels/VatKeyEditorViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/VatKeyEditorViewModel.cs
@@ -1,0 +1,22 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+
+namespace Wrecept.Wpf.ViewModels;
+
+public partial class VatKeyEditorViewModel : ObservableObject
+{
+    [ObservableProperty] private string name = string.Empty;
+    [ObservableProperty] private decimal percentage;
+
+    public IRelayCommand OkCommand { get; }
+    public IRelayCommand CancelCommand { get; }
+
+    public VatKeyEditorViewModel()
+    {
+        OkCommand = new RelayCommand(() => OnOk?.Invoke(this));
+        CancelCommand = new RelayCommand(() => OnCancel?.Invoke());
+    }
+
+    public Action<VatKeyEditorViewModel>? OnOk;
+    public Action? OnCancel;
+}

--- a/Wrecept.Wpf/Views/EditDialogs/ProductEditorView.xaml
+++ b/Wrecept.Wpf/Views/EditDialogs/ProductEditorView.xaml
@@ -1,0 +1,21 @@
+<UserControl x:Class="Wrecept.Wpf.Views.EditDialogs.ProductEditorView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             KeyDown="OnKeyDown">
+    <StackPanel Margin="10">
+        <TextBlock Text="Név" />
+        <TextBox x:Name="InitialFocus" Text="{Binding Name}" Width="200" />
+        <StackPanel Orientation="Horizontal" Margin="0,4,0,0">
+            <TextBlock Width="80" Text="Nettó"/>
+            <TextBox Text="{Binding Net}" Width="80"/>
+        </StackPanel>
+        <StackPanel Orientation="Horizontal" Margin="0,4,0,0">
+            <TextBlock Width="80" Text="Bruttó"/>
+            <TextBox Text="{Binding Gross}" Width="80"/>
+        </StackPanel>
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
+            <Button Content="OK" Width="80" Margin="0,0,8,0" Command="{Binding OkCommand}" />
+            <Button Content="Mégse" Width="80" Command="{Binding CancelCommand}" />
+        </StackPanel>
+    </StackPanel>
+</UserControl>

--- a/Wrecept.Wpf/Views/EditDialogs/ProductEditorView.xaml.cs
+++ b/Wrecept.Wpf/Views/EditDialogs/ProductEditorView.xaml.cs
@@ -1,0 +1,15 @@
+using System.Windows.Controls;
+using System.Windows.Input;
+
+namespace Wrecept.Wpf.Views.EditDialogs;
+
+public partial class ProductEditorView : UserControl
+{
+    public ProductEditorView()
+    {
+        InitializeComponent();
+    }
+
+    private void OnKeyDown(object sender, KeyEventArgs e)
+        => NavigationHelper.Handle(e);
+}

--- a/Wrecept.Wpf/Views/EditDialogs/VatKeyEditorView.xaml
+++ b/Wrecept.Wpf/Views/EditDialogs/VatKeyEditorView.xaml
@@ -1,0 +1,17 @@
+<UserControl x:Class="Wrecept.Wpf.Views.EditDialogs.VatKeyEditorView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             KeyDown="OnKeyDown">
+    <StackPanel Margin="10">
+        <TextBlock Text="Név" />
+        <TextBox x:Name="InitialFocus" Text="{Binding Name}" Width="200" />
+        <StackPanel Orientation="Horizontal" Margin="0,4,0,0">
+            <TextBlock Width="80" Text="%"/>
+            <TextBox Text="{Binding Percentage}" Width="80"/>
+        </StackPanel>
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
+            <Button Content="OK" Width="80" Margin="0,0,8,0" Command="{Binding OkCommand}" />
+            <Button Content="Mégse" Width="80" Command="{Binding CancelCommand}" />
+        </StackPanel>
+    </StackPanel>
+</UserControl>

--- a/Wrecept.Wpf/Views/EditDialogs/VatKeyEditorView.xaml.cs
+++ b/Wrecept.Wpf/Views/EditDialogs/VatKeyEditorView.xaml.cs
@@ -1,0 +1,15 @@
+using System.Windows.Controls;
+using System.Windows.Input;
+
+namespace Wrecept.Wpf.Views.EditDialogs;
+
+public partial class VatKeyEditorView : UserControl
+{
+    public VatKeyEditorView()
+    {
+        InitializeComponent();
+    }
+
+    private void OnKeyDown(object sender, KeyEventArgs e)
+        => NavigationHelper.Handle(e);
+}

--- a/Wrecept.Wpf/Views/InlinePrompts/InvoiceCreatePromptView.xaml
+++ b/Wrecept.Wpf/Views/InlinePrompts/InvoiceCreatePromptView.xaml
@@ -2,7 +2,7 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              KeyDown="OnKeyDown">
-    <Border Background="#F5F5DC" Padding="4" Margin="0,4,0,0">
+    <Border Background="#F5F5DC" Padding="4" Margin="0,4,0,0" HorizontalAlignment="Center">
         <TextBlock Text="{Binding Message}" />
     </Border>
 </UserControl>

--- a/Wrecept.Wpf/Views/InvoiceEditorView.xaml
+++ b/Wrecept.Wpf/Views/InvoiceEditorView.xaml
@@ -50,8 +50,20 @@
 
         <view:InvoiceLookupView x:Name="LookupView" DataContext="{Binding Lookup}" />
 
-        <StackPanel Grid.Column="1" Margin="4">
-            <GroupBox Header="Számlafejléc" Margin="0,0,0,6">
+        <Grid Grid.Column="1" Margin="4">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+            <GroupBox Header="Számlafejléc" Margin="0,0,0,6" Grid.Row="0">
                 <Grid Margin="4">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="70" />
@@ -91,10 +103,10 @@
                     <CheckBox Grid.Row="4" Grid.Column="1" Content="Bruttó ár" IsChecked="{Binding IsGross}" IsEnabled="{Binding IsEditable}" />
                 </Grid>
             </GroupBox>
-            <Separator Margin="0,6" />
+            <Separator Margin="0,6" Grid.Row="1" />
 
             <StackPanel Orientation="Horizontal" DataContext="{Binding Items[0]}" KeyDown="OnEntryKeyDown"
-                        Background="{DynamicResource ControlBackgroundBrush}" FontStyle="Italic" Margin="0,0,0,4">
+                        Background="{DynamicResource ControlBackgroundBrush}" FontStyle="Italic" Margin="0,0,0,4" Grid.Row="2">
                 <c:EditLookup x:Name="EntryProduct" Width="200"
                               ItemsSource="{Binding DataContext.Products, RelativeSource={RelativeSource AncestorType=UserControl}}"
                               DisplayMemberPath="Name"
@@ -114,17 +126,17 @@
                               SelectedValue="{Binding TaxRateId, Mode=TwoWay}"/>
             </StackPanel>
 
-            <Separator Margin="0,6" />
+            <Separator Margin="0,6" Grid.Row="3" />
 
-            <view:InvoiceItemsGrid x:Name="ItemsGrid" Margin="0,4,0,0" />
+            <view:InvoiceItemsGrid x:Name="ItemsGrid" Margin="0,4,0,0" Grid.Row="4" />
 
-            <Separator Margin="0,6" />
+            <Separator Margin="0,6" Grid.Row="5" />
 
-            <c:TotalsPanel />
+            <c:TotalsPanel Grid.Row="6" />
 
-            <TextBlock Text="Negatív mennyiség visszárut jelez." FontStyle="Italic" Margin="0,4" />
+            <TextBlock Text="Negatív mennyiség visszárut jelez." FontStyle="Italic" Margin="0,4" Grid.Row="7" />
 
-            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,6">
+            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,6" Grid.Row="8">
                 <Button Content="Mentés" Command="{Binding SaveCommand}" Margin="0,0,4,0" FocusVisualStyle="{StaticResource GoldFocusVisual}" />
                 <Button Content="Nyomtatás" IsEnabled="{Binding IsArchived}" Margin="0,0,4,0" FocusVisualStyle="{StaticResource GoldFocusVisual}" />
                 <Button Content="Bezárás" Command="{Binding CloseCommand}" Margin="0,0,4,0" FocusVisualStyle="{StaticResource GoldFocusVisual}" />
@@ -141,8 +153,8 @@
                 </Button>
             </StackPanel>
 
-            <ContentControl Content="{Binding SavePrompt}" Visibility="{Binding IsSavePromptVisible, Converter={StaticResource BooleanToVisibilityConverter}}" />
-            <ContentControl Content="{Binding ArchivePrompt}" Visibility="{Binding IsArchivePromptVisible, Converter={StaticResource BooleanToVisibilityConverter}}" />
-        </StackPanel>
+            <ContentControl Content="{Binding SavePrompt}" Visibility="{Binding IsSavePromptVisible, Converter={StaticResource BooleanToVisibilityConverter}}" Grid.Row="9" />
+            <ContentControl Content="{Binding ArchivePrompt}" Visibility="{Binding IsArchivePromptVisible, Converter={StaticResource BooleanToVisibilityConverter}}" Grid.Row="9" Margin="0,4,0,0" />
+        </Grid>
     </Grid>
 </UserControl>

--- a/Wrecept.Wpf/Views/InvoiceItemsGrid.xaml
+++ b/Wrecept.Wpf/Views/InvoiceItemsGrid.xaml
@@ -68,7 +68,8 @@
     </UserControl.Resources>
     <DataGrid x:Name="Grid" ItemsSource="{Binding Items}" AutoGenerateColumns="False"
              IsReadOnly="False"
-             KeyDown="OnKeyDown" RowDetailsVisibilityMode="Collapsed">
+             KeyDown="OnKeyDown" RowDetailsVisibilityMode="Collapsed"
+             VerticalAlignment="Stretch">
         <DataGrid.RowStyle>
             <Style TargetType="DataGridRow">
                 <Setter Property="Background" Value="{Binding Quantity, Converter={StaticResource QuantityToStyleConverter}}" />

--- a/Wrecept.Wpf/Views/InvoiceLookupView.xaml.cs
+++ b/Wrecept.Wpf/Views/InvoiceLookupView.xaml.cs
@@ -31,6 +31,22 @@ public partial class InvoiceLookupView : UserControl
     {
         if (DataContext is InvoiceLookupViewModel vm)
         {
+            if (vm.InlinePrompt is InvoiceCreatePromptViewModel prompt)
+            {
+                if (e.Key == Key.Enter)
+                {
+                    prompt.ConfirmCommand.Execute(null);
+                    e.Handled = true;
+                    return;
+                }
+                if (e.Key == Key.Escape)
+                {
+                    prompt.CancelCommand.Execute(null);
+                    e.Handled = true;
+                    return;
+                }
+            }
+
             if (e.Key == Key.Up && InvoiceList.SelectedIndex == 0)
             {
                 if (vm.InlinePrompt is null)

--- a/docs/progress/2025-07-02_00-53-55_code_agent.md
+++ b/docs/progress/2025-07-02_00-53-55_code_agent.md
@@ -1,0 +1,4 @@
+- Added DialogHelper and generic EditEntityDialog for consistent modal behavior.
+- InvoiceLookupView handles InlinePrompt keys to avoid unintended invoice open.
+- InvoiceCreatePromptView centered; InvoiceEditorView layout uses flexible grid.
+- Introduced NavigationService and DialogService stubs for future dialog routing.


### PR DESCRIPTION
## Summary
- center invoice creation prompt and block Enter/Esc fall-through
- make invoice items grid stretch with window
- add DialogHelper + EditEntityDialog for reusable modals
- stub NavigationService and DialogService
- document progress

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686481b7421c832291317b3477699e9d