### PR TITLE
Fix invalid FontStyle in InvoiceEditorView

### DIFF
--- a/Wrecept.Wpf/Views/InvoiceEditorView.xaml
+++ b/Wrecept.Wpf/Views/InvoiceEditorView.xaml
@@ -106,7 +106,7 @@
             <Separator Margin="0,6" Grid.Row="1" />
 
             <StackPanel Orientation="Horizontal" DataContext="{Binding Items[0]}" KeyDown="OnEntryKeyDown"
-                        Background="{DynamicResource ControlBackgroundBrush}" FontStyle="Italic" Margin="0,0,0,4" Grid.Row="2">
+                        Background="{DynamicResource ControlBackgroundBrush}" Margin="0,0,0,4" Grid.Row="2">
                 <c:EditLookup x:Name="EntryProduct" Width="200"
                               ItemsSource="{Binding DataContext.Products, RelativeSource={RelativeSource AncestorType=UserControl}}"
                               DisplayMemberPath="Name"

--- a/docs/progress/2025-07-02_01-03-10_ui_agent.md
+++ b/docs/progress/2025-07-02_01-03-10_ui_agent.md
@@ -1,0 +1,1 @@
+- Build hibát okozó `FontStyle` attribútum eltávolítva az InvoiceEditorView belső StackPanel-jéről.


### PR DESCRIPTION
## Summary
- remove unsupported `FontStyle` from the entry stack panel
- log the fix

## Testing
- `dotnet build Wrecept.sln -v:m` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*
- `dotnet test tests/Wrecept.Tests/Wrecept.Tests.csproj` *(fails: Wrecept.Wpf not compatible with net8.0)*

------
https://chatgpt.com/codex/tasks/task_e_6864849628048322b21b666921a5d4b7