### PR TITLE
Fix compile errors in Wrecept WPF

### DIFF
--- a/Wrecept.Wpf/ViewModels/VatKeyEditorViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/VatKeyEditorViewModel.cs
@@ -1,3 +1,4 @@
+using System;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 

--- a/Wrecept.Wpf/Views/InvoiceEditorView.xaml
+++ b/Wrecept.Wpf/Views/InvoiceEditorView.xaml
@@ -134,7 +134,7 @@
 
             <c:TotalsPanel Grid.Row="6" />
 
-            <TextBlock Text="Negatív mennyiség visszárut jelez." FontStyle="Italic" Margin="0,4" Grid.Row="7" />
+            <TextBlock Text="Negatív mennyiség visszárut jelez." FontStyle="{x:Static FontStyles.Italic}" Margin="0,4" Grid.Row="7" />
 
             <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,6" Grid.Row="8">
                 <Button Content="Mentés" Command="{Binding SaveCommand}" Margin="0,0,4,0" FocusVisualStyle="{StaticResource GoldFocusVisual}" />

--- a/docs/progress/2025-07-02_01-59-45_code_agent.md
+++ b/docs/progress/2025-07-02_01-59-45_code_agent.md
@@ -1,0 +1,2 @@
+- Added `using System;` in `VatKeyEditorViewModel` to enable `Action` delegates.
+- Ensured compile-time safety by referencing `FontStyles.Italic` in `InvoiceEditorView`.


### PR DESCRIPTION
## Summary
- fix Action delegate references in `VatKeyEditorViewModel`
- clarify XAML italic style usage in `InvoiceEditorView`
- log progress

## Testing
- `dotnet build Wrecept.Core/Wrecept.Core.csproj`

------
https://chatgpt.com/codex/tasks/task_e_6864919cfddc8322814700605e964d3c