### PR TITLE
Add configurable database and config paths

### DIFF
--- a/Wrecept.Core.Tests/Services/UserInfoServiceTests.cs
+++ b/Wrecept.Core.Tests/Services/UserInfoServiceTests.cs
@@ -23,7 +23,8 @@ public class UserInfoServiceTests : IDisposable
     [Fact]
     public async Task LoadAsync_ReturnsDefaults_IfFileMissing()
     {
-        var svc = new UserInfoService();
+        var path = Path.Combine(_tempDir, "Wrecept", "wrecept.json");
+        var svc = new UserInfoService(path);
         var info = await svc.LoadAsync();
 
         Assert.Equal(string.Empty, info.CompanyName);
@@ -35,18 +36,19 @@ public class UserInfoServiceTests : IDisposable
     [Fact]
     public async Task SaveAsync_WritesFile()
     {
-        var svc = new UserInfoService();
+        var path = Path.Combine(_tempDir, "Wrecept", "wrecept.json");
+        var svc = new UserInfoService(path);
         var info = new UserInfo { CompanyName = "ACME" };
         await svc.SaveAsync(info);
 
-        var path = Path.Combine(_tempDir, "Wrecept", "wrecept.json");
         Assert.True(File.Exists(path));
     }
 
     [Fact]
     public async Task LoadAsync_ReturnsSavedObject()
     {
-        var svc = new UserInfoService();
+        var path = Path.Combine(_tempDir, "Wrecept", "wrecept.json");
+        var svc = new UserInfoService(path);
         var info = new UserInfo { CompanyName = "ACME", Address = "Addr", Phone = "123", Email = "a@b.c" };
         await svc.SaveAsync(info);
 

--- a/Wrecept.Core/Entities/AppSettings.cs
+++ b/Wrecept.Core/Entities/AppSettings.cs
@@ -3,4 +3,6 @@ namespace Wrecept.Core.Entities;
 public class AppSettings
 {
     public ScreenMode ScreenMode { get; set; } = ScreenMode.Large;
+    public string DatabasePath { get; set; } = string.Empty;
+    public string UserInfoPath { get; set; } = string.Empty;
 }

--- a/Wrecept.Storage/Data/AppDbContextFactory.cs
+++ b/Wrecept.Storage/Data/AppDbContextFactory.cs
@@ -7,8 +7,9 @@ public class AppDbContextFactory : IDesignTimeDbContextFactory<AppDbContext>
 {
     public AppDbContext CreateDbContext(string[] args)
     {
+        var dbPath = args.Length > 0 ? args[0] : "app.db";
         var options = new DbContextOptionsBuilder<AppDbContext>()
-            .UseSqlite("Data Source=wrecept.db")
+            .UseSqlite($"Data Source={dbPath}")
             .Options;
         return new AppDbContext(options);
     }

--- a/Wrecept.Storage/ServiceCollectionExtensions.cs
+++ b/Wrecept.Storage/ServiceCollectionExtensions.cs
@@ -10,7 +10,7 @@ namespace Wrecept.Storage;
 
 public static class ServiceCollectionExtensions
 {
-    public static IServiceCollection AddStorage(this IServiceCollection services, string dbPath)
+public static IServiceCollection AddStorage(this IServiceCollection services, string dbPath, string userInfoPath, string settingsPath)
     {
         ArgumentException.ThrowIfNullOrEmpty(dbPath);
 
@@ -24,8 +24,8 @@ public static class ServiceCollectionExtensions
         services.AddScoped<ITaxRateRepository, TaxRateRepository>();
         services.AddScoped<IUnitRepository, UnitRepository>();
         services.AddSingleton<ILogService, LogService>();
-        services.AddSingleton<IUserInfoService, UserInfoService>();
-        services.AddSingleton<ISettingsService, SettingsService>();
+        services.AddSingleton<IUserInfoService>(_ => new UserInfoService(userInfoPath));
+        services.AddSingleton<ISettingsService>(_ => new SettingsService(settingsPath));
 
         using var provider = services.BuildServiceProvider();
         var factory = provider.GetRequiredService<IDbContextFactory<AppDbContext>>();

--- a/Wrecept.Storage/Services/SettingsService.cs
+++ b/Wrecept.Storage/Services/SettingsService.cs
@@ -6,9 +6,12 @@ namespace Wrecept.Storage.Services;
 
 public class SettingsService : ISettingsService
 {
-    private readonly string _path = Path.Combine(
-        Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
-        "Wrecept", "settings.json");
+    private readonly string _path;
+
+    public SettingsService(string path)
+    {
+        _path = path;
+    }
 
     public async Task<AppSettings> LoadAsync()
     {

--- a/Wrecept.Storage/Services/UserInfoService.cs
+++ b/Wrecept.Storage/Services/UserInfoService.cs
@@ -6,9 +6,12 @@ namespace Wrecept.Storage.Services;
 
 public class UserInfoService : IUserInfoService
 {
-    private readonly string _path = Path.Combine(
-        Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
-        "Wrecept", "wrecept.json");
+    private readonly string _path;
+
+    public UserInfoService(string path)
+    {
+        _path = path;
+    }
 
     public async Task<UserInfo> LoadAsync()
     {

--- a/Wrecept.Wpf/ViewModels/SetupViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/SetupViewModel.cs
@@ -1,0 +1,55 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Microsoft.Win32;
+using System.IO;
+using System.Windows;
+
+namespace Wrecept.Wpf.ViewModels;
+
+public partial class SetupViewModel : ObservableObject
+{
+    [ObservableProperty]
+    private string databasePath;
+
+    [ObservableProperty]
+    private string configPath;
+
+    public IRelayCommand<Window?> OkCommand { get; }
+    public IRelayCommand<Window?> CancelCommand { get; }
+    public IRelayCommand BrowseDbCommand { get; }
+    public IRelayCommand BrowseConfigCommand { get; }
+
+    public SetupViewModel(string dbPath, string cfgPath)
+    {
+        databasePath = dbPath;
+        configPath = cfgPath;
+        OkCommand = new RelayCommand<Window?>(w => { if (w != null) { w.DialogResult = true; w.Close(); } });
+        CancelCommand = new RelayCommand<Window?>(w => { if (w != null) { w.DialogResult = false; w.Close(); } });
+        BrowseDbCommand = new RelayCommand(OnBrowseDb);
+        BrowseConfigCommand = new RelayCommand(OnBrowseConfig);
+    }
+
+    private void OnBrowseDb()
+    {
+        var dlg = new SaveFileDialog
+        {
+            Filter = "SQLite DB (*.db)|*.db|All files|*.*",
+            FileName = Path.GetFileName(DatabasePath),
+            InitialDirectory = Path.GetDirectoryName(DatabasePath)
+        };
+        if (dlg.ShowDialog() == true)
+            DatabasePath = dlg.FileName;
+    }
+
+    private void OnBrowseConfig()
+    {
+        var dlg = new SaveFileDialog
+        {
+            Filter = "JSON (*.json)|*.json|All files|*.*",
+            FileName = Path.GetFileName(ConfigPath),
+            InitialDirectory = Path.GetDirectoryName(ConfigPath)
+        };
+        if (dlg.ShowDialog() == true)
+            ConfigPath = dlg.FileName;
+    }
+}

--- a/Wrecept.Wpf/Views/SetupWindow.xaml
+++ b/Wrecept.Wpf/Views/SetupWindow.xaml
@@ -1,0 +1,21 @@
+<Window x:Class="Wrecept.Wpf.Views.SetupWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Első indítás" WindowStartupLocation="CenterScreen" SizeToContent="WidthAndHeight">
+    <StackPanel Margin="10">
+        <TextBlock Text="Adatbázis fájl:"/>
+        <DockPanel>
+            <TextBox Width="280" Text="{Binding DatabasePath, UpdateSourceTrigger=PropertyChanged}"/>
+            <Button Content="..." Width="30" Margin="5,0,0,0" Command="{Binding BrowseDbCommand}"/>
+        </DockPanel>
+        <TextBlock Text="Konfigurációs fájl:" Margin="0,10,0,0"/>
+        <DockPanel>
+            <TextBox Width="280" Text="{Binding ConfigPath, UpdateSourceTrigger=PropertyChanged}"/>
+            <Button Content="..." Width="30" Margin="5,0,0,0" Command="{Binding BrowseConfigCommand}"/>
+        </DockPanel>
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
+            <Button Content="OK" Width="80" Margin="0,0,5,0" Command="{Binding OkCommand}" CommandParameter="{Binding RelativeSource={RelativeSource AncestorType=Window}}"/>
+            <Button Content="Mégse" Width="80" Command="{Binding CancelCommand}" CommandParameter="{Binding RelativeSource={RelativeSource AncestorType=Window}}"/>
+        </StackPanel>
+    </StackPanel>
+</Window>

--- a/Wrecept.Wpf/Views/SetupWindow.xaml.cs
+++ b/Wrecept.Wpf/Views/SetupWindow.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows;
+
+namespace Wrecept.Wpf.Views;
+
+public partial class SetupWindow : Window
+{
+    public SetupWindow()
+    {
+        InitializeComponent();
+    }
+}

--- a/docs/DEV_SPECS.md
+++ b/docs/DEV_SPECS.md
@@ -110,6 +110,7 @@ kóddal keresni az ős elemeket, a logika tisztán a ViewModelben marad.
 ├── Themes\              # Application Themes
 └── version.txt          # Last known app version
 ```
+Fejlesztéskor a `wrecept.db` nevű adatbázis kizárólag a migrációk generálásához használatos.
 
 ---
 

--- a/docs/ERROR_HANDLING.md
+++ b/docs/ERROR_HANDLING.md
@@ -28,7 +28,7 @@ Ez a dokumentum összefoglalja a hibakezelési stratégiát. Cél, hogy az alkal
 
 ## Konkrét példák
 
-1. **Adatbázis fájl hiánya** – Ha a `wrecept.db` nem található indításkor, a Storage réteg új üres adatbázist hoz létre, majd figyelmeztető üzenetet jelenítünk meg.
+1. **Adatbázis fájl hiánya** – Ha az `app.db` nem található indításkor, a Storage réteg új üres adatbázist hoz létre, majd figyelmeztető üzenetet jelenítünk meg.
 2. **Üres adatbázis** – Ha egyetlen táblában sincs adat, minta rekordokat szúrunk be és figyelmeztetjük a felhasználót.
 3. **Sémahibák indításkor** – A `DbInitializer` gondoskodik a migrációk lefuttatásáról. Sikertelenség esetén `EnsureCreated()` hívással létrehozza az alap sémát, majd ismét migrál. A `DataSeeder` külön kontextust használ, így a DI-ből kapott példány nem marad használatban.
 4. **Sérült import fájl** – Hibás formátumú vagy hiányzó adatfájl betöltésekor megszakítjuk a folyamatot, naplózzuk a fájl nevét és a kiváltó hibát, és lehetőséget adunk új fájl kiválasztására.
@@ -37,5 +37,7 @@ Ez a dokumentum összefoglalja a hibakezelési stratégiát. Cél, hogy az alkal
 7. **Indítási hiba** – Ha a `DataSeeder` másodszori próbálkozásra is `SqliteException`-t kap, a részleteket az `ILogService` naplózza a `logs` mappába, majd hibaüzenetet jelenítünk meg.
 8. **Egyéb inicializációs hiba** – A `DbInitializer` általános kivételt is naplóz. Ha a második migrációs kísérlet sikertelen, a program leáll.
 9. **Hiányzó tábla új modell után** – A `DataSeeder` felismeri a `no such table` hibát, ismét migrációt futtat és naplózza az eseményt.
+
+*Megjegyzés: a `wrecept.db` fájlt kizárólag fejlesztés közbeni migrációkhoz használjuk.*
 
 ---

--- a/docs/TEST_STRATEGY.md
+++ b/docs/TEST_STRATEGY.md
@@ -13,7 +13,7 @@ A Wrecept stabilitását több szinten biztosítjuk.
 
 1. **Unit tesztek** – A Core és ViewModel rétegek logikáját izoláltan ellenőrizzük.
 2. **Integration tesztek** – Adatbázis műveletek és szolgáltatások együttműködését vizsgáljuk SQLite in-memory módban.
-   * Egy külön teszt a fizikai `wrecept.db` fájlon fut, hogy ellenőrizzük a tényleges mentést és betöltést.
+   * Egy külön teszt a fizikai `app.db` fájlon fut, hogy ellenőrizzük a tényleges mentést és betöltést.
 3. **UI tesztek** – A WPF nézetek billentyű-kezelését automatizáltan teszteljük, például WinAppDriverrel.
 
 ## Hülyebiztos validáció
@@ -26,5 +26,7 @@ A Wrecept stabilitását több szinten biztosítjuk.
 
 * Minimum 80% kódfedettségre törekszünk. A Core és ViewModel rétegek kritikus útvonalait teljesen lefedjük.
 * A tesztek minden commit után futnak GitHub Actions alatt (`dotnet test`). Ha bármely teszt megbukik, a build elutasításra kerül.
+
+*Megjegyzés: a `wrecept.db` néven szereplő adatbázis csak a migrációk tervezési szakaszában használatos.*
 
 ---

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -5,7 +5,7 @@ author: "docs_agent"
 date: "2025-07-01"
 ---
 
-A program a felhasználó cégadatait JSON formátumban tárolja a `%AppData%/Wrecept/wrecept.json` fájlban. A fájl a következő mezőket tartalmazza:
+A program a felhasználó cégadatait JSON formátumban tárolja a `%AppData%/Wrecept/wrecept.json` (vagy a telepítéskor megadott) fájlban. A fájl a következő mezőket tartalmazza:
 
 - `CompanyName` – a vállalkozás neve
 - `Address` – székhely vagy telephely címe
@@ -13,3 +13,4 @@ A program a felhasználó cégadatait JSON formátumban tárolja a `%AppData%/Wr
 - `Email` – általános elérhetőség
 
 A `UserInfoService` tölti be és menti az adatokat. Hiányzó fájl esetén üres értékeket használ. A `Tulajdonos szerkesztése...` menüpont megnyit egy űrlapot, amely ezen mezőket módosítja.
+Az alkalmazás első indításakor lehetőség van a konfigurációs fájl helyének megadására.

--- a/docs/progress/2025-07-02_02-21-28_code_agent.md
+++ b/docs/progress/2025-07-02_02-21-28_code_agent.md
@@ -1,0 +1,4 @@
+- Added setup window to select database and config paths on first start.
+- AppSettings extended with DatabasePath and UserInfoPath.
+- Storage services now accept configurable paths.
+- Documentation clarified design-time wrecept.db usage.


### PR DESCRIPTION
## Summary
- allow choosing database and configuration file on first run
- store these paths in AppSettings and inject them into services
- add SetupWindow UI
- clarify docs about design-time `wrecept.db`

## Testing
- `dotnet build Wrecept.sln -warnaserror` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*
- `dotnet test Wrecept.Core.Tests/Wrecept.Core.Tests.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_686495f9d4ec832283baada44d37cd6d