### PR TITLE
Fix AppSettings reference

### DIFF
--- a/Wrecept.Wpf/App.xaml.cs
+++ b/Wrecept.Wpf/App.xaml.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Wrecept.Core;
 using Wrecept.Core.Services;
+using Wrecept.Core.Entities;
 using Wrecept.Storage;
 using Wrecept.Wpf.ViewModels;
 using Wrecept.Wpf.Views;

--- a/docs/progress/2025-07-02_02-52-23_code_agent.md
+++ b/docs/progress/2025-07-02_02-52-23_code_agent.md
@@ -1,0 +1,2 @@
+- Added missing using Wrecept.Core.Entities in App.xaml.cs to resolve AppSettings type error.
+- Build for WPF project still fails due to missing WindowsDesktop SDK in Linux environment.


### PR DESCRIPTION
## Summary
- fix using directives so WPF project builds
- log progress

## Testing
- `dotnet build Wrecept.Core/Wrecept.Core.csproj -c Debug`
- `dotnet build Wrecept.Storage/Wrecept.Storage.csproj -c Debug`
- `dotnet build Wrecept.Wpf/Wrecept.Wpf.csproj -c Debug` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_68649e5f3ef48322ab42f27d3012076f