### PR TITLE
Fix provider null on startup

### DIFF
--- a/Wrecept.Wpf/App.xaml.cs
+++ b/Wrecept.Wpf/App.xaml.cs
@@ -20,14 +20,22 @@ namespace Wrecept.Wpf;
 
 public partial class App : Application
 {
-public static IServiceProvider Services { get; private set; } = null!;
-public static IServiceProvider Provider => Services;
+public static IServiceProvider? Services { get; private set; }
+public static IServiceProvider Provider => Services ?? throw new InvalidOperationException("App services not initialized");
     public static string DbPath { get; private set; } = string.Empty;
     public static string UserInfoPath { get; private set; } = string.Empty;
     public static string SettingsPath { get; private set; } = string.Empty;
 
     public App()
     {
+        EnsureServicesInitialized();
+    }
+
+    private static void EnsureServicesInitialized()
+    {
+        if (Services != null)
+            return;
+
         var settings = LoadSettings();
         var serviceCollection = new ServiceCollection();
         ConfigureServices(serviceCollection, settings);
@@ -111,6 +119,8 @@ public static IServiceProvider Provider => Services;
     protected override async void OnStartup(StartupEventArgs e)
     {
         base.OnStartup(e);
+
+        EnsureServicesInitialized();
 
         ShutdownMode = ShutdownMode.OnExplicitShutdown;
 

--- a/docs/progress/2025-07-02_03-47-33_code_agent.md
+++ b/docs/progress/2025-07-02_03-47-33_code_agent.md
@@ -1,0 +1,1 @@
+- Added service initialization guard in App to ensure dependency provider is available.


### PR DESCRIPTION
## Summary
- ensure DI container is initialized before use
- document fix in progress log

## Testing
- `dotnet test tests/Wrecept.Tests/Wrecept.Tests.csproj` *(fails: WPF not supported)*

------
https://chatgpt.com/codex/tasks/task_e_6864aaef106c83229aaeda8ef1fe1bcd