### PR TITLE
Fix __EFMigrationsHistory error

### DIFF
--- a/Wrecept.Storage/Data/DbInitializer.cs
+++ b/Wrecept.Storage/Data/DbInitializer.cs
@@ -10,6 +10,7 @@ public static class DbInitializer
     {
         try
         {
+            await db.Database.EnsureCreatedAsync(ct);
             await db.Database.MigrateAsync(ct);
         }
         catch (SqliteException ex)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -52,8 +52,9 @@ Az aktuális képernyőmódot a `SettingsService` tartja nyilván `settings.json
 
 Minden domain modell tartalmaz `CreatedAt` és `UpdatedAt` mezőket. Ezeket a service réteg inicializálja, így naplózható az adat módosításának ideje.
 
- Az alkalmazás indításakor a `DbInitializer` közvetlenül `Database.Migrate()`
- hívást kezdeményez. Hibánál `EnsureCreated()` után másodszor is migrál.
+ Az alkalmazás indításakor a `DbInitializer` előbb `EnsureCreated()` majd
+ `Database.Migrate()` hívást kezdeményez. Így elkerülhető a hiányzó
+ `__EFMigrationsHistory` tábla miatti hiba.
  Az `AddStorage` kiterjesztés ehhez `IDbContextFactory`-t használ,
  így a migráció egy külön kontextuson történik és azonnal eldobásra kerül.
 Az indítás során a `DataSeeder` ellenőrzi, hogy az adatbázis teljesen üres‑e.

--- a/docs/BUILD_RUNTIME_NOTES.md
+++ b/docs/BUILD_RUNTIME_NOTES.md
@@ -27,7 +27,7 @@ Ez a jegyzet a fejlesztés során tapasztalt fordítási és futásidejű probl�
 4. Teszteléskor győződjünk meg róla, hogy a szükséges SDK-k és NuGet csomagok telepítve vannak.
 5. Sémafrissítés után futtassuk le az EF Core migrációkat (`Database.Migrate()`),
    különben futásidőben "no such column" hibát kaphatunk.
-6. Indításkor a `DbInitializer` először `Database.Migrate()` hívást végez. Ha ez `SqliteException`-nel leáll, `EnsureCreated()` után ismét migrál. Ha az adatbázis üres, a felhasználó megerősítheti, hogy Bogus segítségével generált mintaadatok kerüljenek be.
+6. Indításkor a `DbInitializer` előbb `EnsureCreated()`, majd `Database.Migrate()` hívást végez. Így megakadályozható a `__EFMigrationsHistory` tábla hiányából adódó hiba. Ha az adatbázis üres, a felhasználó megerősítheti, hogy Bogus segítségével generált mintaadatok kerüljenek be.
 7. Az `AddStorage` kiterjesztés migrációhoz `IDbContextFactory`-t használ, így a munkakontextus az inicializálás végén eldobásra kerül.
 8. Ha a második adatlekérdezés is `SqliteException`-t dob, a `DataSeeder` a `logs/startup.log` fájlba ír és `Failed` állapotot jelez.
 9. Új modell bevezetésekor, ha valamely tábla hiányzik, a `DataSeeder` ismét migrációt futtat és naplózza a hibát.

--- a/docs/ERROR_HANDLING.md
+++ b/docs/ERROR_HANDLING.md
@@ -30,7 +30,7 @@ Ez a dokumentum összefoglalja a hibakezelési stratégiát. Cél, hogy az alkal
 
 1. **Adatbázis fájl hiánya vagy hiányzó elérési út** – Ha az adatbázis helye nincs megadva vagy az `app.db` nem található, a Storage réteg a `%AppData%/Wrecept/app.db` fájlt hozza létre, majd figyelmeztető üzenetet jelenítünk meg.
 2. **Üres adatbázis** – Ha egyetlen táblában sincs adat, minta rekordokat szúrunk be és figyelmeztetjük a felhasználót.
-3. **Sémahibák indításkor** – A `DbInitializer` gondoskodik a migrációk lefuttatásáról. Sikertelenség esetén `EnsureCreated()` hívással létrehozza az alap sémát, majd ismét migrál. A `DataSeeder` külön kontextust használ, így a DI-ből kapott példány nem marad használatban.
+3. **Sémahibák indításkor** – A `DbInitializer` először `EnsureCreated()`, majd `Database.Migrate()` hívást végez. Ha a migráció hibát dob, újra megpróbálja `EnsureCreated()` után. A `DataSeeder` külön kontextust használ, így a DI-ből kapott példány nem marad használatban.
 4. **Sérült import fájl** – Hibás formátumú vagy hiányzó adatfájl betöltésekor megszakítjuk a folyamatot, naplózzuk a fájl nevét és a kiváltó hibát, és lehetőséget adunk új fájl kiválasztására.
 5. **Hálózati kimaradás** – Külső frissítések letöltése közben kapcsolatvesztés esetén újrapróbálkozunk, majd offline módra váltunk, miközben a felhasználót tájékoztatjuk.
 6. **Sikertelen adatbázis írás** – Ha a fájl zárolt vagy elfogy a tárhely, hibaüzenetet jelenítünk meg, a műveletet naplózzuk, majd biztonsági mentés után újrapróbáljuk.

--- a/docs/progress/2025-07-02_04-06-49_storage_agent.md
+++ b/docs/progress/2025-07-02_04-06-49_storage_agent.md
@@ -1,0 +1,2 @@
+- DbInitializer now calls EnsureCreated before Migrate to avoid missing history table errors.
+- Docs updated (ARCHITECTURE, BUILD_RUNTIME_NOTES, ERROR_HANDLING).


### PR DESCRIPTION
## Summary
- ensure database gets created before running EF migrations
- document initialization sequence change
- log update in progress notes

## Testing
- `dotnet test --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864af7f8b8c8322a603e7f70b25b58c