### PR TITLE
Switch seeder locale to en_GB

### DIFF
--- a/Wrecept.Storage/Data/DataSeeder.cs
+++ b/Wrecept.Storage/Data/DataSeeder.cs
@@ -42,7 +42,7 @@ public static class DataSeeder
         await using var db = new AppDbContext(opts);
         await DbInitializer.EnsureCreatedAndMigratedAsync(db, logService, ct);
 
-        var faker = new Faker("hu");
+        var faker = new Faker("en_GB");
         var now = DateTime.UtcNow;
 
         progress?.Report(new ProgressReport { GlobalPercent = 10, Message = "Alap adatok..." });
@@ -71,7 +71,7 @@ public static class DataSeeder
 
         progress?.Report(new ProgressReport { GlobalPercent = 30, Message = "Szállítók..." });
 
-        var supplierFaker = new Faker<Supplier>("hu")
+        var supplierFaker = new Faker<Supplier>("en_GB")
             .RuleFor(s => s.Name, f => f.Company.CompanyName())
             .RuleFor(s => s.TaxId, f => f.Random.Replace("########-#-##"))
             .RuleFor(s => s.CreatedAt, _ => now)
@@ -82,7 +82,7 @@ public static class DataSeeder
 
         progress?.Report(new ProgressReport { GlobalPercent = 50, Message = "Termékek..." });
 
-        var productFaker = new Faker<Product>("hu")
+        var productFaker = new Faker<Product>("en_GB")
             .RuleFor(p => p.Name, f => f.Commerce.ProductName())
             .RuleFor(p => p.Net, f => Math.Round(f.Random.Decimal(100, 10000), 2))
             .RuleFor(p => p.TaxRateId, f => f.PickRandom(taxes).Id)
@@ -101,7 +101,7 @@ public static class DataSeeder
 
         progress?.Report(new ProgressReport { GlobalPercent = 70, Message = "Számlák..." });
 
-        var invoiceFaker = new Faker<Invoice>("hu")
+        var invoiceFaker = new Faker<Invoice>("en_GB")
             .RuleFor(i => i.Number, f => f.Random.Replace("INV-#####"))
             .RuleFor(i => i.Date, f => DateOnly.FromDateTime(f.Date.Recent(365)))
             .RuleFor(i => i.SupplierId, f => f.PickRandom(suppliers).Id)
@@ -117,7 +117,7 @@ public static class DataSeeder
 
         foreach (var invoice in invoices)
         {
-            var itemFaker = new Faker<InvoiceItem>("hu")
+            var itemFaker = new Faker<InvoiceItem>("en_GB")
                 .RuleFor(it => it.InvoiceId, _ => invoice.Id)
                 .RuleFor(it => it.ProductId, f => f.PickRandom(products).Id)
                 .RuleFor(it => it.Description, (f, it) => products.First(p => p.Id == it.ProductId).Name)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -58,7 +58,7 @@ Minden domain modell tartalmaz `CreatedAt` és `UpdatedAt` mezőket. Ezeket a se
  így a migráció egy külön kontextuson történik és azonnal eldobásra kerül.
 Az indítás során a `DataSeeder` ellenőrzi, hogy az adatbázis teljesen üres‑e.
 Ha igen, a felhasználó megerősítése után Bogus könyvtár segítségével
-magyar lokalizációjú mintaszámlákat generál (100 számla, 20 szállító,
+brit angol lokalizációjú (en_GB) mintaszámlákat generál (100 számla, 20 szállító,
 500 termék, számlánként 5‑60 tétel). A folyamat közben a `StartupWindow`
 mutatja a haladást két progress baron keresztül.
 Ha a második adatlekérdezés is hibát jelez, a részleteket az `ILogService` naplózza a `logs` mappába, és a program hibát jelez.

--- a/docs/progress/2025-07-02_04-25-50_storage_agent.md
+++ b/docs/progress/2025-07-02_04-25-50_storage_agent.md
@@ -1,0 +1,1 @@
+- DataSeeder locale switched from hu to en_GB for sample data.

--- a/docs/progress/2025-07-02_04-26-10_docs_agent.md
+++ b/docs/progress/2025-07-02_04-26-10_docs_agent.md
@@ -1,0 +1,1 @@
+- ARCHITECTURE.md updated to mention en_GB locale seeding.


### PR DESCRIPTION
## Summary
- seed sample data using en_GB locale
- note new seeding locale in architecture docs
- log work in progress notes

## Testing
- `dotnet test tests/Wrecept.Tests/Wrecept.Tests.csproj -v n` *(fails: Project Wrecept.Wpf is not compatible with net8.0)*

------
https://chatgpt.com/codex/tasks/task_e_6864b592a1c8832295206aa7ac931f77