### PR TITLE
Fix startup setup repetition and progress update

### DIFF
--- a/Wrecept.Wpf/App.xaml.cs
+++ b/Wrecept.Wpf/App.xaml.cs
@@ -28,7 +28,6 @@ public static IServiceProvider Provider => Services ?? throw new InvalidOperatio
 
     public App()
     {
-        EnsureServicesInitialized();
     }
 
     private static void EnsureServicesInitialized()

--- a/Wrecept.Wpf/StartupOrchestrator.cs
+++ b/Wrecept.Wpf/StartupOrchestrator.cs
@@ -22,7 +22,9 @@ public class StartupOrchestrator
     public async Task<SeedStatus> SeedAsync(IProgress<ProgressReport> progress, CancellationToken ct)
     {
         progress.Report(new ProgressReport { GlobalPercent = 10, Message = "Mintaszámlák létrehozása..." });
-        var status = await DataSeeder.SeedSampleDataAsync(App.DbPath, _log, progress, ct);
+        var status = await Task.Run(
+            () => DataSeeder.SeedSampleDataAsync(App.DbPath, _log, progress, ct),
+            ct);
         progress.Report(new ProgressReport { GlobalPercent = 100, SubtaskPercent = 100, Message = status.ToString() });
         return status;
     }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -60,7 +60,8 @@ Az indítás során a `DataSeeder` ellenőrzi, hogy az adatbázis teljesen üres
 Ha igen, a felhasználó megerősítése után Bogus könyvtár segítségével
 brit angol lokalizációjú (en_GB) mintaszámlákat generál (100 számla, 20 szállító,
 500 termék, számlánként 5‑60 tétel). A folyamat közben a `StartupWindow`
-mutatja a haladást két progress baron keresztül.
+mutatja a haladást két progress baron keresztül. A mintaadatok feltöltése
+háttérszálon fut, így az UI végig reszponzív marad.
 Ha a második adatlekérdezés is hibát jelez, a részleteket az `ILogService` naplózza a `logs` mappába, és a program hibát jelez.
 
 ## Indítási folyamat

--- a/docs/progress/2025-07-02_04-46-34_code_agent.md
+++ b/docs/progress/2025-07-02_04-46-34_code_agent.md
@@ -1,0 +1,1 @@
+- Startup seeding moved to background thread and SetupWindow shown only once.


### PR DESCRIPTION
## Summary
- remove service initialization from App ctor so first-run setup only shows once
- run sample data seeding on background thread
- document responsive seeding in ARCHITECTURE
- log progress

## Testing
- `dotnet test --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864b8c0443c832286ea1c39a6e9ca88