### PR TITLE
Allow seeding options with progress details

### DIFF
--- a/Wrecept.Wpf/StartupOrchestrator.cs
+++ b/Wrecept.Wpf/StartupOrchestrator.cs
@@ -19,11 +19,29 @@ public class StartupOrchestrator
     public Task<bool> DatabaseEmptyAsync(CancellationToken ct)
         => DataSeeder.IsDatabaseEmptyAsync(App.DbPath, _log, ct);
 
-    public async Task<SeedStatus> SeedAsync(IProgress<ProgressReport> progress, CancellationToken ct)
+    public async Task<SeedStatus> SeedAsync(
+        IProgress<ProgressReport> progress,
+        CancellationToken ct,
+        int supplierCount,
+        int productCount,
+        int invoiceCount,
+        int minItems,
+        int maxItems,
+        bool slow)
     {
         progress.Report(new ProgressReport { GlobalPercent = 10, Message = "Mintaszámlák létrehozása..." });
         var status = await Task.Run(
-            () => DataSeeder.SeedSampleDataAsync(App.DbPath, _log, progress, ct),
+            () => DataSeeder.SeedSampleDataAsync(
+                App.DbPath,
+                _log,
+                progress,
+                ct,
+                supplierCount,
+                productCount,
+                invoiceCount,
+                minItems,
+                maxItems,
+                slow),
             ct);
         progress.Report(new ProgressReport { GlobalPercent = 100, SubtaskPercent = 100, Message = status.ToString() });
         return status;

--- a/Wrecept.Wpf/ViewModels/SeedOptionsViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/SeedOptionsViewModel.cs
@@ -1,0 +1,32 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using System.Windows;
+
+namespace Wrecept.Wpf.ViewModels;
+
+public partial class SeedOptionsViewModel : ObservableObject
+{
+    [ObservableProperty]
+    private int supplierCount = 20;
+
+    [ObservableProperty]
+    private int productCount = 500;
+
+    [ObservableProperty]
+    private int invoiceCount = 100;
+
+    [ObservableProperty]
+    private int minItemsPerInvoice = 5;
+
+    [ObservableProperty]
+    private int maxItemsPerInvoice = 60;
+
+    public IRelayCommand<Window?> OkCommand { get; }
+    public IRelayCommand<Window?> CancelCommand { get; }
+
+    public SeedOptionsViewModel()
+    {
+        OkCommand = new RelayCommand<Window?>(w => { if (w != null) { w.DialogResult = true; w.Close(); } });
+        CancelCommand = new RelayCommand<Window?>(w => { if (w != null) { w.DialogResult = false; w.Close(); } });
+    }
+}

--- a/Wrecept.Wpf/Views/SeedOptionsWindow.xaml
+++ b/Wrecept.Wpf/Views/SeedOptionsWindow.xaml
@@ -1,0 +1,23 @@
+<Window x:Class="Wrecept.Wpf.Views.SeedOptionsWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Mintaszámok" WindowStartupLocation="CenterScreen" SizeToContent="WidthAndHeight">
+    <StackPanel Margin="10" >
+        <TextBlock Text="Szállítók száma:"/>
+        <TextBox Width="120" Text="{Binding SupplierCount, UpdateSourceTrigger=PropertyChanged}"/>
+        <TextBlock Text="Termékek száma:" Margin="0,5,0,0"/>
+        <TextBox Width="120" Text="{Binding ProductCount, UpdateSourceTrigger=PropertyChanged}"/>
+        <TextBlock Text="Számlák száma:" Margin="0,5,0,0"/>
+        <TextBox Width="120" Text="{Binding InvoiceCount, UpdateSourceTrigger=PropertyChanged}"/>
+        <TextBlock Text="Tételek számlánként (min-max):" Margin="0,5,0,0"/>
+        <DockPanel>
+            <TextBox Width="50" Text="{Binding MinItemsPerInvoice, UpdateSourceTrigger=PropertyChanged}"/>
+            <TextBlock Text="-" Margin="5,0" VerticalAlignment="Center"/>
+            <TextBox Width="50" Text="{Binding MaxItemsPerInvoice, UpdateSourceTrigger=PropertyChanged}"/>
+        </DockPanel>
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
+            <Button Content="OK" Width="80" Margin="0,0,5,0" Command="{Binding OkCommand}" CommandParameter="{Binding RelativeSource={RelativeSource AncestorType=Window}}"/>
+            <Button Content="Mégse" Width="80" Command="{Binding CancelCommand}" CommandParameter="{Binding RelativeSource={RelativeSource AncestorType=Window}}"/>
+        </StackPanel>
+    </StackPanel>
+</Window>

--- a/Wrecept.Wpf/Views/SeedOptionsWindow.xaml.cs
+++ b/Wrecept.Wpf/Views/SeedOptionsWindow.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows;
+
+namespace Wrecept.Wpf.Views;
+
+public partial class SeedOptionsWindow : Window
+{
+    public SeedOptionsWindow()
+    {
+        InitializeComponent();
+    }
+}

--- a/Wrecept.Wpf/Views/StartupWindow.xaml
+++ b/Wrecept.Wpf/Views/StartupWindow.xaml
@@ -4,8 +4,11 @@
         Title="Indulás" Height="200" Width="400" WindowStartupLocation="CenterScreen">
     <StackPanel Margin="10">
         <ProgressBar Minimum="0" Maximum="100" Height="20" Margin="0,0,0,10" Value="{Binding GlobalProgress}"/>
-        <ProgressBar Minimum="0" Maximum="100" Height="20" Margin="0,0,0,10" Value="{Binding SubProgress}"/>
-        <TextBlock Text="{Binding StatusMessage}"/>
+        <Grid Margin="0,0,0,10">
+            <ProgressBar Minimum="0" Maximum="100" Height="20" Value="{Binding SubProgress}"/>
+            <TextBlock Text="{Binding StatusMessage}" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+        </Grid>
+        <TextBlock Text="{Binding StatusMessage}" Visibility="Collapsed"/>
         <Button Content="Mégse" Command="{Binding CancelCommand}" HorizontalAlignment="Right" Width="80" Margin="0,10,0,0"/>
     </StackPanel>
 </Window>

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -57,11 +57,12 @@ Minden domain modell tartalmaz `CreatedAt` és `UpdatedAt` mezőket. Ezeket a se
  Az `AddStorage` kiterjesztés ehhez `IDbContextFactory`-t használ,
  így a migráció egy külön kontextuson történik és azonnal eldobásra kerül.
 Az indítás során a `DataSeeder` ellenőrzi, hogy az adatbázis teljesen üres‑e.
-Ha igen, a felhasználó megerősítése után Bogus könyvtár segítségével
-brit angol lokalizációjú (en_GB) mintaszámlákat generál (100 számla, 20 szállító,
-500 termék, számlánként 5‑60 tétel). A folyamat közben a `StartupWindow`
-mutatja a haladást két progress baron keresztül. A mintaadatok feltöltése
-háttérszálon fut, így az UI végig reszponzív marad.
+Ha igen, a felhasználó egy párbeszédablakban megadhatja,
+hány szállító, termék, számla és tétel generálódjon.
+A Bogus könyvtár en_GB lokalizációval hozza létre a mintaszámlákat.
+A `StartupWindow` a két ProgressBar segítségével jelzi,
+hogy például *Szállítók 3/20* állásnál tart a folyamat.
+A mintaadatok betöltése háttérszálon fut, így az UI végig reszponzív marad.
 Ha a második adatlekérdezés is hibát jelez, a részleteket az `ILogService` naplózza a `logs` mappába, és a program hibát jelez.
 
 ## Indítási folyamat

--- a/docs/progress/2025-07-02_05-00-30_code_agent.md
+++ b/docs/progress/2025-07-02_05-00-30_code_agent.md
@@ -1,0 +1,5 @@
+- StartupWindow alsó progress barja már számokat is mutat (Szállítók 3/20 stb.).
+- SeedOptionsWindow létrehozva, így a mintaadatok mennyisége megadható.
+- DataSeeder paraméterezve, iteratív jelentésekkel és opcionális lassítással.
+- App.xaml módosítva: üres adatbázisnál megjelenik az opciós ablak és a részletes haladás.
+- ARCHITECTURE.md frissült a testreszabható mintaszámokkal.


### PR DESCRIPTION
## Summary
- add SeedOptionsViewModel and window to configure sample data counts
- overlay message on StartupWindow's sub progress bar
- add optional parameters to StartupOrchestrator and DataSeeder
- integrate the new seeding flow in App startup
- document customizable seeding in ARCHITECTURE

## Testing
- `dotnet test Wrecept.Core.Tests/Wrecept.Core.Tests.csproj -v m`
- `dotnet build Wrecept.Wpf/Wrecept.Wpf.csproj -v m` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864bb4e03b883228db255e488553cdd