### PR TITLE
UI layout update for invoice editor

### DIFF
--- a/Wrecept.Wpf/Views/Controls/TotalsPanel.xaml
+++ b/Wrecept.Wpf/Views/Controls/TotalsPanel.xaml
@@ -1,11 +1,16 @@
 <UserControl x:Class="Wrecept.Wpf.Views.Controls.TotalsPanel"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <UserControl.Resources>
+        <Style x:Key="RightTextBlock" TargetType="TextBlock">
+            <Setter Property="TextAlignment" Value="Right" />
+        </Style>
+    </UserControl.Resources>
     <StackPanel>
         <ItemsControl ItemsSource="{Binding VatSummaries}">
             <ItemsControl.ItemTemplate>
                 <DataTemplate>
-                    <TextBlock Margin="0,0,0,2">
+                    <TextBlock Margin="0,0,0,2" Style="{StaticResource RightTextBlock}">
                         <Run Text="{Binding Rate}" />
                         <Run Text=" - nettó " />
                         <Run Text="{Binding Net}" />
@@ -15,14 +20,28 @@
                 </DataTemplate>
             </ItemsControl.ItemTemplate>
         </ItemsControl>
-        <StackPanel Orientation="Horizontal" Margin="0,4,0,0">
-            <TextBlock Text="Nettó:" Width="60" />
-            <TextBlock Text="{Binding NetTotal}" Width="80" TextAlignment="Right" />
-            <TextBlock Text="ÁFA:" Width="40" Margin="20,0,0,0" />
-            <TextBlock Text="{Binding VatTotal}" Width="80" TextAlignment="Right" />
-            <TextBlock Text="Bruttó:" Width="60" Margin="20,0,0,0" />
-            <TextBlock Text="{Binding GrossTotal}" Width="80" TextAlignment="Right" />
-        </StackPanel>
-        <TextBlock Text="{Binding AmountInWords, StringFormat=Azaz: {0}}" FontWeight="Bold" Margin="0,2,0,4" />
+        <Grid Margin="0,4,0,0">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="80" />
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="80" />
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="80" />
+            </Grid.ColumnDefinitions>
+            <TextBlock Text="Nettó:" Grid.Column="0" />
+            <TextBlock Text="{Binding NetTotal}" Grid.Column="1" Style="{StaticResource RightTextBlock}" />
+            <TextBlock Text="ÁFA:" Grid.Column="2" Margin="20,0,0,0" />
+            <TextBlock Text="{Binding VatTotal}" Grid.Column="3" Style="{StaticResource RightTextBlock}" />
+            <TextBlock Text="Bruttó:" Grid.Column="4" Margin="20,0,0,0" />
+            <TextBlock Text="{Binding GrossTotal}" Grid.Column="5" Style="{StaticResource RightTextBlock}" />
+        </Grid>
+        <TextBlock Text="{Binding AmountInWords, StringFormat=Azaz: {0}}"
+                   FontWeight="Bold"
+                   Margin="0,2,0,4"
+                   Style="{StaticResource RightTextBlock}"
+                   TextWrapping="Wrap"
+                   Language="hu-HU"
+                   IsHyphenationEnabled="True" />
     </StackPanel>
 </UserControl>

--- a/Wrecept.Wpf/Views/InvoiceEditorView.xaml
+++ b/Wrecept.Wpf/Views/InvoiceEditorView.xaml
@@ -44,7 +44,7 @@
     </UserControl.Resources>
     <Grid>
         <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="220" />
+            <ColumnDefinition Width="Auto" MinWidth="220" />
             <ColumnDefinition Width="*" />
         </Grid.ColumnDefinitions>
 
@@ -54,16 +54,19 @@
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
                 <RowDefinition Height="*"/>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
             </Grid.RowDefinitions>
-            <GroupBox Header="Számlafejléc" Margin="0,0,0,6" Grid.Row="0">
+
+            <Grid Grid.Row="0" Margin="0,0,0,6">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+                <c:TotalsPanel Grid.Column="0" Margin="0,0,8,0" />
+                <GroupBox Header="Számlafejléc" Grid.Column="1">
                 <Grid Margin="4">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="70" />
@@ -102,11 +105,11 @@
 
                     <CheckBox Grid.Row="4" Grid.Column="1" Content="Bruttó ár" IsChecked="{Binding IsGross}" IsEnabled="{Binding IsEditable}" />
                 </Grid>
-            </GroupBox>
-            <Separator Margin="0,6" Grid.Row="1" />
+                </GroupBox>
+            </Grid>
 
             <StackPanel Orientation="Horizontal" DataContext="{Binding Items[0]}" KeyDown="OnEntryKeyDown"
-                        Background="{DynamicResource ControlBackgroundBrush}" Margin="0,0,0,4" Grid.Row="2">
+                        Background="{DynamicResource ControlBackgroundBrush}" Margin="0,0,0,4" Grid.Row="1">
                 <c:EditLookup x:Name="EntryProduct" Width="200"
                               ItemsSource="{Binding DataContext.Products, RelativeSource={RelativeSource AncestorType=UserControl}}"
                               DisplayMemberPath="Name"
@@ -126,17 +129,13 @@
                               SelectedValue="{Binding TaxRateId, Mode=TwoWay}"/>
             </StackPanel>
 
-            <Separator Margin="0,6" Grid.Row="3" />
+            <ScrollViewer Grid.Row="2" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto">
+                <view:InvoiceItemsGrid x:Name="ItemsGrid" Margin="0,0,0,4" />
+            </ScrollViewer>
 
-            <view:InvoiceItemsGrid x:Name="ItemsGrid" Margin="0,4,0,0" Grid.Row="4" />
+            <TextBlock Text="Negatív mennyiség visszárut jelez." FontStyle="{x:Static FontStyles.Italic}" Margin="0,4" Grid.Row="3" />
 
-            <Separator Margin="0,6" Grid.Row="5" />
-
-            <c:TotalsPanel Grid.Row="6" />
-
-            <TextBlock Text="Negatív mennyiség visszárut jelez." FontStyle="{x:Static FontStyles.Italic}" Margin="0,4" Grid.Row="7" />
-
-            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,6" Grid.Row="8">
+            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,6" Grid.Row="4">
                 <Button Content="Mentés" Command="{Binding SaveCommand}" Margin="0,0,4,0" FocusVisualStyle="{StaticResource GoldFocusVisual}" />
                 <Button Content="Nyomtatás" IsEnabled="{Binding IsArchived}" Margin="0,0,4,0" FocusVisualStyle="{StaticResource GoldFocusVisual}" />
                 <Button Content="Bezárás" Command="{Binding CloseCommand}" Margin="0,0,4,0" FocusVisualStyle="{StaticResource GoldFocusVisual}" />
@@ -153,8 +152,8 @@
                 </Button>
             </StackPanel>
 
-            <ContentControl Content="{Binding SavePrompt}" Visibility="{Binding IsSavePromptVisible, Converter={StaticResource BooleanToVisibilityConverter}}" Grid.Row="9" />
-            <ContentControl Content="{Binding ArchivePrompt}" Visibility="{Binding IsArchivePromptVisible, Converter={StaticResource BooleanToVisibilityConverter}}" Grid.Row="9" Margin="0,4,0,0" />
+            <ContentControl Content="{Binding SavePrompt}" Visibility="{Binding IsSavePromptVisible, Converter={StaticResource BooleanToVisibilityConverter}}" Grid.Row="5" />
+            <ContentControl Content="{Binding ArchivePrompt}" Visibility="{Binding IsArchivePromptVisible, Converter={StaticResource BooleanToVisibilityConverter}}" Grid.Row="5" Margin="0,4,0,0" />
         </Grid>
     </Grid>
 </UserControl>

--- a/docs/progress/2025-07-02_05-28-20_ui_agent.md
+++ b/docs/progress/2025-07-02_05-28-20_ui_agent.md
@@ -1,0 +1,3 @@
+- InvoiceEditorView átrendezve rugalmas Grid elrendezésre, a TotalsPanel a fejléc mellé került
+- A táblázat ScrollViewer-be került, hogy felbontástól függően kitöltse a rendelkezésre álló helyet
+- TotalsPanel igazítások: jobbra zárt szövegek, "Azaz" érték kötőjelesen tördelhető


### PR DESCRIPTION
## Summary
- tweak TotalsPanel layout and add hyphenated `Azaz` line
- refactor InvoiceEditorView to a flexible grid and move totals next to the header
- scroll invoice items while keeping buttons fixed
- log UI changes

## Testing
- `dotnet restore`
- `dotnet build --no-restore` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*
- `dotnet test --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864c263c7948322a05264f59a034dc3