### PR TITLE
Fix TotalsPanel orientation setter

### DIFF
--- a/Wrecept.Wpf/Views/Controls/TotalsPanel.xaml
+++ b/Wrecept.Wpf/Views/Controls/TotalsPanel.xaml
@@ -46,7 +46,7 @@
         </TextBlock>
         <StackPanel.Triggers>
             <DataTrigger Binding="{Binding IsCompactMode, RelativeSource={RelativeSource AncestorType=UserControl}}" Value="True">
-                <Setter TargetName="TotalsStack" Property="Orientation" Value="Vertical" />
+                <Setter TargetName="TotalsStack" Property="StackPanel.Orientation" Value="Vertical" />
             </DataTrigger>
         </StackPanel.Triggers>
     </StackPanel>

--- a/docs/progress/2025-07-02_05-55-35_ui_agent.md
+++ b/docs/progress/2025-07-02_05-55-35_ui_agent.md
@@ -1,0 +1,2 @@
+- fix TotalsPanel XAML orientation setter
+- adjusted Property to StackPanel.Orientation to resolve design-time error


### PR DESCRIPTION
## Summary
- correct property name for TotalsPanel orientation setter so XAML parses
- log progress

## Testing
- `dotnet test Wrecept.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864c94a25448322bfafac7f1f6ac984