### PR TITLE
Fix TotalsPanel orientation trigger

### DIFF
--- a/Wrecept.Wpf/Views/Controls/TotalsPanel.xaml
+++ b/Wrecept.Wpf/Views/Controls/TotalsPanel.xaml
@@ -46,7 +46,7 @@
         </TextBlock>
         <StackPanel.Triggers>
             <DataTrigger Binding="{Binding IsCompactMode, RelativeSource={RelativeSource AncestorType=UserControl}}" Value="True">
-                <Setter TargetName="TotalsStack" Property="StackPanel.Orientation" Value="Vertical" />
+                <Setter TargetName="TotalsStack" Property="Orientation" Value="Vertical" />
             </DataTrigger>
         </StackPanel.Triggers>
     </StackPanel>

--- a/docs/progress/2025-07-02_06-01-07_ui_agent.md
+++ b/docs/progress/2025-07-02_06-01-07_ui_agent.md
@@ -1,0 +1,1 @@
+- revert orientation setter to avoid XamlParseException


### PR DESCRIPTION
## Summary
- fix orientation setter causing runtime crash
- log the fix

## Testing
- `dotnet build Wrecept.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop missing)*

------
https://chatgpt.com/codex/tasks/task_e_6864ca9a44c48322bbaeb9e2e3a37329