### PR TITLE
Refactor invoice header layout

### DIFF
--- a/Wrecept.Wpf/Themes/RetroTheme.Dark.xaml
+++ b/Wrecept.Wpf/Themes/RetroTheme.Dark.xaml
@@ -21,6 +21,18 @@
     <sys:Double x:Key="FontSizeNormal">16</sys:Double>
     <sys:Double x:Key="FontSizeLarge">18</sys:Double>
 
+    <!-- Header font resources -->
+    <FontFamily x:Key="MonospacedFont">pack://application:,,,/Resources/#IBM Plex Mono</FontFamily>
+    <Style TargetType="TextBlock" x:Key="HeaderText">
+        <Setter Property="FontFamily" Value="{StaticResource MonospacedFont}" />
+        <Setter Property="FontSize" Value="14" />
+    </Style>
+    <Style TargetType="TextBlock" x:Key="HeaderTextBold">
+        <Setter Property="FontFamily" Value="{StaticResource MonospacedFont}" />
+        <Setter Property="FontSize" Value="16" />
+        <Setter Property="FontWeight" Value="Bold" />
+    </Style>
+
     <Style TargetType="TextBlock">
         <Setter Property="Foreground" Value="{StaticResource ForegroundBrush}" />
         <Setter Property="FontFamily" Value="Consolas" />

--- a/Wrecept.Wpf/Themes/RetroTheme.xaml
+++ b/Wrecept.Wpf/Themes/RetroTheme.xaml
@@ -22,6 +22,18 @@
     <sys:Double x:Key="FontSizeNormal">16</sys:Double>
     <sys:Double x:Key="FontSizeLarge">18</sys:Double>
 
+    <!-- Header font resources -->
+    <FontFamily x:Key="MonospacedFont">pack://application:,,,/Resources/#IBM Plex Mono</FontFamily>
+    <Style TargetType="TextBlock" x:Key="HeaderText">
+        <Setter Property="FontFamily" Value="{StaticResource MonospacedFont}" />
+        <Setter Property="FontSize" Value="14" />
+    </Style>
+    <Style TargetType="TextBlock" x:Key="HeaderTextBold">
+        <Setter Property="FontFamily" Value="{StaticResource MonospacedFont}" />
+        <Setter Property="FontSize" Value="16" />
+        <Setter Property="FontWeight" Value="Bold" />
+    </Style>
+
     <Style TargetType="TextBlock">
         <Setter Property="Foreground" Value="{StaticResource ForegroundBrush}" />
         <Setter Property="FontFamily" Value="Consolas" />

--- a/Wrecept.Wpf/Views/Controls/TotalsPanel.xaml
+++ b/Wrecept.Wpf/Views/Controls/TotalsPanel.xaml
@@ -31,22 +31,24 @@
         </ItemsControl>
         <StackPanel x:Name="TotalsStack" Margin="0,4,0,0" Style="{StaticResource TotalsStackStyle}">
             <StackPanel Orientation="Horizontal" Margin="0,0,12,0">
-                <TextBlock Text="Nettó:" />
-                <TextBlock Text="{Binding NetTotal}" Width="80" Style="{StaticResource RightTextBlock}" />
+                <TextBlock Text="Nettó:" Style="{StaticResource HeaderText}" />
+                <TextBlock Text="{Binding NetTotal}" Width="80" Style="{StaticResource HeaderTextBold}" TextAlignment="Right" />
             </StackPanel>
             <StackPanel Orientation="Horizontal" Margin="0,0,12,0">
-                <TextBlock Text="ÁFA:" />
-                <TextBlock Text="{Binding VatTotal}" Width="80" Style="{StaticResource RightTextBlock}" />
+                <TextBlock Text="ÁFA:" Style="{StaticResource HeaderText}" />
+                <TextBlock Text="{Binding VatTotal}" Width="80" Style="{StaticResource HeaderTextBold}" TextAlignment="Right" />
             </StackPanel>
             <StackPanel Orientation="Horizontal">
-                <TextBlock Text="Bruttó:" />
-                <TextBlock Text="{Binding GrossTotal}" Width="80" Style="{StaticResource RightTextBlock}" />
+                <TextBlock Text="Bruttó:" Style="{StaticResource HeaderText}" />
+                <TextBlock Text="{Binding GrossTotal}" Width="80" Style="{StaticResource HeaderTextBold}" TextAlignment="Right" />
             </StackPanel>
         </StackPanel>
         <TextBlock FontWeight="Bold"
                    Margin="0,2,0,4"
-                   Style="{StaticResource RightTextBlock}"
+                   Style="{StaticResource HeaderTextBold}"
                    TextWrapping="Wrap"
+                   TextAlignment="Right"
+                   MaxWidth="300"
                    Language="hu-HU"
                    IsHyphenationEnabled="True">
             <Run Text="Azaz&#x2010;:" />

--- a/Wrecept.Wpf/Views/InvoiceEditorView.xaml
+++ b/Wrecept.Wpf/Views/InvoiceEditorView.xaml
@@ -64,23 +64,15 @@
                 <GroupBox Header="Számlafejléc">
                     <Grid Margin="4">
                         <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="7*" />
                             <ColumnDefinition Width="3*" />
+                            <ColumnDefinition Width="3*" />
+                            <ColumnDefinition Width="4*" />
                         </Grid.ColumnDefinitions>
-                        <Grid Grid.Column="0">
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="70" />
-                                <ColumnDefinition Width="*" />
-                            </Grid.ColumnDefinitions>
-                            <Grid.RowDefinitions>
-                                <RowDefinition />
-                                <RowDefinition />
-                                <RowDefinition />
-                                <RowDefinition />
-                                <RowDefinition />
-                            </Grid.RowDefinitions>
-                            <TextBlock Grid.Row="0" Grid.Column="0" Text="Szállító" VerticalAlignment="Center" />
-                            <c:EditLookup Grid.Row="0" Grid.Column="1" Width="200"
+
+                        <!-- Bal oszlop -->
+                        <StackPanel Grid.Column="0">
+                            <TextBlock Text="Szállító" Style="{StaticResource HeaderText}" />
+                            <c:EditLookup Width="200"
                                           ItemsSource="{Binding Suppliers}"
                                           DisplayMemberPath="Name"
                                           SelectedValuePath="Id"
@@ -88,14 +80,8 @@
                                           CreateCommand="{Binding ShowSupplierCreatorCommand}"
                                           IsEnabled="{Binding IsEditable}" />
 
-                            <TextBlock Grid.Row="1" Grid.Column="0" Text="Dátum" VerticalAlignment="Center" />
-                            <DatePicker Grid.Row="1" Grid.Column="1" SelectedDate="{Binding InvoiceDate}" Width="120" IsEnabled="{Binding IsEditable}" />
-
-                            <TextBlock Grid.Row="2" Grid.Column="0" Text="Szám" VerticalAlignment="Center" />
-                            <TextBox Grid.Row="2" Grid.Column="1" Width="120" Text="{Binding Number}" IsEnabled="{Binding IsNew}" />
-
-                            <TextBlock Grid.Row="3" Grid.Column="0" Text="Fiz. mód" VerticalAlignment="Center" />
-                            <c:EditLookup Grid.Row="3" Grid.Column="1" Width="200"
+                            <TextBlock Text="Fizetési mód" Margin="0,4,0,0" Style="{StaticResource HeaderText}" />
+                            <c:EditLookup Width="200"
                                           ItemsSource="{Binding PaymentMethods}"
                                           DisplayMemberPath="Name"
                                           SelectedValuePath="Id"
@@ -103,9 +89,21 @@
                                           CreateCommand="{Binding ShowPaymentMethodCreatorCommand}"
                                           IsEnabled="{Binding IsEditable}" />
 
-                            <CheckBox Grid.Row="4" Grid.Column="1" Content="Bruttó ár" IsChecked="{Binding IsGross}" IsEnabled="{Binding IsEditable}" />
-                        </Grid>
-                        <c:TotalsPanel Grid.Column="1" Margin="12,0,0,0" />
+                            <CheckBox Content="Bruttó ár" Margin="0,4,0,0" IsChecked="{Binding IsGross}" IsEnabled="{Binding IsEditable}" />
+                        </StackPanel>
+
+                        <!-- Középső oszlop -->
+                        <StackPanel Grid.Column="1" HorizontalAlignment="Center">
+                            <TextBlock Text="Dátum" Style="{StaticResource HeaderText}" />
+                            <DatePicker SelectedDate="{Binding InvoiceDate}" Width="120" IsEnabled="{Binding IsEditable}" />
+                            <TextBlock Text="Számlaszám" Margin="0,4,0,0" Style="{StaticResource HeaderText}" />
+                            <TextBox Width="120" Text="{Binding Number}" IsEnabled="{Binding IsNew}" Style="{StaticResource HeaderTextBold}" />
+                        </StackPanel>
+
+                        <!-- Jobb oszlop: TotalsPanel -->
+                        <Border Grid.Column="2" Padding="4" Margin="0,0,0,0" Background="{DynamicResource ControlBackgroundBrush}">
+                            <c:TotalsPanel HorizontalAlignment="Right" />
+                        </Border>
                     </Grid>
                 </GroupBox>
             </Grid>

--- a/docs/progress/2025-07-02_06-19-48_ui_agent.md
+++ b/docs/progress/2025-07-02_06-19-48_ui_agent.md
@@ -1,0 +1,3 @@
+- InvoiceEditorView fejlécét háromoszlopos gridre alakítottam, a TotalsPanel jobb oldalra került.
+- HeaderText és HeaderTextBold stílusok bevezetve IBM Plex Mono fonttal.
+- TotalsPanelben kiemelt összesítő mezők, "Azaz" szöveg többsoros tördeléssel.


### PR DESCRIPTION
## Summary
- align InvoiceEditorView header to three-column grid
- tweak TotalsPanel to use bold header style and better word wrapping
- extend both themes with monospaced header font styles
- log refactoring progress

## Testing
- `dotnet test --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864ce73ef108322aa44b6fbf9c305de