### PR TITLE
Fix style target mismatch in InvoiceEditorView

### DIFF
--- a/Wrecept.Wpf/Themes/RetroTheme.Dark.xaml
+++ b/Wrecept.Wpf/Themes/RetroTheme.Dark.xaml
@@ -47,6 +47,12 @@
         <Setter Property="FontSize" Value="{StaticResource FontSizeNormal}" />
     </Style>
 
+    <Style TargetType="TextBox" x:Key="HeaderTextBoxBold" BasedOn="{StaticResource {x:Type TextBox}}">
+        <Setter Property="FontFamily" Value="{StaticResource MonospacedFont}" />
+        <Setter Property="FontSize" Value="16" />
+        <Setter Property="FontWeight" Value="Bold" />
+    </Style>
+
     <Style TargetType="Button">
         <Setter Property="Background" Value="{StaticResource HighlightBrush}" />
         <Setter Property="Foreground" Value="White" />

--- a/Wrecept.Wpf/Themes/RetroTheme.xaml
+++ b/Wrecept.Wpf/Themes/RetroTheme.xaml
@@ -48,6 +48,12 @@
         <Setter Property="FontSize" Value="{StaticResource FontSizeNormal}" />
     </Style>
 
+    <Style TargetType="TextBox" x:Key="HeaderTextBoxBold" BasedOn="{StaticResource {x:Type TextBox}}">
+        <Setter Property="FontFamily" Value="{StaticResource MonospacedFont}" />
+        <Setter Property="FontSize" Value="16" />
+        <Setter Property="FontWeight" Value="Bold" />
+    </Style>
+
     <Style TargetType="Button">
         <Setter Property="Background" Value="{StaticResource HighlightBrush}" />
         <Setter Property="Foreground" Value="White" />

--- a/Wrecept.Wpf/Views/InvoiceEditorView.xaml
+++ b/Wrecept.Wpf/Views/InvoiceEditorView.xaml
@@ -97,7 +97,10 @@
                             <TextBlock Text="Dátum" Style="{StaticResource HeaderText}" />
                             <DatePicker SelectedDate="{Binding InvoiceDate}" Width="120" IsEnabled="{Binding IsEditable}" />
                             <TextBlock Text="Számlaszám" Margin="0,4,0,0" Style="{StaticResource HeaderText}" />
-                            <TextBox Width="120" Text="{Binding Number}" IsEnabled="{Binding IsNew}" Style="{StaticResource HeaderTextBold}" />
+                            <TextBox Width="120"
+                                     Text="{Binding Number}"
+                                     IsEnabled="{Binding IsNew}"
+                                     Style="{StaticResource HeaderTextBoxBold}" />
                         </StackPanel>
 
                         <!-- Jobb oszlop: TotalsPanel -->

--- a/docs/progress/2025-07-02_06-36-40_ui_agent.md
+++ b/docs/progress/2025-07-02_06-36-40_ui_agent.md
@@ -1,0 +1,3 @@
+- "HeaderTextBoxBold" stílus bevezetve a RetroTheme-ben.
+- InvoiceEditorView Számlaszám mezője ezt az új stílust használja.
+- themes.md frissítve a stíluslista bővítésével.

--- a/docs/themes.md
+++ b/docs/themes.md
@@ -17,6 +17,10 @@ A Retro UI hangs on a 16 színű DOS-palettán. A XAML erőforrás szótár egys
 - **ControlBackgroundBrush:** Olívzöld (`#c7bb4f`) mezők alapja.
 - **HeaderFooterBrush:** Sötétebb sárga (`#806000`) fejléc és lábléc szín.
 
+Stílusok:
+- **HeaderText**, **HeaderTextBold**: IBM Plex Mono betűcsalád feliratokhoz.
+- **HeaderTextBoxBold**: ugyanez a megjelenés szövegmezőknél.
+
 Betűméretek:
 - **FontSizeNormal:** 16 px, általános szövegekhez és űrlapmezőkhöz.
 - **FontSizeLarge:** 18 px, gombokhoz, menükhöz és táblázatokhoz.


### PR DESCRIPTION
## Summary
- introduce `HeaderTextBoxBold` style in light and dark Retro theme
- use new style for invoice number field
- document style in `themes.md`
- log progress

## Testing
- `dotnet test --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864d2b0b2248322a1bc7ccd91be17e9