### PR TITLE
Apply IBM Plex Mono font across UI

### DIFF
--- a/Wrecept.Wpf/Themes/RetroTheme.Dark.xaml
+++ b/Wrecept.Wpf/Themes/RetroTheme.Dark.xaml
@@ -35,7 +35,7 @@
 
     <Style TargetType="TextBlock">
         <Setter Property="Foreground" Value="{StaticResource ForegroundBrush}" />
-        <Setter Property="FontFamily" Value="Consolas" />
+        <Setter Property="FontFamily" Value="{StaticResource MonospacedFont}" />
         <Setter Property="FontSize" Value="{StaticResource FontSizeNormal}" />
     </Style>
 
@@ -43,7 +43,7 @@
         <Setter Property="Foreground" Value="{StaticResource ForegroundBrush}" />
         <Setter Property="Background" Value="{StaticResource ControlBackgroundBrush}" />
         <Setter Property="BorderBrush" Value="{StaticResource HighlightBrush}" />
-        <Setter Property="FontFamily" Value="Consolas" />
+        <Setter Property="FontFamily" Value="{StaticResource MonospacedFont}" />
         <Setter Property="FontSize" Value="{StaticResource FontSizeNormal}" />
     </Style>
 
@@ -53,25 +53,40 @@
         <Setter Property="FontWeight" Value="Bold" />
     </Style>
 
+    <Style TargetType="ComboBox">
+        <Setter Property="FontFamily" Value="{StaticResource MonospacedFont}" />
+        <Setter Property="FontSize" Value="{StaticResource FontSizeNormal}" />
+    </Style>
+
+    <Style TargetType="Label">
+        <Setter Property="FontFamily" Value="{StaticResource MonospacedFont}" />
+        <Setter Property="FontSize" Value="{StaticResource FontSizeNormal}" />
+    </Style>
+
+    <Style TargetType="CheckBox">
+        <Setter Property="FontFamily" Value="{StaticResource MonospacedFont}" />
+        <Setter Property="FontSize" Value="{StaticResource FontSizeNormal}" />
+    </Style>
+
     <Style TargetType="Button">
         <Setter Property="Background" Value="{StaticResource HighlightBrush}" />
         <Setter Property="Foreground" Value="White" />
         <Setter Property="BorderBrush" Value="{StaticResource ForegroundBrush}" />
-        <Setter Property="FontFamily" Value="Consolas" />
+        <Setter Property="FontFamily" Value="{StaticResource MonospacedFont}" />
         <Setter Property="FontSize" Value="{StaticResource FontSizeLarge}" />
     </Style>
 
     <Style TargetType="Menu">
         <Setter Property="Background" Value="{StaticResource HeaderFooterBrush}" />
         <Setter Property="Foreground" Value="{StaticResource ForegroundBrush}" />
-        <Setter Property="FontFamily" Value="Consolas" />
+        <Setter Property="FontFamily" Value="{StaticResource MonospacedFont}" />
         <Setter Property="FontSize" Value="{StaticResource FontSizeLarge}" />
     </Style>
 
     <Style TargetType="MenuItem">
         <Setter Property="Background" Value="{StaticResource HeaderFooterBrush}" />
         <Setter Property="Foreground" Value="{StaticResource ForegroundBrush}" />
-        <Setter Property="FontFamily" Value="Consolas" />
+        <Setter Property="FontFamily" Value="{StaticResource MonospacedFont}" />
         <Setter Property="FontSize" Value="{StaticResource FontSizeLarge}" />
     </Style>
 
@@ -82,13 +97,14 @@
         <Setter Property="GridLinesVisibility" Value="All" />
         <Setter Property="RowBackground" Value="{StaticResource ControlBackgroundBrush}" />
         <Setter Property="AlternatingRowBackground" Value="{StaticResource ControlBackgroundBrush}" />
-        <Setter Property="FontFamily" Value="Consolas" />
+        <Setter Property="FontFamily" Value="{StaticResource MonospacedFont}" />
         <Setter Property="FontSize" Value="{StaticResource FontSizeLarge}" />
     </Style>
 
     <Style TargetType="DataGridRow" x:Key="RetroDataGridRowStyle">
         <Setter Property="Foreground" Value="{StaticResource ForegroundBrush}" />
         <Setter Property="Background" Value="{StaticResource ControlBackgroundBrush}" />
+        <Setter Property="FontFamily" Value="{StaticResource MonospacedFont}" />
         <Setter Property="FontSize" Value="{StaticResource FontSizeLarge}" />
         <Style.Triggers>
             <Trigger Property="IsSelected" Value="True">

--- a/Wrecept.Wpf/Themes/RetroTheme.xaml
+++ b/Wrecept.Wpf/Themes/RetroTheme.xaml
@@ -36,7 +36,7 @@
 
     <Style TargetType="TextBlock">
         <Setter Property="Foreground" Value="{StaticResource ForegroundBrush}" />
-        <Setter Property="FontFamily" Value="Consolas" />
+        <Setter Property="FontFamily" Value="{StaticResource MonospacedFont}" />
         <Setter Property="FontSize" Value="{StaticResource FontSizeNormal}" />
     </Style>
 
@@ -44,7 +44,7 @@
         <Setter Property="Foreground" Value="{StaticResource ForegroundBrush}" />
         <Setter Property="Background" Value="{StaticResource ControlBackgroundBrush}" />
         <Setter Property="BorderBrush" Value="{StaticResource HighlightBrush}" />
-        <Setter Property="FontFamily" Value="Consolas" />
+        <Setter Property="FontFamily" Value="{StaticResource MonospacedFont}" />
         <Setter Property="FontSize" Value="{StaticResource FontSizeNormal}" />
     </Style>
 
@@ -54,25 +54,40 @@
         <Setter Property="FontWeight" Value="Bold" />
     </Style>
 
+    <Style TargetType="ComboBox">
+        <Setter Property="FontFamily" Value="{StaticResource MonospacedFont}" />
+        <Setter Property="FontSize" Value="{StaticResource FontSizeNormal}" />
+    </Style>
+
+    <Style TargetType="Label">
+        <Setter Property="FontFamily" Value="{StaticResource MonospacedFont}" />
+        <Setter Property="FontSize" Value="{StaticResource FontSizeNormal}" />
+    </Style>
+
+    <Style TargetType="CheckBox">
+        <Setter Property="FontFamily" Value="{StaticResource MonospacedFont}" />
+        <Setter Property="FontSize" Value="{StaticResource FontSizeNormal}" />
+    </Style>
+
     <Style TargetType="Button">
         <Setter Property="Background" Value="{StaticResource HighlightBrush}" />
         <Setter Property="Foreground" Value="White" />
         <Setter Property="BorderBrush" Value="{StaticResource ForegroundBrush}" />
-        <Setter Property="FontFamily" Value="Consolas" />
+        <Setter Property="FontFamily" Value="{StaticResource MonospacedFont}" />
         <Setter Property="FontSize" Value="{StaticResource FontSizeLarge}" />
     </Style>
 
     <Style TargetType="Menu">
         <Setter Property="Background" Value="{StaticResource HeaderFooterBrush}" />
         <Setter Property="Foreground" Value="{StaticResource ForegroundBrush}" />
-        <Setter Property="FontFamily" Value="Consolas" />
+        <Setter Property="FontFamily" Value="{StaticResource MonospacedFont}" />
         <Setter Property="FontSize" Value="{StaticResource FontSizeLarge}" />
     </Style>
 
     <Style TargetType="MenuItem">
         <Setter Property="Background" Value="{StaticResource HeaderFooterBrush}" />
         <Setter Property="Foreground" Value="{StaticResource ForegroundBrush}" />
-        <Setter Property="FontFamily" Value="Consolas" />
+        <Setter Property="FontFamily" Value="{StaticResource MonospacedFont}" />
         <Setter Property="FontSize" Value="{StaticResource FontSizeLarge}" />
     </Style>
 
@@ -83,13 +98,14 @@
         <Setter Property="GridLinesVisibility" Value="All" />
         <Setter Property="RowBackground" Value="{StaticResource ControlBackgroundBrush}" />
         <Setter Property="AlternatingRowBackground" Value="{StaticResource ControlBackgroundBrush}" />
-        <Setter Property="FontFamily" Value="Consolas" />
+        <Setter Property="FontFamily" Value="{StaticResource MonospacedFont}" />
         <Setter Property="FontSize" Value="{StaticResource FontSizeLarge}" />
     </Style>
 
     <Style TargetType="DataGridRow" x:Key="RetroDataGridRowStyle">
         <Setter Property="Foreground" Value="{StaticResource ForegroundBrush}" />
         <Setter Property="Background" Value="{StaticResource ControlBackgroundBrush}" />
+        <Setter Property="FontFamily" Value="{StaticResource MonospacedFont}" />
         <Setter Property="FontSize" Value="{StaticResource FontSizeLarge}" />
         <Style.Triggers>
             <Trigger Property="IsSelected" Value="True">

--- a/Wrecept.Wpf/Views/AboutView.xaml
+++ b/Wrecept.Wpf/Views/AboutView.xaml
@@ -3,6 +3,6 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              KeyDown="OnKeyDown">
     <ScrollViewer Background="{DynamicResource StageBackground}" Margin="4">
-        <TextBlock Text="{Binding AboutText}" TextWrapping="Wrap" FontFamily="Consolas"/>
+        <TextBlock Text="{Binding AboutText}" TextWrapping="Wrap" FontFamily="{DynamicResource MonospacedFont}"/>
     </ScrollViewer>
 </UserControl>

--- a/Wrecept.Wpf/Views/InvoiceEditorView.xaml
+++ b/Wrecept.Wpf/Views/InvoiceEditorView.xaml
@@ -70,9 +70,19 @@
                         </Grid.ColumnDefinitions>
 
                         <!-- Bal oszlop -->
-                        <StackPanel Grid.Column="0">
-                            <TextBlock Text="Szállító" Style="{StaticResource HeaderText}" />
-                            <c:EditLookup Width="200"
+                        <Grid Grid.Column="0">
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="Auto" />
+                            </Grid.RowDefinitions>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition Width="220" />
+                            </Grid.ColumnDefinitions>
+
+                            <TextBlock Grid.Row="0" Grid.Column="0" Text="Szállító" Style="{StaticResource HeaderText}" />
+                            <c:EditLookup Grid.Row="0" Grid.Column="1" Width="220"
                                           ItemsSource="{Binding Suppliers}"
                                           DisplayMemberPath="Name"
                                           SelectedValuePath="Id"
@@ -80,8 +90,8 @@
                                           CreateCommand="{Binding ShowSupplierCreatorCommand}"
                                           IsEnabled="{Binding IsEditable}" />
 
-                            <TextBlock Text="Fizetési mód" Margin="0,4,0,0" Style="{StaticResource HeaderText}" />
-                            <c:EditLookup Width="200"
+                            <TextBlock Grid.Row="1" Grid.Column="0" Text="Fizetési mód" Margin="0,4,0,0" Style="{StaticResource HeaderText}" />
+                            <c:EditLookup Grid.Row="1" Grid.Column="1" Width="220" Margin="0,4,0,0"
                                           ItemsSource="{Binding PaymentMethods}"
                                           DisplayMemberPath="Name"
                                           SelectedValuePath="Id"
@@ -89,19 +99,29 @@
                                           CreateCommand="{Binding ShowPaymentMethodCreatorCommand}"
                                           IsEnabled="{Binding IsEditable}" />
 
-                            <CheckBox Content="Bruttó ár" Margin="0,4,0,0" IsChecked="{Binding IsGross}" IsEnabled="{Binding IsEditable}" />
-                        </StackPanel>
+                            <CheckBox Grid.Row="2" Grid.ColumnSpan="2" Content="Bruttó ár" Margin="0,4,0,0" IsChecked="{Binding IsGross}" IsEnabled="{Binding IsEditable}" />
+                        </Grid>
 
                         <!-- Középső oszlop -->
-                        <StackPanel Grid.Column="1" HorizontalAlignment="Center">
-                            <TextBlock Text="Dátum" Style="{StaticResource HeaderText}" />
-                            <DatePicker SelectedDate="{Binding InvoiceDate}" Width="120" IsEnabled="{Binding IsEditable}" />
-                            <TextBlock Text="Számlaszám" Margin="0,4,0,0" Style="{StaticResource HeaderText}" />
-                            <TextBox Width="120"
+                        <Grid Grid.Column="1">
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="Auto" />
+                            </Grid.RowDefinitions>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition Width="220" />
+                            </Grid.ColumnDefinitions>
+
+                            <TextBlock Grid.Row="0" Grid.Column="0" Text="Dátum" Style="{StaticResource HeaderText}" />
+                            <DatePicker Grid.Row="0" Grid.Column="1" Width="220" SelectedDate="{Binding InvoiceDate}" IsEnabled="{Binding IsEditable}" />
+
+                            <TextBlock Grid.Row="1" Grid.Column="0" Margin="0,4,0,0" Text="Számlaszám" Style="{StaticResource HeaderText}" />
+                            <TextBox Grid.Row="1" Grid.Column="1" Width="220" Margin="0,4,0,0"
                                      Text="{Binding Number}"
                                      IsEnabled="{Binding IsNew}"
                                      Style="{StaticResource HeaderTextBoxBold}" />
-                        </StackPanel>
+                        </Grid>
 
                         <!-- Jobb oszlop: TotalsPanel -->
                         <Border Grid.Column="2" Padding="4" Margin="0,0,0,0" Background="{DynamicResource ControlBackgroundBrush}">

--- a/docs/progress/2025-07-02_06-54-06_ui_agent.md
+++ b/docs/progress/2025-07-02_06-54-06_ui_agent.md
@@ -1,0 +1,4 @@
+- Minden vezérlő alapértelmezett fontja IBM Plex Mono lett a RetroTheme-ben.
+- A sötét téma ugyanezt a fontot használja, kiegészítő stílusokkal.
+- InvoiceEditorView fejlécében a bal és középső oszlop rácsra váltott egységes 220px-es mezőkkel.
+- AboutView betűtípusa is MonospacedFont erőforrást használ.


### PR DESCRIPTION
## Summary
- use IBM Plex Mono in RetroTheme and RetroTheme.Dark
- add ComboBox, Label and CheckBox styles
- align InvoiceEditor header columns using a grid with fixed width controls
- switch AboutView to the MonospacedFont resource
- log progress

## Testing
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864d61f006883229fabb0a7286c919b