### PR TITLE
Fix async prompt handling

### DIFF
--- a/Wrecept.Wpf/ViewModels/InvoiceLookupViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/InvoiceLookupViewModel.cs
@@ -56,8 +56,17 @@ public partial class InvoiceLookupViewModel : ObservableObject
             Number = number,
             Date = DateOnly.FromDateTime(DateTime.Today)
         };
+
         var id = await _invoices.CreateHeaderAsync(invoice);
-        await LoadAsync();
+
+        Invoices.Insert(0, new InvoiceLookupItem
+        {
+            Id = id,
+            Number = number,
+            Date = invoice.Date,
+            Supplier = string.Empty
+        });
+
         SelectedInvoice = Invoices.FirstOrDefault(i => i.Id == id);
         return id;
     }

--- a/Wrecept.Wpf/ViewModels/ProductCreatorViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/ProductCreatorViewModel.cs
@@ -58,7 +58,7 @@ public partial class ProductCreatorViewModel : ObservableObject
         _row.Product = product.Name;
         _parent.InlineCreator = null;
         if (_parent.IsEditable)
-            _parent.AddLineItemCommand.Execute(null);
+            await _parent.AddLineItemCommand.ExecuteAsync(null);
     }
 
     [RelayCommand]

--- a/Wrecept.Wpf/Views/InlinePrompts/ArchivePromptView.xaml.cs
+++ b/Wrecept.Wpf/Views/InlinePrompts/ArchivePromptView.xaml.cs
@@ -10,13 +10,13 @@ public partial class ArchivePromptView : UserControl
         InitializeComponent();
     }
 
-    private void OnKeyDown(object sender, KeyEventArgs e)
+    private async void OnKeyDown(object sender, KeyEventArgs e)
     {
         if (DataContext is not Wrecept.Wpf.ViewModels.ArchivePromptViewModel vm)
             return;
         if (e.Key == Key.Enter)
         {
-            vm.ConfirmCommand.Execute(null);
+            await vm.ConfirmCommand.ExecuteAsync(null);
             e.Handled = true;
         }
         else if (e.Key == Key.Escape)

--- a/Wrecept.Wpf/Views/InlinePrompts/InvoiceCreatePromptView.xaml.cs
+++ b/Wrecept.Wpf/Views/InlinePrompts/InvoiceCreatePromptView.xaml.cs
@@ -10,13 +10,13 @@ public partial class InvoiceCreatePromptView : UserControl
         InitializeComponent();
     }
 
-    private void OnKeyDown(object sender, KeyEventArgs e)
+    private async void OnKeyDown(object sender, KeyEventArgs e)
     {
         if (DataContext is not Wrecept.Wpf.ViewModels.InvoiceCreatePromptViewModel vm)
             return;
         if (e.Key == Key.Enter)
         {
-            vm.ConfirmCommand.Execute(null);
+            await vm.ConfirmCommand.ExecuteAsync(null);
             e.Handled = true;
         }
         else if (e.Key == Key.Escape)

--- a/Wrecept.Wpf/Views/InlinePrompts/SaveLinePromptView.xaml.cs
+++ b/Wrecept.Wpf/Views/InlinePrompts/SaveLinePromptView.xaml.cs
@@ -10,13 +10,13 @@ public partial class SaveLinePromptView : UserControl
         InitializeComponent();
     }
 
-    private void OnKeyDown(object sender, KeyEventArgs e)
+    private async void OnKeyDown(object sender, KeyEventArgs e)
     {
         if (DataContext is not Wrecept.Wpf.ViewModels.SaveLinePromptViewModel vm)
             return;
         if (e.Key == Key.Enter)
         {
-            vm.ConfirmCommand.Execute(null);
+            await vm.ConfirmCommand.ExecuteAsync(null);
             e.Handled = true;
         }
         else if (e.Key == Key.Escape)

--- a/Wrecept.Wpf/Views/InvoiceEditorView.xaml.cs
+++ b/Wrecept.Wpf/Views/InvoiceEditorView.xaml.cs
@@ -46,13 +46,13 @@ public partial class InvoiceEditorView : UserControl
         NavigationHelper.Handle(e);
     }
 
-    private void OnEntryKeyDown(object sender, KeyEventArgs e)
+    private async void OnEntryKeyDown(object sender, KeyEventArgs e)
     {
         if (DataContext is not InvoiceEditorViewModel vm)
             return;
         if (e.Key == Key.Enter && e.OriginalSource is FrameworkElement { Name: "EntryTax" })
         {
-            vm.AddLineItemCommand.Execute(null);
+            await vm.AddLineItemCommand.ExecuteAsync(null);
             e.Handled = true;
         }
         else

--- a/Wrecept.Wpf/Views/InvoiceLookupView.xaml.cs
+++ b/Wrecept.Wpf/Views/InvoiceLookupView.xaml.cs
@@ -27,7 +27,7 @@ public partial class InvoiceLookupView : UserControl
             await vm.LoadAsync();
     }
 
-    private void OnKeyDown(object sender, KeyEventArgs e)
+    private async void OnKeyDown(object sender, KeyEventArgs e)
     {
         if (DataContext is InvoiceLookupViewModel vm)
         {
@@ -35,7 +35,7 @@ public partial class InvoiceLookupView : UserControl
             {
                 if (e.Key == Key.Enter)
                 {
-                    prompt.ConfirmCommand.Execute(null);
+                    await prompt.ConfirmCommand.ExecuteAsync(null);
                     e.Handled = true;
                     return;
                 }
@@ -60,7 +60,7 @@ public partial class InvoiceLookupView : UserControl
             if (e.Key == Key.Enter)
             {
                 if (this.FindAncestor<InvoiceEditorView>()?.DataContext is InvoiceEditorViewModel parent)
-                    parent.OpenSelectedInvoiceCommand.Execute(null);
+                    await parent.OpenSelectedInvoiceCommand.ExecuteAsync(null);
                 e.Handled = true;
                 return;
             }

--- a/docs/progress/2025-07-02_10-46-59_code_agent.md
+++ b/docs/progress/2025-07-02_10-46-59_code_agent.md
@@ -1,0 +1,2 @@
+- async key handlers now await commands to prevent UI freezes when creating invoices
+- InvoiceLookupViewModel adds new header without full reload


### PR DESCRIPTION
## Summary
- await inline prompt commands to avoid UI stalls
- insert new invoice header directly instead of reloading whole list
- record progress

## Testing
- `dotnet test --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_68650abbc7d48322935feb5ecccac998