### PR TITLE
Unify master data editing

### DIFF
--- a/Wrecept.Core.Tests/Services/PaymentMethodServiceTests.cs
+++ b/Wrecept.Core.Tests/Services/PaymentMethodServiceTests.cs
@@ -63,6 +63,18 @@ public class PaymentMethodServiceTests
     }
 
     [Fact]
+    public async Task UpdateAsync_AllowsArchiving()
+    {
+        var repo = new FakeRepo();
+        var svc = new PaymentMethodService(repo);
+        var method = new PaymentMethod { Id = Guid.NewGuid(), Name = "Cash", IsArchived = true };
+
+        await svc.UpdateAsync(method);
+
+        Assert.True(repo.Updated?.IsArchived);
+    }
+
+    [Fact]
     public async Task UpdateAsync_Throws_WhenIdInvalid()
     {
         var repo = new FakeRepo();

--- a/Wrecept.Core.Tests/Services/ProductServiceTests.cs
+++ b/Wrecept.Core.Tests/Services/ProductServiceTests.cs
@@ -65,6 +65,18 @@ public class ProductServiceTests
     }
 
     [Fact]
+    public async Task UpdateAsync_AllowsArchiving()
+    {
+        var repo = new FakeRepo();
+        var svc = new ProductService(repo);
+        var prod = new Product { Id = 2, Name = "Prod", Net = 1, Gross = 1, IsArchived = true };
+
+        await svc.UpdateAsync(prod);
+
+        Assert.True(repo.Updated?.IsArchived);
+    }
+
+    [Fact]
     public async Task UpdateAsync_Throws_WhenIdInvalid()
     {
         var repo = new FakeRepo();

--- a/Wrecept.Core.Tests/Services/SupplierServiceTests.cs
+++ b/Wrecept.Core.Tests/Services/SupplierServiceTests.cs
@@ -63,6 +63,18 @@ public class SupplierServiceTests
     }
 
     [Fact]
+    public async Task UpdateAsync_AllowsArchiving()
+    {
+        var repo = new FakeRepo();
+        var svc = new SupplierService(repo);
+        var supplier = new Supplier { Id = 2, Name = "Supp", IsArchived = true };
+
+        await svc.UpdateAsync(supplier);
+
+        Assert.True(repo.Updated?.IsArchived);
+    }
+
+    [Fact]
     public async Task UpdateAsync_Throws_WhenIdInvalid()
     {
         var repo = new FakeRepo();

--- a/Wrecept.Core.Tests/Services/UnitServiceTests.cs
+++ b/Wrecept.Core.Tests/Services/UnitServiceTests.cs
@@ -63,6 +63,18 @@ public class UnitServiceTests
     }
 
     [Fact]
+    public async Task UpdateAsync_AllowsArchiving()
+    {
+        var repo = new FakeRepo();
+        var svc = new UnitService(repo);
+        var unit = new Unit { Id = Guid.NewGuid(), Name = "kg", IsArchived = true };
+
+        await svc.UpdateAsync(unit);
+
+        Assert.True(repo.Updated?.IsArchived);
+    }
+
+    [Fact]
     public async Task UpdateAsync_Throws_WhenIdInvalid()
     {
         var repo = new FakeRepo();

--- a/Wrecept.Wpf/ViewModels/EditableMasterDataViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/EditableMasterDataViewModel.cs
@@ -1,0 +1,43 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using System.Threading.Tasks;
+
+namespace Wrecept.Wpf.ViewModels;
+
+public abstract partial class EditableMasterDataViewModel<T> : MasterDataBaseViewModel<T>
+{
+    [ObservableProperty]
+    private bool isEditing;
+
+    public IRelayCommand EditSelectedCommand { get; }
+    public IRelayCommand DeleteSelectedCommand { get; }
+    public IRelayCommand CloseDetailsCommand { get; }
+
+    protected EditableMasterDataViewModel()
+    {
+        EditSelectedCommand = new RelayCommand(OnEditSelected, CanModify);
+        DeleteSelectedCommand = new RelayCommand(async () => await OnDeleteSelected(), CanModify);
+        CloseDetailsCommand = new RelayCommand(() => IsEditing = false);
+    }
+
+    partial void OnSelectedItemChanged(T? oldValue, T? newValue)
+    {
+        (EditSelectedCommand as RelayCommand)?.NotifyCanExecuteChanged();
+        (DeleteSelectedCommand as RelayCommand)?.NotifyCanExecuteChanged();
+    }
+
+    private void OnEditSelected() => IsEditing = !IsEditing;
+
+    private async Task OnDeleteSelected()
+    {
+        if (SelectedItem != null)
+        {
+            await DeleteAsync();
+            await LoadAsync();
+        }
+    }
+
+    protected virtual Task DeleteAsync() => Task.CompletedTask;
+
+    private bool CanModify() => SelectedItem != null;
+}

--- a/Wrecept.Wpf/ViewModels/PaymentMethodMasterViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/PaymentMethodMasterViewModel.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace Wrecept.Wpf.ViewModels;
 
-public partial class PaymentMethodMasterViewModel : MasterDataBaseViewModel<PaymentMethod>
+public partial class PaymentMethodMasterViewModel : EditableMasterDataViewModel<PaymentMethod>
 {
     public ObservableCollection<PaymentMethod> PaymentMethods => Items;
     private readonly IPaymentMethodService _service;
@@ -18,4 +18,13 @@ public partial class PaymentMethodMasterViewModel : MasterDataBaseViewModel<Paym
 
     protected override Task<List<PaymentMethod>> GetItemsAsync()
         => _service.GetActiveAsync();
+
+    protected override async Task DeleteAsync()
+    {
+        if (SelectedItem != null)
+        {
+            SelectedItem.IsArchived = true;
+            await _service.UpdateAsync(SelectedItem);
+        }
+    }
 }

--- a/Wrecept.Wpf/ViewModels/ProductGroupMasterViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/ProductGroupMasterViewModel.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace Wrecept.Wpf.ViewModels;
 
-public partial class ProductGroupMasterViewModel : MasterDataBaseViewModel<ProductGroup>
+public partial class ProductGroupMasterViewModel : EditableMasterDataViewModel<ProductGroup>
 {
     public ObservableCollection<ProductGroup> ProductGroups => Items;
 
@@ -19,4 +19,13 @@ public partial class ProductGroupMasterViewModel : MasterDataBaseViewModel<Produ
 
     protected override Task<List<ProductGroup>> GetItemsAsync()
         => _service.GetActiveAsync();
+
+    protected override async Task DeleteAsync()
+    {
+        if (SelectedItem != null)
+        {
+            SelectedItem.IsArchived = true;
+            await _service.UpdateAsync(SelectedItem);
+        }
+    }
 }

--- a/Wrecept.Wpf/ViewModels/ProductMasterViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/ProductMasterViewModel.cs
@@ -1,6 +1,5 @@
 using System.Collections.ObjectModel;
 using CommunityToolkit.Mvvm.ComponentModel;
-using CommunityToolkit.Mvvm.Input;
 using Wrecept.Core.Models;
 using Wrecept.Core.Services;
 using System.Threading.Tasks;
@@ -9,7 +8,7 @@ using System.Collections.Generic;
 
 namespace Wrecept.Wpf.ViewModels;
 
-public partial class ProductMasterViewModel : MasterDataBaseViewModel<Product>
+public partial class ProductMasterViewModel : EditableMasterDataViewModel<Product>
 {
     public ObservableCollection<Product> Products => Items;
     public ObservableCollection<TaxRate> TaxRates { get; } = new();
@@ -17,32 +16,23 @@ public partial class ProductMasterViewModel : MasterDataBaseViewModel<Product>
     private readonly IProductService _service;
     private readonly ITaxRateService _taxRates;
 
-    [ObservableProperty]
-    private bool isEditing;
-
-    public IRelayCommand EditSelectedCommand { get; }
-    public IRelayCommand DeleteSelectedCommand { get; }
-    public IRelayCommand CloseDetailsCommand { get; }
-
     public ProductMasterViewModel(IProductService service, ITaxRateService taxRates)
     {
         _service = service;
         _taxRates = taxRates;
-        EditSelectedCommand = new RelayCommand(() => IsEditing = !IsEditing, () => SelectedItem != null);
-        DeleteSelectedCommand = new RelayCommand(async () =>
-        {
-            if (SelectedItem != null)
-            {
-                SelectedItem.IsArchived = true;
-                await _service.UpdateAsync(SelectedItem);
-                await LoadAsync();
-            }
-        }, () => SelectedItem != null);
-        CloseDetailsCommand = new RelayCommand(() => IsEditing = false);
     }
 
     protected override Task<List<Product>> GetItemsAsync()
         => _service.GetActiveAsync();
+
+    protected override async Task DeleteAsync()
+    {
+        if (SelectedItem != null)
+        {
+            SelectedItem.IsArchived = true;
+            await _service.UpdateAsync(SelectedItem);
+        }
+    }
 
     public override async Task LoadAsync()
     {

--- a/Wrecept.Wpf/ViewModels/SupplierMasterViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/SupplierMasterViewModel.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace Wrecept.Wpf.ViewModels;
 
-public partial class SupplierMasterViewModel : MasterDataBaseViewModel<Supplier>
+public partial class SupplierMasterViewModel : EditableMasterDataViewModel<Supplier>
 {
     private readonly ISupplierService _service;
 
@@ -19,4 +19,13 @@ public partial class SupplierMasterViewModel : MasterDataBaseViewModel<Supplier>
 
     protected override Task<List<Supplier>> GetItemsAsync()
         => _service.GetActiveAsync();
+
+    protected override async Task DeleteAsync()
+    {
+        if (SelectedItem != null)
+        {
+            SelectedItem.IsArchived = true;
+            await _service.UpdateAsync(SelectedItem);
+        }
+    }
 }

--- a/Wrecept.Wpf/ViewModels/TaxRateMasterViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/TaxRateMasterViewModel.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace Wrecept.Wpf.ViewModels;
 
-public partial class TaxRateMasterViewModel : MasterDataBaseViewModel<TaxRate>
+public partial class TaxRateMasterViewModel : EditableMasterDataViewModel<TaxRate>
 {
     public ObservableCollection<TaxRate> TaxRates => Items;
 
@@ -20,4 +20,13 @@ public partial class TaxRateMasterViewModel : MasterDataBaseViewModel<TaxRate>
 
     protected override Task<List<TaxRate>> GetItemsAsync()
         => _service.GetActiveAsync(DateTime.UtcNow);
+
+    protected override async Task DeleteAsync()
+    {
+        if (SelectedItem != null)
+        {
+            SelectedItem.IsArchived = true;
+            await _service.UpdateAsync(SelectedItem);
+        }
+    }
 }

--- a/Wrecept.Wpf/ViewModels/UnitMasterViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/UnitMasterViewModel.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace Wrecept.Wpf.ViewModels;
 
-public partial class UnitMasterViewModel : MasterDataBaseViewModel<Unit>
+public partial class UnitMasterViewModel : EditableMasterDataViewModel<Unit>
 {
     public ObservableCollection<Unit> Units => Items;
 
@@ -19,4 +19,13 @@ public partial class UnitMasterViewModel : MasterDataBaseViewModel<Unit>
 
     protected override Task<List<Unit>> GetItemsAsync()
         => _service.GetActiveAsync();
+
+    protected override async Task DeleteAsync()
+    {
+        if (SelectedItem != null)
+        {
+            SelectedItem.IsArchived = true;
+            await _service.UpdateAsync(SelectedItem);
+        }
+    }
 }

--- a/Wrecept.Wpf/Views/PaymentMethodMasterView.xaml
+++ b/Wrecept.Wpf/Views/PaymentMethodMasterView.xaml
@@ -11,4 +11,18 @@
         <DataGridCheckBoxColumn Binding="{Binding IsArchived}" Header="Archivált" />
         <DataGridTextColumn Binding="{Binding UpdatedAt}" Header="Módosítva" />
     </viewsControls:BaseMasterView.Columns>
+    <viewsControls:BaseMasterView.RowDetailsTemplate>
+        <DataTemplate>
+            <StackPanel Margin="4">
+                <StackPanel Orientation="Horizontal">
+                    <TextBlock Width="80" Text="Név"/>
+                    <TextBox x:Name="InitialFocus" Text="{Binding Name, Mode=TwoWay}" Width="200"/>
+                </StackPanel>
+                <StackPanel Orientation="Horizontal" Margin="0,4,0,0">
+                    <TextBlock Width="80" Text="Határidő"/>
+                    <TextBox Text="{Binding DueInDays, Mode=TwoWay}" Width="80"/>
+                </StackPanel>
+            </StackPanel>
+        </DataTemplate>
+    </viewsControls:BaseMasterView.RowDetailsTemplate>
 </viewsControls:BaseMasterView>

--- a/Wrecept.Wpf/Views/ProductGroupMasterView.xaml
+++ b/Wrecept.Wpf/Views/ProductGroupMasterView.xaml
@@ -10,4 +10,14 @@
         <DataGridCheckBoxColumn Binding="{Binding IsArchived}" Header="Archivált" />
         <DataGridTextColumn Binding="{Binding UpdatedAt}" Header="Módosítva" />
     </viewsControls:BaseMasterView.Columns>
+    <viewsControls:BaseMasterView.RowDetailsTemplate>
+        <DataTemplate>
+            <StackPanel Margin="4">
+                <StackPanel Orientation="Horizontal">
+                    <TextBlock Width="80" Text="Név"/>
+                    <TextBox x:Name="InitialFocus" Text="{Binding Name, Mode=TwoWay}" Width="200"/>
+                </StackPanel>
+            </StackPanel>
+        </DataTemplate>
+    </viewsControls:BaseMasterView.RowDetailsTemplate>
 </viewsControls:BaseMasterView>

--- a/Wrecept.Wpf/Views/SupplierMasterView.xaml
+++ b/Wrecept.Wpf/Views/SupplierMasterView.xaml
@@ -8,4 +8,14 @@
     <viewsControls:BaseMasterView.Columns>
         <DataGridTextColumn Header="Név" Binding="{Binding Name}" Width="*" />
     </viewsControls:BaseMasterView.Columns>
+    <viewsControls:BaseMasterView.RowDetailsTemplate>
+        <DataTemplate>
+            <StackPanel Margin="4">
+                <StackPanel Orientation="Horizontal">
+                    <TextBlock Width="80" Text="Név"/>
+                    <TextBox x:Name="InitialFocus" Text="{Binding Name, Mode=TwoWay}" Width="200"/>
+                </StackPanel>
+            </StackPanel>
+        </DataTemplate>
+    </viewsControls:BaseMasterView.RowDetailsTemplate>
 </viewsControls:BaseMasterView>

--- a/Wrecept.Wpf/Views/TaxRateMasterView.xaml
+++ b/Wrecept.Wpf/Views/TaxRateMasterView.xaml
@@ -19,4 +19,22 @@
             </DataGridCheckBoxColumn.ElementStyle>
         </DataGridCheckBoxColumn>
     </viewsControls:BaseMasterView.Columns>
+    <viewsControls:BaseMasterView.RowDetailsTemplate>
+        <DataTemplate>
+            <StackPanel Margin="4">
+                <StackPanel Orientation="Horizontal">
+                    <TextBlock Width="80" Text="Kód"/>
+                    <TextBox x:Name="InitialFocus" Text="{Binding Code, Mode=TwoWay}" Width="80"/>
+                </StackPanel>
+                <StackPanel Orientation="Horizontal" Margin="0,4,0,0">
+                    <TextBlock Width="80" Text="Név"/>
+                    <TextBox Text="{Binding Name, Mode=TwoWay}" Width="200"/>
+                </StackPanel>
+                <StackPanel Orientation="Horizontal" Margin="0,4,0,0">
+                    <TextBlock Width="80" Text="Százalék"/>
+                    <TextBox Text="{Binding Percentage, Mode=TwoWay}" Width="80"/>
+                </StackPanel>
+            </StackPanel>
+        </DataTemplate>
+    </viewsControls:BaseMasterView.RowDetailsTemplate>
 </viewsControls:BaseMasterView>

--- a/Wrecept.Wpf/Views/UnitMasterView.xaml
+++ b/Wrecept.Wpf/Views/UnitMasterView.xaml
@@ -17,4 +17,18 @@
         </DataGridCheckBoxColumn>
         <DataGridTextColumn Binding="{Binding UpdatedAt}" Header="Módosítva" />
     </viewsControls:BaseMasterView.Columns>
+    <viewsControls:BaseMasterView.RowDetailsTemplate>
+        <DataTemplate>
+            <StackPanel Margin="4">
+                <StackPanel Orientation="Horizontal">
+                    <TextBlock Width="80" Text="Kód"/>
+                    <TextBox x:Name="InitialFocus" Text="{Binding Code, Mode=TwoWay}" Width="80"/>
+                </StackPanel>
+                <StackPanel Orientation="Horizontal" Margin="0,4,0,0">
+                    <TextBlock Width="80" Text="Név"/>
+                    <TextBox Text="{Binding Name, Mode=TwoWay}" Width="200"/>
+                </StackPanel>
+            </StackPanel>
+        </DataTemplate>
+    </viewsControls:BaseMasterView.RowDetailsTemplate>
 </viewsControls:BaseMasterView>

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -50,6 +50,10 @@ Felhasználói üzenetekhez az `INotificationService` ad egységes felületet. W
 Az alapvető cégadatokat a `UserInfoService` kezeli. Az adatok a `%AppData%/Wrecept/wrecept.json` fájlban tárolódnak, betöltésük az alkalmazás futása közben történik.
 Az aktuális képernyőmódot a `SettingsService` tartja nyilván `settings.json` fájlban, amit a `ScreenModeManager` olvas be induláskor.
 
+### Törzsadatok szerkesztése
+
+A különböző mesteradat nézeteket kiszolgáló ViewModel-ek mind az `EditableMasterDataViewModel<T>` osztályból öröklődnek. Ez az alaposztály valósítja meg az egységes `EditSelectedCommand`, `DeleteSelectedCommand` és `CloseDetailsCommand` parancsokat, továbbá az `IsEditing` flag-et. A törlés valójában archiválás: a leszármazott ViewModel a `DeleteAsync` metódusban hívja meg a hozzá tartozó Service `UpdateAsync` műveletét, miután az entitást archiváltnak jelölte.
+
 Minden domain modell tartalmaz `CreatedAt` és `UpdatedAt` mezőket. Ezeket a service réteg inicializálja, így naplózható az adat módosításának ideje.
 
  Az alkalmazás indításakor a `DbInitializer` megkísérli a `Database.Migrate()`

--- a/docs/KeyboardFlow.md
+++ b/docs/KeyboardFlow.md
@@ -36,6 +36,7 @@ A Wrecept minden felületén a billentyűzet az elsődleges vezérlő eszköz. A
 - `Enter`: kijelölt sor szerkesztése.
 - `Delete`: kijelölt sor törlése.
 - `Escape`: részletes nézetből vissza a listához.
+Az összes mesteradat ViewModel az `EditableMasterDataViewModel` leszármazottja, így ezek a billentyűk minden listában azonos módon viselkednek.
 
 ## 📦 Modal Prompt Behavior
 

--- a/docs/progress/2025-07-02_13-03-33_code_agent.md
+++ b/docs/progress/2025-07-02_13-03-33_code_agent.md
@@ -1,0 +1,5 @@
+- Introduced EditableMasterDataViewModel with common edit/delete commands.
+- Updated all master ViewModels to derive from it and archive via DeleteAsync.
+- Added RowDetailsTemplate to every MasterView for inline editing.
+- Extended service tests to cover archiving via UpdateAsync.
+- Updated architecture and keyboard docs about unified editing.


### PR DESCRIPTION
## Summary
- introduce `EditableMasterDataViewModel` for common edit/delete flow
- refactor all master view models to use the new base
- add minimal row details editors so keyboard shortcuts work everywhere
- update docs about unified editing
- extend service tests for archiving

## Testing
- `dotnet test --no-build -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68652c545ce48322ac783af279667c53