### PR TITLE
Fix MonospacedFont usage

### DIFF
--- a/Wrecept.Wpf/Views/Controls/TotalsPanel.xaml
+++ b/Wrecept.Wpf/Views/Controls/TotalsPanel.xaml
@@ -14,7 +14,8 @@
             <Setter Property="HorizontalAlignment" Value="Stretch" />
         </Style>
     </UserControl.Resources>
-    <StackPanel FontFamily="{StaticResource MonospacedFont}" FontSize="14">
+    <StackPanel TextElement.FontFamily="{StaticResource MonospacedFont}"
+                TextElement.FontSize="14">
         <ItemsControl ItemsSource="{Binding VatSummaries}" Margin="0,0,0,2">
             <ItemsControl.ItemTemplate>
                 <DataTemplate>

--- a/docs/progress/2025-07-02_16-28-50_ui_agent.md
+++ b/docs/progress/2025-07-02_16-28-50_ui_agent.md
@@ -1,0 +1,2 @@
+- Fixed TotalsPanel.xaml compile error by using TextElement.FontFamily.
+- Installed .NET 8 SDK for build environment (Linux lacks windowsdesktop pack, build skipped).


### PR DESCRIPTION
## Summary
- fix `FontFamily` usage on `StackPanel` in `TotalsPanel`
- record progress

## Testing
- `dotnet restore Wrecept.sln`
- `dotnet build Wrecept.sln --no-restore` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68655bae298c8322b8b35436d9e7c1e6