### PR TITLE
Fix build errors

### DIFF
--- a/Wrecept.Wpf/ViewModels/EditableMasterDataViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/EditableMasterDataViewModel.cs
@@ -20,7 +20,7 @@ public abstract partial class EditableMasterDataViewModel<T> : MasterDataBaseVie
         CloseDetailsCommand = new RelayCommand(() => IsEditing = false);
     }
 
-    partial void OnSelectedItemChanged(T? value)
+    protected override void SelectedItemChanged(T? value)
     {
         (EditSelectedCommand as RelayCommand)?.NotifyCanExecuteChanged();
         (DeleteSelectedCommand as RelayCommand)?.NotifyCanExecuteChanged();

--- a/Wrecept.Wpf/ViewModels/MasterDataBaseViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/MasterDataBaseViewModel.cs
@@ -12,6 +12,11 @@ public abstract partial class MasterDataBaseViewModel<T> : ObservableObject, IMa
     [ObservableProperty]
     private T? selectedItem;
 
+    partial void OnSelectedItemChanged(T? value)
+        => SelectedItemChanged(value);
+
+    protected virtual void SelectedItemChanged(T? value) { }
+
     public virtual async Task LoadAsync()
     {
         var items = await GetItemsAsync();

--- a/Wrecept.Wpf/Views/Controls/TotalsPanel.xaml
+++ b/Wrecept.Wpf/Views/Controls/TotalsPanel.xaml
@@ -3,14 +3,14 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <UserControl.Resources>
         <Style x:Key="ValueCell" TargetType="TextBlock">
-            <Setter Property="FontFamily" Value="{StaticResource MonospacedFont}" />
-            <Setter Property="FontSize" Value="14" />
+            <Setter Property="TextElement.FontFamily" Value="{StaticResource MonospacedFont}" />
+            <Setter Property="TextElement.FontSize" Value="14" />
             <Setter Property="TextAlignment" Value="Right" />
             <Setter Property="HorizontalAlignment" Value="Right" />
         </Style>
         <Style x:Key="LabelCell" TargetType="TextBlock">
-            <Setter Property="FontFamily" Value="{StaticResource MonospacedFont}" />
-            <Setter Property="FontSize" Value="14" />
+            <Setter Property="TextElement.FontFamily" Value="{StaticResource MonospacedFont}" />
+            <Setter Property="TextElement.FontSize" Value="14" />
             <Setter Property="HorizontalAlignment" Value="Stretch" />
         </Style>
     </UserControl.Resources>

--- a/docs/progress/2025-07-02_17-20-17_code_agent.md
+++ b/docs/progress/2025-07-02_17-20-17_code_agent.md
@@ -1,0 +1,3 @@
+- Added virtual SelectedItemChanged hook in MasterDataBaseViewModel.
+- Updated EditableMasterDataViewModel to override SelectedItemChanged and adjust commands.
+- Replaced font setters in TotalsPanel with TextElement attached properties.

--- a/docs/progress/2025-07-02_17-20-17_ui_agent.md
+++ b/docs/progress/2025-07-02_17-20-17_ui_agent.md
@@ -1,0 +1,1 @@
+- Normalized TotalsPanel styles using TextElement.FontFamily and FontSize.


### PR DESCRIPTION
## Summary
- add virtual SelectedItemChanged hook in MasterDataBaseViewModel
- override SelectedItemChanged in EditableMasterDataViewModel to update commands
- normalize TotalsPanel fonts via TextElement attached properties
- log progress for code_agent and ui_agent

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68656942afc48322a0cec92abc00b892