### PR TITLE
Fix ShutdownMode initialization

### DIFF
--- a/Wrecept.Wpf/App.xaml.cs
+++ b/Wrecept.Wpf/App.xaml.cs
@@ -138,9 +138,9 @@ public static IServiceProvider Provider => Services ?? throw new InvalidOperatio
     {
         base.OnStartup(e);
 
-        await EnsureServicesInitializedAsync();
-
         ShutdownMode = ShutdownMode.OnExplicitShutdown;
+
+        await EnsureServicesInitializedAsync();
 
         var orchestrator = Provider.GetRequiredService<StartupOrchestrator>();
         using var cts = new CancellationTokenSource();

--- a/docs/BUILD_RUNTIME_NOTES.md
+++ b/docs/BUILD_RUNTIME_NOTES.md
@@ -31,5 +31,8 @@ Ez a jegyzet a fejlesztés során tapasztalt fordítási és futásidejű probl�
 7. Az `AddStorage` kiterjesztés migrációhoz `IDbContextFactory`-t használ, így a munkakontextus az inicializálás végén eldobásra kerül.
 8. Ha a második adatlekérdezés is `SqliteException`-t dob, a `DataSeeder` a `logs/startup.log` fájlba ír és `Failed` állapotot jelez.
 9. Új modell bevezetésekor, ha valamely tábla hiányzik, a `DataSeeder` ismét migrációt futtat és naplózza a hibát.
+10. A `SetupWindow` bezárása után az alkalmazás alapértelmezett `OnLastWindowClose` módja miatt azonnal leállt,
+    ezért a `ShutdownMode` beállítása a `OnStartup` végén `InvalidOperationException`-t dobott.
+    A megoldás: `OnStartup` elején állítsuk `ShutdownMode = OnExplicitShutdown` értékre.
 
 ---

--- a/docs/progress/2025-07-02_17-44-37_code_agent.md
+++ b/docs/progress/2025-07-02_17-44-37_code_agent.md
@@ -1,0 +1,1 @@
+- Startup ShutdownMode set at the beginning of OnStartup to prevent InvalidOperationException when SetupWindow closes.


### PR DESCRIPTION
## Summary
- ensure ShutdownMode is set before showing SetupWindow
- document the runtime error in BUILD_RUNTIME_NOTES
- log progress on startup fix

## Testing
- `dotnet test` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68656f663df483229bbee590c7c8e022