### PR TITLE
Fix partial method issue

### DIFF
--- a/Wrecept.Wpf/ViewModels/EditableMasterDataViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/EditableMasterDataViewModel.cs
@@ -20,8 +20,9 @@ public abstract partial class EditableMasterDataViewModel<T> : MasterDataBaseVie
         CloseDetailsCommand = new RelayCommand(() => IsEditing = false);
     }
 
-    partial void OnSelectedItemChanged(T? value)
+    protected override void SelectedItemChanged(T? value)
     {
+        base.SelectedItemChanged(value);
         (EditSelectedCommand as RelayCommand)?.NotifyCanExecuteChanged();
         (DeleteSelectedCommand as RelayCommand)?.NotifyCanExecuteChanged();
     }

--- a/docs/progress/2025-07-02_18-43-57_code_agent.md
+++ b/docs/progress/2025-07-02_18-43-57_code_agent.md
@@ -1,0 +1,1 @@
+- Fix Partial method implementation: moved logic to overridable method SelectedItemChanged.


### PR DESCRIPTION
## Summary
- fix SelectedItemChanged partial method implementation

## Testing
- `dotnet build Wrecept.Core/Wrecept.Core.csproj -c Debug`
- `dotnet build Wrecept.Storage/Wrecept.Storage.csproj -c Debug`
- `dotnet build Wrecept.Wpf/Wrecept.Wpf.csproj -c Debug` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*


------
https://chatgpt.com/codex/tasks/task_e_68657c17cffc832298d06d76aa475aa6