### PR TITLE
Implement invoice draft creation

### DIFF
--- a/Wrecept.Wpf/ViewModels/InvoiceLookupViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/InvoiceLookupViewModel.cs
@@ -49,26 +49,19 @@ public partial class InvoiceLookupViewModel : ObservableObject
         }
     }
 
-    public async Task<int> CreateInvoiceAsync(string number)
+    public Task<int> CreateInvoiceAsync(string number)
     {
-        var invoice = new Invoice
+        var item = new InvoiceLookupItem
         {
+            Id = 0,
             Number = number,
-            Date = DateOnly.FromDateTime(DateTime.Today)
+            Date = DateOnly.FromDateTime(DateTime.Today),
+            Supplier = string.Empty
         };
 
-        var id = await _invoices.CreateHeaderAsync(invoice);
-
-        Invoices.Insert(0, new InvoiceLookupItem
-        {
-            Id = id,
-            Number = number,
-            Date = invoice.Date,
-            Supplier = string.Empty
-        });
-
-        SelectedInvoice = Invoices.FirstOrDefault(i => i.Id == id);
-        return id;
+        Invoices.Insert(0, item);
+        SelectedInvoice = item;
+        return Task.FromResult(0);
     }
 
 }

--- a/docs/BUSINESS_LOGIC.md
+++ b/docs/BUSINESS_LOGIC.md
@@ -25,6 +25,9 @@ Ez a dokumentum definiálja a **Wrecept** rendszer üzleti logikáját. A rendsz
    * fizetési módot (`PaymentMethod`), amelyhez `DueInDays` is tartozik,
    * beérkezés dátuma alapján **automatikusan számítható a fizetési határidő**.
 
+   A fejlécadatok először csak memóriában kerülnek tárolásra. Az adatbázisba írás
+   a teljes számla mentésekor történik, így elkerülhetők a félbehagyott rekordok.
+
 2. A felhasználó tetszőleges számú tételt rögzít:
 
    * termék kiválasztása,

--- a/docs/progress/2025-07-02_19-44-27_code_agent.md
+++ b/docs/progress/2025-07-02_19-44-27_code_agent.md
@@ -1,0 +1,3 @@
+- Invoice header now stored in memory until final save; AddLineItemAsync inserts into draft when IsNew.
+- Lookup new invoice creation no longer hits DB, returns temp item.
+- Updated tests and BUSINESS_LOGIC docs accordingly.

--- a/tests/viewmodels/InvoiceEditorViewModelTests.cs
+++ b/tests/viewmodels/InvoiceEditorViewModelTests.cs
@@ -119,7 +119,7 @@ public class InvoiceEditorViewModelTests
 
         await prompt.ConfirmAsyncCommand.ExecuteAsync(null);
 
-        Assert.Single(invoiceSvc.Invoices);
+        Assert.Empty(invoiceSvc.Invoices);
         Assert.Null(lookup.InlinePrompt);
     }
 
@@ -198,7 +198,7 @@ public class InvoiceEditorViewModelTests
 
         await creator.ConfirmAsync();
 
-        Assert.Single(invoiceSvc.Items);
+        Assert.Empty(invoiceSvc.Items);
         Assert.Null(vm.InlineCreator);
     }
 


### PR DESCRIPTION
## Summary
- keep new invoice header in memory until final save
- avoid DB calls when creating invoice from lookup
- adjust invoice item addition to support draft
- update Hungarian business logic docs about draft behavior
- update tests

## Testing
- `dotnet test --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets missing)*

------
https://chatgpt.com/codex/tasks/task_e_6865889a78208322836f145b90033d73