### PR TITLE
Fix InvoiceLookupView ItemTemplate conflict

### DIFF
--- a/Wrecept.Wpf/Views/InvoiceLookupView.xaml
+++ b/Wrecept.Wpf/Views/InvoiceLookupView.xaml
@@ -18,7 +18,6 @@
                   ItemsSource="{Binding Invoices}"
                   SelectedItem="{Binding SelectedInvoice}"
                   IsEditable="True" IsTextSearchEnabled="True"
-                  DisplayMemberPath="Number"
                   Margin="4">
             <ComboBox.ItemTemplate>
                 <DataTemplate>

--- a/docs/progress/2025-07-02_21-57-24_ui_agent.md
+++ b/docs/progress/2025-07-02_21-57-24_ui_agent.md
@@ -1,0 +1,1 @@
+- Removed DisplayMemberPath from InvoiceLookupView ComboBox to avoid XAML parse error when ItemTemplate is set.


### PR DESCRIPTION
## Summary
- remove `DisplayMemberPath` when ComboBox uses an `ItemTemplate`
- log fix in progress notes

## Testing
- `dotnet` command not found in container

------
https://chatgpt.com/codex/tasks/task_e_6865aa9b6f7c832299acba877cab8ea2