### PR TITLE
Restore invoice list layout

### DIFF
--- a/Wrecept.Wpf/Views/InvoiceLookupView.xaml
+++ b/Wrecept.Wpf/Views/InvoiceLookupView.xaml
@@ -14,12 +14,11 @@
             <RowDefinition Height="*" />
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
-        <ComboBox x:Name="InvoiceList"
-                  ItemsSource="{Binding Invoices}"
-                  SelectedItem="{Binding SelectedInvoice}"
-                  IsEditable="True" IsTextSearchEnabled="True"
-                  Margin="4">
-            <ComboBox.ItemTemplate>
+        <ListBox x:Name="InvoiceList"
+                 ItemsSource="{Binding Invoices}"
+                 SelectedItem="{Binding SelectedInvoice}"
+                 Margin="4">
+            <ListBox.ItemTemplate>
                 <DataTemplate>
                     <StackPanel Orientation="Horizontal">
                         <TextBlock Text="{Binding Number}" Width="80"/>
@@ -27,8 +26,8 @@
                         <TextBlock Text="{Binding Supplier}" />
                     </StackPanel>
                 </DataTemplate>
-            </ComboBox.ItemTemplate>
-        </ComboBox>
+            </ListBox.ItemTemplate>
+        </ListBox>
         <ContentControl Content="{Binding InlinePrompt}" Margin="4" Grid.Row="1" />
     </Grid>
 </UserControl>

--- a/docs/progress/2025-07-02_22-03-05_ui_agent.md
+++ b/docs/progress/2025-07-02_22-03-05_ui_agent.md
@@ -1,0 +1,1 @@
+- Reverted InvoiceLookupView ComboBox to ListBox for stable navigation.


### PR DESCRIPTION
## Summary
- revert InvoiceLookupView ComboBox back to ListBox for stability
- log UI fix

## Testing
- `dotnet test tests/Wrecept.Tests/Wrecept.Tests.csproj` *(fails: Project Wrecept.Wpf is not compatible with net8.0)*

------
https://chatgpt.com/codex/tasks/task_e_6865ac1a5a7c8322b494b037bac3e713