### PR TITLE
Implement SmartLookup control

### DIFF
--- a/Wrecept.Wpf/Views/Controls/SmartLookup.xaml
+++ b/Wrecept.Wpf/Views/Controls/SmartLookup.xaml
@@ -1,0 +1,36 @@
+<UserControl x:Class="Wrecept.Wpf.Views.Controls.SmartLookup"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:local="clr-namespace:Wrecept.Wpf.Converters">
+    <UserControl.Resources>
+        <local:StringNullOrEmptyToVisibilityConverter x:Key="EmptyToVisibility" />
+    </UserControl.Resources>
+    <Grid>
+        <Grid>
+            <TextBox x:Name="PART_TextBox"
+                     Text="{Binding Text, RelativeSource={RelativeSource AncestorType=UserControl}, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+            <TextBlock Text="{Binding Watermark, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                       Foreground="Gray"
+                       Margin="4,2,0,0"
+                       IsHitTestVisible="False"
+                       Visibility="{Binding Text, RelativeSource={RelativeSource AncestorType=UserControl}, Converter={StaticResource EmptyToVisibility}}" />
+        </Grid>
+        <Popup x:Name="PART_Popup"
+               Placement="Bottom"
+               PlacementTarget="{Binding ElementName=PART_TextBox}"
+               StaysOpen="False"
+               AllowsTransparency="True">
+            <Border Background="{DynamicResource ControlBackgroundBrush}" BorderBrush="{DynamicResource HighlightBrush}" BorderThickness="1">
+                <StackPanel>
+                    <ListBox x:Name="PART_ListBox"
+                             ItemsSource="{Binding FilteredItems, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                             DisplayMemberPath="{Binding DisplayMemberPath, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                             SelectedValuePath="{Binding SelectedValuePath, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                             SelectedValue="{Binding SelectedValue, RelativeSource={RelativeSource AncestorType=UserControl}, Mode=TwoWay}"
+                             MaxHeight="200" />
+                    <TextBlock x:Name="PART_CreatePrompt" Foreground="Gray" Padding="4,2" IsHitTestVisible="False" />
+                </StackPanel>
+            </Border>
+        </Popup>
+    </Grid>
+</UserControl>

--- a/Wrecept.Wpf/Views/Controls/SmartLookup.xaml.cs
+++ b/Wrecept.Wpf/Views/Controls/SmartLookup.xaml.cs
@@ -1,0 +1,226 @@
+using System;
+using System.Collections;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using System.Windows.Input;
+
+namespace Wrecept.Wpf.Views.Controls;
+
+public partial class SmartLookup : UserControl
+{
+    public static readonly DependencyProperty ItemsSourceProperty = DependencyProperty.Register(
+        nameof(ItemsSource), typeof(IEnumerable), typeof(SmartLookup));
+
+    public static readonly DependencyProperty SelectedValueProperty = DependencyProperty.Register(
+        nameof(SelectedValue), typeof(object), typeof(SmartLookup),
+        new FrameworkPropertyMetadata(null, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault));
+
+    public static readonly DependencyProperty SelectedValuePathProperty = DependencyProperty.Register(
+        nameof(SelectedValuePath), typeof(string), typeof(SmartLookup));
+
+    public static readonly DependencyProperty DisplayMemberPathProperty = DependencyProperty.Register(
+        nameof(DisplayMemberPath), typeof(string), typeof(SmartLookup));
+
+    public static readonly DependencyProperty TextProperty = DependencyProperty.Register(
+        nameof(Text), typeof(string), typeof(SmartLookup),
+        new FrameworkPropertyMetadata(string.Empty, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, OnTextChanged));
+
+    public static readonly DependencyProperty WatermarkProperty = DependencyProperty.Register(
+        nameof(Watermark), typeof(string), typeof(SmartLookup));
+
+    public static readonly DependencyProperty CreateCommandProperty = DependencyProperty.Register(
+        nameof(CreateCommand), typeof(ICommand), typeof(SmartLookup));
+
+    public static readonly DependencyProperty MaxSuggestionsProperty = DependencyProperty.Register(
+        nameof(MaxSuggestions), typeof(int), typeof(SmartLookup), new PropertyMetadata(10));
+
+    public IEnumerable? ItemsSource
+    {
+        get => (IEnumerable?)GetValue(ItemsSourceProperty);
+        set => SetValue(ItemsSourceProperty, value);
+    }
+
+    public object? SelectedValue
+    {
+        get => GetValue(SelectedValueProperty);
+        set => SetValue(SelectedValueProperty, value);
+    }
+
+    public string? SelectedValuePath
+    {
+        get => (string?)GetValue(SelectedValuePathProperty);
+        set => SetValue(SelectedValuePathProperty, value);
+    }
+
+    public string? DisplayMemberPath
+    {
+        get => (string?)GetValue(DisplayMemberPathProperty);
+        set => SetValue(DisplayMemberPathProperty, value);
+    }
+
+    public string Text
+    {
+        get => (string)GetValue(TextProperty);
+        set => SetValue(TextProperty, value);
+    }
+
+    public string? Watermark
+    {
+        get => (string?)GetValue(WatermarkProperty);
+        set => SetValue(WatermarkProperty, value);
+    }
+
+    public ICommand? CreateCommand
+    {
+        get => (ICommand?)GetValue(CreateCommandProperty);
+        set => SetValue(CreateCommandProperty, value);
+    }
+
+    public int MaxSuggestions
+    {
+        get => (int)GetValue(MaxSuggestionsProperty);
+        set => SetValue(MaxSuggestionsProperty, value);
+    }
+
+    private CancellationTokenSource? _cts;
+    public ObservableCollection<object> FilteredItems { get; } = new();
+
+    public SmartLookup()
+    {
+        InitializeComponent();
+        Loaded += OnLoaded;
+        Unloaded += OnUnloaded;
+    }
+
+    private void OnLoaded(object sender, RoutedEventArgs e)
+    {
+        if (PART_TextBox != null)
+        {
+            PART_TextBox.GotFocus += TextBox_GotFocus;
+            PART_TextBox.PreviewKeyDown += TextBox_PreviewKeyDown;
+        }
+    }
+
+    private void OnUnloaded(object sender, RoutedEventArgs e)
+    {
+        if (PART_TextBox != null)
+        {
+            PART_TextBox.GotFocus -= TextBox_GotFocus;
+            PART_TextBox.PreviewKeyDown -= TextBox_PreviewKeyDown;
+        }
+    }
+
+    private static void OnTextChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is SmartLookup lookup)
+            _ = lookup.FilterAsync();
+    }
+
+    private void TextBox_GotFocus(object sender, RoutedEventArgs e)
+        => _ = FilterAsync();
+
+    private async Task FilterAsync()
+    {
+        var text = Text ?? string.Empty;
+        _cts?.Cancel();
+        _cts = new CancellationTokenSource();
+        var token = _cts.Token;
+        var source = ItemsSource?.Cast<object>() ?? Enumerable.Empty<object>();
+        var display = DisplayMemberPath;
+        var max = MaxSuggestions;
+
+        var results = await Task.Run(() =>
+        {
+            return source.Where(item => Match(item, text, display))
+                         .Take(max)
+                         .ToList();
+        }, token);
+
+        if (token.IsCancellationRequested) return;
+
+        FilteredItems.Clear();
+        foreach (var item in results)
+            FilteredItems.Add(item);
+
+        if (FilteredItems.Count == 0 && !string.IsNullOrWhiteSpace(text))
+        {
+            PART_CreatePrompt.Text = $"➕ Új létrehozása: '{text}'";
+            PART_CreatePrompt.Visibility = Visibility.Visible;
+        }
+        else
+        {
+            PART_CreatePrompt.Text = string.Empty;
+            PART_CreatePrompt.Visibility = Visibility.Collapsed;
+        }
+
+        PART_ListBox.SelectedIndex = FilteredItems.Count > 0 ? 0 : -1;
+        PART_Popup.IsOpen = FilteredItems.Count > 0 || PART_CreatePrompt.Visibility == Visibility.Visible;
+    }
+
+    private static bool Match(object item, string text, string? display)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+            return true;
+        var value = GetProperty(item, display)?.ToString();
+        return value?.IndexOf(text, StringComparison.OrdinalIgnoreCase) >= 0;
+    }
+
+    private static object? GetProperty(object item, string? path)
+    {
+        if (path is null)
+            return item;
+        var prop = item.GetType().GetProperty(path);
+        return prop?.GetValue(item);
+    }
+
+    private void TextBox_PreviewKeyDown(object sender, KeyEventArgs e)
+    {
+        if (e.Key == Key.Down)
+        {
+            if (FilteredItems.Count > 0)
+            {
+                var index = PART_ListBox.SelectedIndex + 1;
+                if (index >= FilteredItems.Count) index = 0;
+                PART_ListBox.SelectedIndex = index;
+            }
+            e.Handled = true;
+        }
+        else if (e.Key == Key.Up)
+        {
+            if (FilteredItems.Count > 0)
+            {
+                var index = PART_ListBox.SelectedIndex - 1;
+                if (index < 0) index = FilteredItems.Count - 1;
+                PART_ListBox.SelectedIndex = index;
+            }
+            e.Handled = true;
+        }
+        else if (e.Key == Key.Enter)
+        {
+            if (PART_ListBox.SelectedItem != null)
+            {
+                SelectedValue = GetProperty(PART_ListBox.SelectedItem, SelectedValuePath);
+                Text = GetProperty(PART_ListBox.SelectedItem, DisplayMemberPath)?.ToString() ?? string.Empty;
+                PART_Popup.IsOpen = false;
+                MoveFocus(new TraversalRequest(FocusNavigationDirection.Next));
+            }
+            else if (FilteredItems.Count == 0 && !string.IsNullOrWhiteSpace(Text))
+            {
+                if (CreateCommand?.CanExecute(Text) == true)
+                    CreateCommand.Execute(Text);
+                PART_Popup.IsOpen = false;
+            }
+            e.Handled = true;
+        }
+        else if (e.Key == Key.Escape)
+        {
+            PART_Popup.IsOpen = false;
+            e.Handled = true;
+        }
+    }
+}

--- a/Wrecept.Wpf/Views/InvoiceEditorView.xaml
+++ b/Wrecept.Wpf/Views/InvoiceEditorView.xaml
@@ -83,13 +83,14 @@
                             </Grid.ColumnDefinitions>
 
                             <TextBlock Grid.Row="0" Grid.Column="0" Text="Szállító" Style="{StaticResource HeaderText}" />
-                            <c:EditLookup Grid.Row="0" Grid.Column="1" Width="220"
-                                          ItemsSource="{Binding Suppliers}"
-                                          DisplayMemberPath="Name"
-                                          SelectedValuePath="Id"
-                                          SelectedValue="{Binding SupplierId}"
-                                          CreateCommand="{Binding ShowSupplierCreatorCommand}"
-                                          IsEnabled="{Binding IsEditable}" />
+                            <c:SmartLookup Grid.Row="0" Grid.Column="1" Width="220"
+                                           ItemsSource="{Binding Suppliers}"
+                                           DisplayMemberPath="Name"
+                                           SelectedValuePath="Id"
+                                           SelectedValue="{Binding SupplierId}"
+                                           CreateCommand="{Binding ShowSupplierCreatorCommand}"
+                                           Watermark="Kezdjen el gépelni..."
+                                           IsEnabled="{Binding IsEditable}" />
 
                             <TextBlock Grid.Row="1" Grid.Column="0" Text="Fizetési mód" Margin="0,4,0,0" Style="{StaticResource HeaderText}" />
                             <c:EditLookup Grid.Row="1" Grid.Column="1" Width="220" Margin="0,4,0,0"
@@ -135,17 +136,19 @@
             <StackPanel Orientation="Horizontal" DataContext="{Binding Items[0]}" KeyDown="OnEntryKeyDown"
                         Background="{DynamicResource ControlBackgroundBrush}" Margin="0,0,0,4" Grid.Row="1"
                         IsEnabled="{Binding DataContext.IsEditable, RelativeSource={RelativeSource AncestorType=UserControl}}">
-                <c:EditLookup x:Name="EntryProduct" Width="200"
-                              ItemsSource="{Binding DataContext.Products, RelativeSource={RelativeSource AncestorType=UserControl}}"
-                              DisplayMemberPath="Name"
-                              SelectedValuePath="Name"
-                              SelectedValue="{Binding Product, Mode=TwoWay}"/>
+                <c:SmartLookup x:Name="EntryProduct" Width="200"
+                               ItemsSource="{Binding DataContext.Products, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                               DisplayMemberPath="Name"
+                               SelectedValuePath="Name"
+                               SelectedValue="{Binding Product, Mode=TwoWay}"
+                               Watermark="Termék neve" />
                 <TextBox x:Name="EntryQuantity" Width="60" Margin="4,0" Text="{Binding Quantity, Mode=TwoWay}"/>
-                <c:EditLookup x:Name="EntryUnit" Width="80"
-                              ItemsSource="{Binding DataContext.Units, RelativeSource={RelativeSource AncestorType=UserControl}}"
-                              DisplayMemberPath="Name"
-                              SelectedValuePath="Id"
-                              SelectedValue="{Binding UnitId, Mode=TwoWay}"/>
+                <c:SmartLookup x:Name="EntryUnit" Width="80"
+                               ItemsSource="{Binding DataContext.Units, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                               DisplayMemberPath="Name"
+                               SelectedValuePath="Id"
+                               SelectedValue="{Binding UnitId, Mode=TwoWay}"
+                               Watermark="Me.e." />
                 <TextBox x:Name="EntryPrice" Width="80" Margin="4,0" Text="{Binding UnitPrice, Mode=TwoWay}"/>
                 <c:EditLookup x:Name="EntryTax" Width="100"
                               ItemsSource="{Binding DataContext.TaxRates, RelativeSource={RelativeSource AncestorType=UserControl}}"

--- a/docs/FEATURE_PLAN.md
+++ b/docs/FEATURE_PLAN.md
@@ -78,7 +78,7 @@ Allow keyboard-only product/supplier lookup and inline creation.
 
 | Step | Agent            | Task Description                              | Blocking Dependency |
 | ---- | ---------------- | --------------------------------------------- | ------------------- |
-| 1    | `ui_agent`       | Implement `EditLookup` UI pattern             | -                   |
+| 1    | `ui_agent`       | Implement `SmartLookup` UI pattern            | -                   |
 | 2    | `logic_agent`    | Handle navigation, trigger Add dialog         | ui\_agent           |
 | 3    | `core_agent`     | Ensure services support async create & reload | logic\_agent        |
 | 4    | `code_agent`     | ViewModel binding and error handling          | core\_agent         |

--- a/docs/UI_FLOW.md
+++ b/docs/UI_FLOW.md
@@ -32,11 +32,11 @@ Confirmation prompt: Create invoice XXXXX1231? (Enter=Yes, Esc=No)
 
 After invoice number confirmed:
 
-Supplier selection (EditLookup)
+Supplier selection (SmartLookup)
 
 Date selection (default = today, arrow or numpad)
 
-Payment method (EditLookup)
+Payment method (SmartLookup)
 
 Bruttó checkbox (affects unit price interpretation)
 
@@ -44,7 +44,7 @@ Bruttó checkbox (affects unit price interpretation)
 
 Focus shifts to the first line’s Product Name
 
-EditLookup behavior with real-time filtering and keyboard navigation
+SmartLookup behavior with real-time filtering and keyboard navigation
 
 If product not found → inline product creator in-row (no modal popup)
 
@@ -70,9 +70,9 @@ Display read-only controls
 
 Archive button visible while invoice not archived. Confirmation text: "Véglegesíti a számlát, később nem módosítható."
 
-📊 EditLookup UX-behavior
+📊 SmartLookup UX-behavior
 
-All master-data fields (e.g., Supplier, Product, TaxRate, Unit) use a unified EditLookup component:
+All master-data fields (e.g., Supplier, Product, TaxRate, Unit) use a unified SmartLookup component:
 
 Typing filters the list in real time.
 
@@ -91,7 +91,7 @@ Example:
 → ↓ selects "Trappista"
 → Enter → field set to ProductId = 23, focus → Quantity
 
-The EditLookup behavior ensures consistent UX and keyboard flow across invoice fields.
+The SmartLookup behavior ensures consistent UX and keyboard flow across invoice fields.
 
 📀 Screen Mockups
 
@@ -109,10 +109,10 @@ The EditLookup behavior ensures consistent UX and keyboard flow across invoice f
 🧾 Invoice Editor View
 
 ┌───── Lista ────┬──────── Számla szerkesztő ────────────────┐
-│ [Számlaszám]   │ Szállító: [EditLookup   ]                │
+│ [Számlaszám]   │ Szállító: [SmartLookup   ]               │
 │ [Dátum]        │ Dátum:    [2025-06-30  ]                │
 │ [Szállító]     │ Szám:     [XXXXX1231   ]                │
-│                │ Fiz. mód: [EditLookup   ]   [ ] Bruttó  │
+│                │ Fiz. mód: [SmartLookup   ]   [ ] Bruttó │
 │                ├──────────────────────────────────────────┤
 │                │ Termék  Menny. Csop. Me.e. Ár  ÁFA       │
 │                │ [Edit] [  1] ...                         │

--- a/docs/progress/2025-07-02_22-51-06_ui_agent.md
+++ b/docs/progress/2025-07-02_22-51-06_ui_agent.md
@@ -1,0 +1,3 @@
+- SmartLookup UserControl added for inline lookup with create option.
+- Replaced EditLookup in InvoiceEditorView for Supplier, Product and Unit fields.
+- Updated UI_FLOW.md and FEATURE_PLAN.md to reference SmartLookup.


### PR DESCRIPTION
## Summary
- create SmartLookup UserControl for better lookup UX
- replace EditLookup with SmartLookup in InvoiceEditorView
- update feature plan and UI flow documentation
- log progress

## Testing
- `dotnet test --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865aeb205888322addeb40c1f79e071