### PR TITLE
Unified StackPanel item editing

### DIFF
--- a/Wrecept.Wpf/ViewModels/DeleteItemPromptViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/DeleteItemPromptViewModel.cs
@@ -1,0 +1,31 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+
+namespace Wrecept.Wpf.ViewModels;
+
+public partial class DeleteItemPromptViewModel : ObservableObject
+{
+    private readonly InvoiceEditorViewModel _parent;
+    private readonly InvoiceItemRowViewModel _row;
+
+    public DeleteItemPromptViewModel(InvoiceEditorViewModel parent, InvoiceItemRowViewModel row)
+    {
+        _parent = parent;
+        _row = row;
+    }
+
+    public string Message => "Biztosan törlöd ezt a tételt? (Enter=Igen, Esc=Nem)";
+
+    [RelayCommand]
+    private void Confirm()
+    {
+        _parent.DeleteItemConfirmed(_row);
+        _parent.DeletePrompt = null;
+    }
+
+    [RelayCommand]
+    private void Cancel()
+    {
+        _parent.DeletePrompt = null;
+    }
+}

--- a/Wrecept.Wpf/ViewModels/EditableItemViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/EditableItemViewModel.cs
@@ -1,0 +1,37 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace Wrecept.Wpf.ViewModels;
+
+public partial class EditableItemViewModel : InvoiceItemRowViewModel
+{
+    public bool IsEditingExisting { get; internal set; }
+    public InvoiceItemRowViewModel? TargetRow { get; internal set; }
+
+    public EditableItemViewModel(InvoiceEditorViewModel parent) : base(parent)
+    {
+    }
+}
+
+public class NewLineItemViewModel : EditableItemViewModel
+{
+    public NewLineItemViewModel(InvoiceEditorViewModel parent) : base(parent)
+    {
+    }
+}
+
+public class ExistingLineItemEditViewModel : EditableItemViewModel
+{
+    public ExistingLineItemEditViewModel(InvoiceEditorViewModel parent, InvoiceItemRowViewModel target) : base(parent)
+    {
+        IsEditingExisting = true;
+        TargetRow = target;
+        Product = target.Product;
+        Quantity = target.Quantity;
+        UnitPrice = target.UnitPrice;
+        TaxRateId = target.TaxRateId;
+        UnitId = target.UnitId;
+        UnitName = target.UnitName;
+        TaxRateName = target.TaxRateName;
+        ProductGroup = target.ProductGroup;
+    }
+}

--- a/Wrecept.Wpf/Views/InlinePrompts/DeleteItemPromptView.xaml
+++ b/Wrecept.Wpf/Views/InlinePrompts/DeleteItemPromptView.xaml
@@ -1,0 +1,10 @@
+<UserControl x:Class="Wrecept.Wpf.Views.InlinePrompts.DeleteItemPromptView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:view="clr-namespace:Wrecept.Wpf.Views"
+             KeyDown="OnKeyDown"
+             IsEnabled="{Binding DataContext.IsEditable, RelativeSource={RelativeSource AncestorType=view:InvoiceEditorView}}">
+    <Border Background="#F5F5DC" Padding="4" Margin="0,4,0,0">
+        <TextBlock Text="{Binding Message}" />
+    </Border>
+</UserControl>

--- a/Wrecept.Wpf/Views/InlinePrompts/DeleteItemPromptView.xaml.cs
+++ b/Wrecept.Wpf/Views/InlinePrompts/DeleteItemPromptView.xaml.cs
@@ -1,0 +1,28 @@
+using System.Windows.Controls;
+using System.Windows.Input;
+
+namespace Wrecept.Wpf.Views.InlinePrompts;
+
+public partial class DeleteItemPromptView : UserControl
+{
+    public DeleteItemPromptView()
+    {
+        InitializeComponent();
+    }
+
+    private void OnKeyDown(object sender, KeyEventArgs e)
+    {
+        if (DataContext is not Wrecept.Wpf.ViewModels.DeleteItemPromptViewModel vm)
+            return;
+        if (e.Key == Key.Enter)
+        {
+            vm.ConfirmCommand.Execute(null);
+            e.Handled = true;
+        }
+        else if (e.Key == Key.Escape)
+        {
+            vm.CancelCommand.Execute(null);
+            e.Handled = true;
+        }
+    }
+}

--- a/Wrecept.Wpf/Views/InvoiceEditorView.xaml
+++ b/Wrecept.Wpf/Views/InvoiceEditorView.xaml
@@ -33,6 +33,9 @@
         <DataTemplate DataType="{x:Type vm:ArchivePromptViewModel}">
             <prompt:ArchivePromptView/>
         </DataTemplate>
+        <DataTemplate DataType="{x:Type vm:DeleteItemPromptViewModel}">
+            <prompt:DeleteItemPromptView/>
+        </DataTemplate>
         <Style x:Key="GoldFocusVisual" TargetType="Control">
             <Setter Property="Template">
                 <Setter.Value>
@@ -133,9 +136,18 @@
                 </GroupBox>
             </Grid>
 
-            <StackPanel Orientation="Horizontal" DataContext="{Binding Items[0]}" KeyDown="OnEntryKeyDown"
-                        Background="{DynamicResource ControlBackgroundBrush}" Margin="0,0,0,4" Grid.Row="1"
+            <StackPanel Orientation="Horizontal" DataContext="{Binding EditableItem}" KeyDown="OnEntryKeyDown" Margin="0,0,0,4" Grid.Row="1"
                         IsEnabled="{Binding DataContext.IsEditable, RelativeSource={RelativeSource AncestorType=UserControl}}">
+                <StackPanel.Style>
+                    <Style TargetType="StackPanel">
+                        <Setter Property="Background" Value="{DynamicResource ControlBackgroundBrush}" />
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding IsEditingExisting}" Value="True">
+                                <Setter Property="Background" Value="LightYellow" />
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </StackPanel.Style>
                 <c:SmartLookup x:Name="EntryProduct" Width="200"
                                ItemsSource="{Binding DataContext.Products, RelativeSource={RelativeSource AncestorType=UserControl}}"
                                DisplayMemberPath="Name"
@@ -183,6 +195,7 @@
 
             <ContentControl Content="{Binding SavePrompt}" Visibility="{Binding IsSavePromptVisible, Converter={StaticResource BooleanToVisibilityConverter}}" Grid.Row="5" />
             <ContentControl Content="{Binding ArchivePrompt}" Visibility="{Binding IsArchivePromptVisible, Converter={StaticResource BooleanToVisibilityConverter}}" Grid.Row="5" Margin="0,4,0,0" />
+            <ContentControl Content="{Binding DeletePrompt}" Visibility="{Binding IsDeletePromptVisible, Converter={StaticResource BooleanToVisibilityConverter}}" Grid.Row="5" Margin="0,8,0,0" />
         </Grid>
     </Grid>
 </UserControl>

--- a/Wrecept.Wpf/Views/InvoiceEditorView.xaml.cs
+++ b/Wrecept.Wpf/Views/InvoiceEditorView.xaml.cs
@@ -58,12 +58,15 @@ public partial class InvoiceEditorView : UserControl
 
         if (e.Key == Key.Enter && fe?.Name == "EntryTax")
         {
-            await vm.AddLineItemCommand.ExecuteAsync(null);
+            if (vm.EditableItem.IsEditingExisting)
+                vm.SaveEditedItemCommand.Execute(null);
+            else
+                await vm.AddLineItemCommand.ExecuteAsync(null);
             e.Handled = true;
             return;
         }
 
-        if (e.Key == Key.Escape && vm.Items.Count > 1 && !vm.IsInLineFinalizationPrompt)
+        if (e.Key == Key.Escape && string.IsNullOrWhiteSpace(vm.EditableItem.Product) && !vm.IsInLineFinalizationPrompt)
         {
             vm.SavePrompt = new SaveLinePromptViewModel(vm,
                 "Befejezted a tételsorok rögzítését? (Enter=Igen, Esc=Nem)",

--- a/Wrecept.Wpf/Views/InvoiceItemsGrid.xaml
+++ b/Wrecept.Wpf/Views/InvoiceItemsGrid.xaml
@@ -10,11 +10,6 @@
 
         <Style x:Key="EditableCellStyle" TargetType="DataGridCell">
             <Setter Property="IsHitTestVisible" Value="False" />
-            <Style.Triggers>
-                <DataTrigger Binding="{Binding IsFirstRow}" Value="True">
-                    <Setter Property="IsHitTestVisible" Value="True" />
-                </DataTrigger>
-            </Style.Triggers>
         </Style>
 
         <DataTemplate x:Key="ProductDisplayTemplate">
@@ -67,7 +62,7 @@
         <local:InvoiceLineTotalsConverter x:Key="GrossConverter" Mode="Gross" />
     </UserControl.Resources>
     <DataGrid x:Name="Grid" ItemsSource="{Binding Items}" AutoGenerateColumns="False"
-             IsReadOnly="{Binding IsArchived}"
+             IsReadOnly="True"
              IsEnabled="{Binding IsEditable}"
              KeyDown="OnKeyDown" RowDetailsVisibilityMode="Collapsed"
              VerticalAlignment="Stretch">

--- a/Wrecept.Wpf/Views/InvoiceItemsGrid.xaml.cs
+++ b/Wrecept.Wpf/Views/InvoiceItemsGrid.xaml.cs
@@ -17,10 +17,22 @@ public partial class InvoiceItemsGrid : UserControl
             return;
         if (!vm.IsEditable)
             return;
-        if (e.Key == Key.Enter && Grid.SelectedItem is InvoiceItemRowViewModel row)
+        if (Grid.SelectedItem is InvoiceItemRowViewModel row)
         {
-            vm.EditLineFromSelection(row);
-            e.Handled = true;
+            if (e.Key == Key.Enter)
+            {
+                vm.EditLineFromSelection(row);
+                e.Handled = true;
+            }
+            else if (e.Key == Key.Delete)
+            {
+                vm.RequestDeleteItem(row);
+                e.Handled = true;
+            }
+            else
+            {
+                NavigationHelper.Handle(e);
+            }
         }
         else
         {

--- a/docs/progress/2025-07-02_23-23-58_code_agent.md
+++ b/docs/progress/2025-07-02_23-23-58_code_agent.md
@@ -1,0 +1,5 @@
+- StackPanel item entry now binds to new EditableItemViewModel with edit mode flag.
+- Added SaveEditedItemCommand and Delete item workflow with confirmation prompt.
+- InvoiceItemsGrid made read-only; Enter edits selected row, Delete triggers prompt.
+- Updated InvoiceEditorView XAML and code-behind for unified stackpanel handling.
+- New DeleteItemPromptView and ViewModel added.


### PR DESCRIPTION
## Summary
- centralize invoice item editing in stackpanel
- add EditableItemViewModel with edit mode switch
- implement SaveEditedItem and Delete item confirmation
- make InvoiceItemsGrid read-only
- document changes

## Testing
- `dotnet build --no-restore` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*
- `dotnet test --no-build` *(fails: WindowsDesktop targets missing)*

------
https://chatgpt.com/codex/tasks/task_e_6865bd8f32b883229d9c171f2dcba17c