### PR TITLE
Fix item deletion logic and style warning

### DIFF
--- a/Wrecept.Wpf/ViewModels/InvoiceEditorViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/InvoiceEditorViewModel.cs
@@ -658,7 +658,10 @@ private void UpdateSupplierId(string name)
             return;
         Items.RemoveAt(index);
         if (IsNew && index - 1 >= 0 && index - 1 < _draft.Items.Count)
-            _draft.Items.RemoveAt(index - 1);
+        {
+            var domainItem = _draft.Items.ElementAt(index - 1);
+            _draft.Items.Remove(domainItem);
+        }
         RecalculateTotals();
     }
 

--- a/Wrecept.Wpf/Views/Controls/TotalsPanel.xaml
+++ b/Wrecept.Wpf/Views/Controls/TotalsPanel.xaml
@@ -3,13 +3,13 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <UserControl.Resources>
         <Style x:Key="ValueCell" TargetType="TextBlock">
-            <Setter Property="FontFamily" Value="{StaticResource MonospacedFont}" />
+            <Setter Property="TextElement.FontFamily" Value="{StaticResource MonospacedFont}" />
             <Setter Property="TextElement.FontSize" Value="14" />
             <Setter Property="TextAlignment" Value="Right" />
             <Setter Property="HorizontalAlignment" Value="Right" />
         </Style>
         <Style x:Key="LabelCell" TargetType="TextBlock">
-            <Setter Property="FontFamily" Value="{StaticResource MonospacedFont}" />
+            <Setter Property="TextElement.FontFamily" Value="{StaticResource MonospacedFont}" />
             <Setter Property="TextElement.FontSize" Value="14" />
             <Setter Property="HorizontalAlignment" Value="Stretch" />
         </Style>

--- a/docs/progress/2025-07-02_23-34-58_code_agent.md
+++ b/docs/progress/2025-07-02_23-34-58_code_agent.md
@@ -1,0 +1,2 @@
+- Fixed DeleteItemConfirmed to remove domain item via ICollection.Remove.
+- Updated TotalsPanel style to use TextElement.FontFamily to resolve build-time XAML error.


### PR DESCRIPTION
## Summary
- adjust TotalsPanel styles to use `TextElement.FontFamily`
- delete invoice items by object instead of RemoveAt
- log agent progress

## Testing
- `dotnet restore Wrecept.sln`
- `dotnet test tests/Wrecept.UiTests/Wrecept.UiTests.csproj -c Debug` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865c156d36c8322a495117b9f130bc7