### PR TITLE
Fix InvoiceEditorViewModel startup NRE

### DIFF
--- a/Wrecept.Wpf/ViewModels/InvoiceEditorViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/InvoiceEditorViewModel.cs
@@ -242,8 +242,9 @@ partial void OnSupplierChanged(string value) => UpdateSupplierId(value);
             if (Lookup.InlinePrompt is null)
                 await LoadInvoice(item.Id, item.Number);
         };
+        Items = new ObservableCollection<InvoiceItemRowViewModel>();
         EditableItem = new NewLineItemViewModel(this) { IsFirstRow = true };
-        Items = new ObservableCollection<InvoiceItemRowViewModel>(new[] { EditableItem });
+        Items.Add(EditableItem);
     }
 
     public async Task LoadAsync(IProgress<ProgressReport>? progress = null)

--- a/docs/progress/2025-07-02_23-44-20_code_agent.md
+++ b/docs/progress/2025-07-02_23-44-20_code_agent.md
@@ -1,0 +1,2 @@
+- Fix NullReferenceException in InvoiceEditorViewModel constructor by initializing Items before EditableItem.
+- Items collection now adds first line after EditableItem set to prevent OnEditableItemChanged crash at startup.


### PR DESCRIPTION
## Summary
- ensure `Items` is initialized before setting `EditableItem`
- add progress log for bug fix

## Testing
- `dotnet test --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865c3bc601c83228d5f72db39003f26