### PR TITLE
Fix list arrow navigation

### DIFF
--- a/Wrecept.Wpf/NavigationHelper.cs
+++ b/Wrecept.Wpf/NavigationHelper.cs
@@ -1,5 +1,6 @@
 using System.Windows;
 using System.Windows.Input;
+using System.Windows.Controls;
 
 namespace Wrecept.Wpf;
 
@@ -8,6 +9,16 @@ public static class NavigationHelper
     public static void Handle(KeyEventArgs e)
     {
         var element = e.OriginalSource as UIElement;
+
+        // Allow list controls to handle arrow navigation themselves
+        if (e.OriginalSource is DependencyObject d)
+        {
+            if ((e.Key is Key.Up or Key.Down) &&
+                (d.FindAncestor<ListBox>() is not null || d.FindAncestor<DataGrid>() is not null))
+            {
+                return;
+            }
+        }
 
         switch (e.Key)
         {

--- a/Wrecept.Wpf/Views/InvoiceItemsGrid.xaml.cs
+++ b/Wrecept.Wpf/Views/InvoiceItemsGrid.xaml.cs
@@ -29,14 +29,15 @@ public partial class InvoiceItemsGrid : UserControl
                 vm.RequestDeleteItem(row);
                 e.Handled = true;
             }
-            else
+            else if (e.Key is not (Key.Up or Key.Down))
             {
                 NavigationHelper.Handle(e);
             }
         }
         else
         {
-            NavigationHelper.Handle(e);
+            if (e.Key is not (Key.Up or Key.Down))
+                NavigationHelper.Handle(e);
         }
     }
 }

--- a/Wrecept.Wpf/Views/InvoiceLookupView.xaml.cs
+++ b/Wrecept.Wpf/Views/InvoiceLookupView.xaml.cs
@@ -65,6 +65,10 @@ public partial class InvoiceLookupView : UserControl
                 return;
             }
         }
+
+        if (e.Key is Key.Up or Key.Down)
+            return;
+
         NavigationHelper.Handle(e);
     }
 }

--- a/docs/progress/2025-07-02_23-55-19_logic_agent.md
+++ b/docs/progress/2025-07-02_23-55-19_logic_agent.md
@@ -1,0 +1,2 @@
+- NavigationHelper most már nem nyeli le a Fel/Le nyilakat ListBox és DataGrid esetén.
+- InvoiceLookupView és InvoiceItemsGrid csak akkor hívja a segédet, ha nem Fel/Le nyilat nyomtak.


### PR DESCRIPTION
## Summary
- skip handling Up/Down keys in `NavigationHelper` when the focus is inside a `ListBox` or `DataGrid`
- avoid calling the helper for Up/Down in `InvoiceLookupView` and `InvoiceItemsGrid`
- log progress

## Testing
- `dotnet test --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865c5346cec832298b26667d747c0de