### PR TITLE
Fix SmartLookup command parameter binding

### DIFF
--- a/Wrecept.Wpf/Views/Controls/SmartLookup.xaml.cs
+++ b/Wrecept.Wpf/Views/Controls/SmartLookup.xaml.cs
@@ -36,6 +36,9 @@ public partial class SmartLookup : UserControl
     public static readonly DependencyProperty CreateCommandProperty = DependencyProperty.Register(
         nameof(CreateCommand), typeof(ICommand), typeof(SmartLookup));
 
+    public static readonly DependencyProperty CommandParameterProperty = DependencyProperty.Register(
+        nameof(CommandParameter), typeof(object), typeof(SmartLookup));
+
     public static readonly DependencyProperty MaxSuggestionsProperty = DependencyProperty.Register(
         nameof(MaxSuggestions), typeof(int), typeof(SmartLookup), new PropertyMetadata(10));
 
@@ -79,6 +82,12 @@ public partial class SmartLookup : UserControl
     {
         get => (ICommand?)GetValue(CreateCommandProperty);
         set => SetValue(CreateCommandProperty, value);
+    }
+
+    public object? CommandParameter
+    {
+        get => GetValue(CommandParameterProperty);
+        set => SetValue(CommandParameterProperty, value);
     }
 
     public int MaxSuggestions
@@ -211,8 +220,9 @@ public partial class SmartLookup : UserControl
             }
             else if (FilteredItems.Count == 0 && !string.IsNullOrWhiteSpace(Text))
             {
-                if (CreateCommand?.CanExecute(Text) == true)
-                    CreateCommand.Execute(Text);
+                var param = CommandParameter ?? Text;
+                if (CreateCommand?.CanExecute(param) == true)
+                    CreateCommand.Execute(param);
                 PART_Popup.IsOpen = false;
             }
             e.Handled = true;

--- a/docs/progress/2025-07-03_00-34-18_code_agent.md
+++ b/docs/progress/2025-07-03_00-34-18_code_agent.md
@@ -1,0 +1,2 @@
+- Added CommandParameter dependency property to SmartLookup.
+- SmartLookup now passes this value to CreateCommand when no suggestions exist.


### PR DESCRIPTION
## Summary
- extend `SmartLookup` with `CommandParameter` dependency property
- pass this parameter to `CreateCommand` when creating new items
- document the change

## Testing
- `dotnet build Wrecept.sln -v:m` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*
- `dotnet test Wrecept.sln -v:m` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865cf39bd8083229a946f9ba42307c7