### PR TITLE
Refactor invoice header layout

### DIFF
--- a/Wrecept.Wpf/Themes/RetroTheme.Dark.xaml
+++ b/Wrecept.Wpf/Themes/RetroTheme.Dark.xaml
@@ -33,6 +33,22 @@
         <Setter Property="FontWeight" Value="Bold" />
     </Style>
 
+    <Style TargetType="TextBlock" x:Key="LabelTextStyle">
+        <Setter Property="FontFamily" Value="{StaticResource MonospacedFont}" />
+        <Setter Property="FontSize" Value="14" />
+        <Setter Property="FontWeight" Value="SemiBold" />
+    </Style>
+
+    <Style TargetType="TextBlock" x:Key="ValueTextStyle">
+        <Setter Property="FontFamily" Value="{StaticResource MonospacedFont}" />
+        <Setter Property="FontSize" Value="14" />
+        <Setter Property="TextAlignment" Value="Right" />
+    </Style>
+
+    <Style TargetType="TextBlock" x:Key="BoldTotalStyle" BasedOn="{StaticResource ValueTextStyle}">
+        <Setter Property="FontWeight" Value="Bold" />
+    </Style>
+
     <Style TargetType="TextBlock">
         <Setter Property="Foreground" Value="{StaticResource ForegroundBrush}" />
         <Setter Property="FontFamily" Value="{StaticResource MonospacedFont}" />

--- a/Wrecept.Wpf/Views/Controls/TotalsPanel.xaml
+++ b/Wrecept.Wpf/Views/Controls/TotalsPanel.xaml
@@ -1,70 +1,49 @@
 <UserControl x:Class="Wrecept.Wpf.Views.Controls.TotalsPanel"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-    <UserControl.Resources>
-        <Style x:Key="ValueCell" TargetType="TextBlock">
-            <Setter Property="TextElement.FontFamily" Value="{StaticResource MonospacedFont}" />
-            <Setter Property="TextElement.FontSize" Value="14" />
-            <Setter Property="TextAlignment" Value="Right" />
-            <Setter Property="HorizontalAlignment" Value="Right" />
-        </Style>
-        <Style x:Key="LabelCell" TargetType="TextBlock">
-            <Setter Property="TextElement.FontFamily" Value="{StaticResource MonospacedFont}" />
-            <Setter Property="TextElement.FontSize" Value="14" />
-            <Setter Property="HorizontalAlignment" Value="Stretch" />
-        </Style>
-    </UserControl.Resources>
-    <StackPanel>
-        <ItemsControl ItemsSource="{Binding VatSummaries}" Margin="0,0,0,2">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="90" />
+        </Grid.ColumnDefinitions>
+
+        <ItemsControl Grid.Row="0" Grid.ColumnSpan="2" ItemsSource="{Binding VatSummaries}" Margin="0,0,0,2">
             <ItemsControl.ItemTemplate>
                 <DataTemplate>
                     <Grid Margin="0,0,0,1">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="*" />
-                            <ColumnDefinition Width="80" />
-                            <ColumnDefinition Width="80" />
+                            <ColumnDefinition Width="90" />
                         </Grid.ColumnDefinitions>
-                        <TextBlock Grid.Column="0" Text="{Binding Rate}" Style="{StaticResource LabelCell}" />
-                        <TextBlock Grid.Column="1" Text="{Binding Net, StringFormat=N2}" Style="{StaticResource ValueCell}" />
-                        <TextBlock Grid.Column="2" Text="{Binding Vat, StringFormat=N2}" Style="{StaticResource ValueCell}" />
+                        <TextBlock Grid.Column="0" Text="{Binding Rate}" Style="{StaticResource LabelTextStyle}" />
+                        <TextBlock Grid.Column="1" Text="{Binding Vat, StringFormat=N2}" Style="{StaticResource ValueTextStyle}" />
                     </Grid>
                 </DataTemplate>
             </ItemsControl.ItemTemplate>
         </ItemsControl>
 
-        <Grid Margin="0,4,0,0">
-            <Grid.RowDefinitions>
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-            </Grid.RowDefinitions>
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="80" />
-                <ColumnDefinition Width="80" />
-            </Grid.ColumnDefinitions>
+        <TextBlock Grid.Row="1" Grid.Column="0" Text="Nettó összesen" Style="{StaticResource LabelTextStyle}" />
+        <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding NetTotal, StringFormat=N2}" Style="{StaticResource ValueTextStyle}" />
 
-            <TextBlock Grid.Row="0" Grid.Column="0" Text="Nettó összesen" Style="{StaticResource LabelCell}" />
-            <TextBlock Grid.Row="0" Grid.Column="1" Text="{Binding NetTotal, StringFormat=N2}" Style="{StaticResource ValueCell}" />
+        <TextBlock Grid.Row="2" Grid.Column="0" Text="ÁFA összesen" Style="{StaticResource LabelTextStyle}" />
+        <TextBlock Grid.Row="2" Grid.Column="1" Text="{Binding VatTotal, StringFormat=N2}" Style="{StaticResource ValueTextStyle}" />
 
-            <TextBlock Grid.Row="1" Grid.Column="0" Text="ÁFA összesen" Style="{StaticResource LabelCell}" />
-            <TextBlock Grid.Row="1" Grid.Column="2" Text="{Binding VatTotal, StringFormat=N2}" Style="{StaticResource ValueCell}" />
+        <TextBlock Grid.Row="3" Grid.Column="0" Text="Bruttó" Style="{StaticResource LabelTextStyle}" />
+        <TextBlock Grid.Row="3" Grid.Column="1" Text="{Binding GrossTotal, StringFormat=N2}" Style="{StaticResource BoldTotalStyle}" />
 
-            <TextBlock Grid.Row="2" Grid.Column="0" Text="Bruttó" Style="{StaticResource LabelCell}" FontWeight="Bold" />
-            <TextBlock Grid.Row="2" Grid.Column="1" Grid.ColumnSpan="2" Text="{Binding GrossTotal, StringFormat=N2}" Style="{StaticResource ValueCell}" FontWeight="Bold" />
-        </Grid>
-
-        <TextBlock Margin="0,2,0,0"
-                   FontFamily="{StaticResource MonospacedFont}"
-                   FontSize="12"
-                   FontStyle="Italic"
-                   TextWrapping="Wrap"
-                   TextAlignment="Right"
-                   MaxWidth="300"
-                   Language="hu-HU"
-                   IsHyphenationEnabled="True">
+        <TextBlock Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2" Margin="0,2,0,0"
+                   Style="{StaticResource ValueTextStyle}"
+                   FontStyle="Italic" TextWrapping="Wrap" MaxWidth="300"
+                   TextAlignment="Right" Language="hu-HU" IsHyphenationEnabled="True">
             <Run Text="Azaz&#x2010;:" />
             <Run Text="{Binding AmountInWords}" />
         </TextBlock>
-    </StackPanel>
+    </Grid>
 </UserControl>

--- a/Wrecept.Wpf/Views/InvoiceEditorView.xaml
+++ b/Wrecept.Wpf/Views/InvoiceEditorView.xaml
@@ -69,9 +69,9 @@
                 <GroupBox Header="Számlafejléc">
                     <Grid Margin="4">
                         <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="3*" />
-                            <ColumnDefinition Width="3*" />
-                            <ColumnDefinition Width="4*" />
+                            <ColumnDefinition Width="2*" />
+                            <ColumnDefinition Width="2*" />
+                            <ColumnDefinition Width="Auto" />
                         </Grid.ColumnDefinitions>
 
                         <!-- Bal oszlop -->
@@ -86,7 +86,7 @@
                                 <ColumnDefinition Width="220" />
                             </Grid.ColumnDefinitions>
 
-                            <TextBlock Grid.Row="0" Grid.Column="0" Text="Szállító" Style="{StaticResource HeaderText}" />
+                            <TextBlock Grid.Row="0" Grid.Column="0" Text="Szállító" Style="{StaticResource LabelTextStyle}" />
                             <c:SmartLookup Grid.Row="0" Grid.Column="1" Width="220"
                                            ItemsSource="{Binding Suppliers}"
                                            DisplayMemberPath="Name"
@@ -96,7 +96,7 @@
                                            Watermark="Kezdjen el gépelni..."
                                            IsEnabled="{Binding IsEditable}" />
 
-                            <TextBlock Grid.Row="1" Grid.Column="0" Text="Fizetési mód" Margin="0,4,0,0" Style="{StaticResource HeaderText}" />
+                            <TextBlock Grid.Row="1" Grid.Column="0" Text="Fizetési mód" Margin="0,4,0,0" Style="{StaticResource LabelTextStyle}" />
                             <c:EditLookup Grid.Row="1" Grid.Column="1" Width="220" Margin="0,4,0,0"
                                           ItemsSource="{Binding PaymentMethods}"
                                           DisplayMemberPath="Name"
@@ -109,7 +109,7 @@
                         </Grid>
 
                         <!-- Középső oszlop -->
-                        <Grid Grid.Column="1">
+                        <Grid Grid.Column="1" Margin="8,0">
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="Auto" />
                                 <RowDefinition Height="Auto" />
@@ -119,10 +119,10 @@
                                 <ColumnDefinition Width="220" />
                             </Grid.ColumnDefinitions>
 
-                            <TextBlock Grid.Row="0" Grid.Column="0" Text="Dátum" Style="{StaticResource HeaderText}" />
+                            <TextBlock Grid.Row="0" Grid.Column="0" Text="Dátum" Style="{StaticResource LabelTextStyle}" />
                             <DatePicker Grid.Row="0" Grid.Column="1" Width="220" SelectedDate="{Binding InvoiceDate}" IsEnabled="{Binding IsEditable}" />
 
-                            <TextBlock Grid.Row="1" Grid.Column="0" Margin="0,4,0,0" Text="Számlaszám" Style="{StaticResource HeaderText}" />
+                            <TextBlock Grid.Row="1" Grid.Column="0" Margin="0,4,0,0" Text="Számlaszám" Style="{StaticResource LabelTextStyle}" />
                             <TextBox Grid.Row="1" Grid.Column="1" Width="220" Margin="0,4,0,0"
                                      Text="{Binding Number}"
                                      IsEnabled="{Binding IsNew}"
@@ -130,8 +130,8 @@
                         </Grid>
 
                         <!-- Jobb oszlop: TotalsPanel -->
-                        <Border Grid.Column="2" Padding="4" Margin="0,0,0,0" Background="{DynamicResource ControlBackgroundBrush}">
-                            <c:TotalsPanel HorizontalAlignment="Right" />
+                        <Border Grid.Column="2" Padding="4" Margin="8,0,0,0" Background="{DynamicResource ControlBackgroundBrush}">
+                            <c:TotalsPanel />
                         </Border>
                     </Grid>
                 </GroupBox>

--- a/docs/progress/2025-07-03_01-08-31_ui_agent.md
+++ b/docs/progress/2025-07-03_01-08-31_ui_agent.md
@@ -1,0 +1,3 @@
+- InvoiceEditorView header grid átszervezve 3 oszloposra, TotalsPanel jobb oldalon.
+- TotalsPanel kétoszlopos Gridre cserélve, az értékek jobbra igazítva.
+- Új szövegstílusok (LabelTextStyle, ValueTextStyle, BoldTotalStyle) a RetroTheme.Dark.xaml-ben.


### PR DESCRIPTION
## Summary
- redesign InvoiceEditorView header grid
- simplify TotalsPanel to two-column layout
- introduce common text styles for invoice totals
- log progress

## Testing
- `dotnet test --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865d6de0db08322bf3a1c6b2860c6c6