### PR TITLE
Fix LabelTextStyle lookup

### DIFF
--- a/Wrecept.Wpf/Themes/RetroTheme.xaml
+++ b/Wrecept.Wpf/Themes/RetroTheme.xaml
@@ -34,6 +34,22 @@
         <Setter Property="FontWeight" Value="Bold" />
     </Style>
 
+    <Style TargetType="TextBlock" x:Key="LabelTextStyle">
+        <Setter Property="FontFamily" Value="{StaticResource MonospacedFont}" />
+        <Setter Property="FontSize" Value="14" />
+        <Setter Property="FontWeight" Value="SemiBold" />
+    </Style>
+
+    <Style TargetType="TextBlock" x:Key="ValueTextStyle">
+        <Setter Property="FontFamily" Value="{StaticResource MonospacedFont}" />
+        <Setter Property="FontSize" Value="14" />
+        <Setter Property="TextAlignment" Value="Right" />
+    </Style>
+
+    <Style TargetType="TextBlock" x:Key="BoldTotalStyle" BasedOn="{StaticResource ValueTextStyle}">
+        <Setter Property="FontWeight" Value="Bold" />
+    </Style>
+
     <Style TargetType="TextBlock">
         <Setter Property="Foreground" Value="{StaticResource ForegroundBrush}" />
         <Setter Property="FontFamily" Value="{StaticResource MonospacedFont}" />

--- a/docs/progress/2025-07-03_01-16-20_docs_agent.md
+++ b/docs/progress/2025-07-03_01-16-20_docs_agent.md
@@ -1,0 +1,1 @@
+- themes.md kiegészítve a szövegstílusok mindkét témában való elérhetőségével.

--- a/docs/progress/2025-07-03_01-16-20_ui_agent.md
+++ b/docs/progress/2025-07-03_01-16-20_ui_agent.md
@@ -1,0 +1,1 @@
+- LabelTextStyle, ValueTextStyle és BoldTotalStyle átmásolva a RetroTheme.xaml-be a futási hiba megszüntetéséhez.

--- a/docs/themes.md
+++ b/docs/themes.md
@@ -20,6 +20,7 @@ A Retro UI hangs on a 16 színű DOS-palettán. A XAML erőforrás szótár egys
 Stílusok:
 - **HeaderText**, **HeaderTextBold**: IBM Plex Mono betűcsalád feliratokhoz.
 - **HeaderTextBoxBold**: ugyanez a megjelenés szövegmezőknél.
+- **LabelTextStyle**, **ValueTextStyle**, **BoldTotalStyle**: számlamezők és összesítések tipográfiája mindkét témában.
 
 Betűméretek:
 - **FontSizeNormal:** 16 px, általános szövegekhez és űrlapmezőkhöz.


### PR DESCRIPTION
## Summary
- add missing label styles to RetroTheme.xaml so startup succeeds
- document text styles being available in both themes
- log changes for ui_agent and docs_agent

## Testing
- `dotnet test --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865d92536948322971b86562163d120