### PR TITLE
Improve keyboard handlers

### DIFF
--- a/Wrecept.Wpf/Dialogs/DialogHelper.cs
+++ b/Wrecept.Wpf/Dialogs/DialogHelper.cs
@@ -20,6 +20,9 @@ public static class DialogHelper
         {
             if (e.Key == Key.Enter)
             {
+                if (e.OriginalSource is TextBox box && box.AcceptsReturn)
+                    return;
+
                 ok.Execute(null);
                 e.Handled = true;
             }

--- a/Wrecept.Wpf/NavigationHelper.cs
+++ b/Wrecept.Wpf/NavigationHelper.cs
@@ -14,7 +14,10 @@ public static class NavigationHelper
         if (e.OriginalSource is DependencyObject d)
         {
             if ((e.Key is Key.Up or Key.Down) &&
-                (d.FindAncestor<ListBox>() is not null || d.FindAncestor<DataGrid>() is not null))
+                (d.FindAncestor<ListBox>() is not null ||
+                 d.FindAncestor<DataGrid>() is not null ||
+                 d.FindAncestor<ComboBox>() is not null ||
+                 d.FindAncestor<TreeView>() is not null))
             {
                 return;
             }

--- a/Wrecept.Wpf/Views/Controls/BaseMasterView.cs
+++ b/Wrecept.Wpf/Views/Controls/BaseMasterView.cs
@@ -46,9 +46,9 @@ public abstract class BaseMasterView : UserControl
             new KeyBinding { Key = Key.Delete },
             new KeyBinding { Key = Key.Escape }
         };
-        InputBindings.Add(commands[0]);
-        InputBindings.Add(commands[1]);
-        InputBindings.Add(commands[2]);
+        dataGrid.InputBindings.Add(commands[0]);
+        dataGrid.InputBindings.Add(commands[1]);
+        dataGrid.InputBindings.Add(commands[2]);
         BindingOperations.SetBinding(commands[0], InputBinding.CommandProperty, new Binding("EditSelectedCommand"));
         BindingOperations.SetBinding(commands[1], InputBinding.CommandProperty, new Binding("DeleteSelectedCommand"));
         BindingOperations.SetBinding(commands[2], InputBinding.CommandProperty, new Binding("CloseDetailsCommand"));

--- a/docs/KeyboardFlow.md
+++ b/docs/KeyboardFlow.md
@@ -37,12 +37,14 @@ A Wrecept minden felületén a billentyűzet az elsődleges vezérlő eszköz. A
 - `Delete`: kijelölt sor törlése.
 - `Escape`: részletes nézetből vissza a listához.
 Az összes mesteradat ViewModel az `EditableMasterDataViewModel` leszármazottja, így ezek a billentyűk minden listában azonos módon viselkednek.
+Az InputBindingek mostantól a rács vezérlőn vannak, így szövegmezők szerkesztésekor az `Enter` nem zárja le véletlenül a részleteket.
 
 ## 📦 Modal Prompt Behavior
 
 Az `ArchivePromptView`, `SaveLinePromptView` és `InvoiceCreatePromptView` egyaránt követi:
 - `Enter` a megerősítő parancsot futtatja.
 - `Escape` a mégse parancsot hívja.
+- Többsoros `TextBox` esetén az `Enter` nem kerül lekezelésre, hogy az új sor bevitele működjön.
 A fókusz a prompt bezárása után visszatér a megnyitó nézethez.
 
 ## 📋 Focus Reset Rules
@@ -56,6 +58,7 @@ Az `Enter` alapértelmezésben a következő vezérlőre ugrik, ha az aktuális 
 ## 💡 Design Philosophy
 
 A billentyűzetes navigációt a sebesség és az időtálló megszokhatóság jegyében terveztük. Minden akció egzaktul megismételhető, vizuális visszajelzéssel kombinálva.
+Általánosan `KeyDown` eseményeket használunk; csak a `SmartLookup` és az `EditLookup` kezel `PreviewKeyDown`-t, hogy még a `TextBox` szintjén elcsípje a navigációs billentyűket.
 
 ## 🔧 Future Enhancements
 

--- a/docs/progress/2025-07-03_10-52-26_logic_agent.md
+++ b/docs/progress/2025-07-03_10-52-26_logic_agent.md
@@ -1,0 +1,3 @@
+- NavigationHelper bővítve ComboBox és TreeView esetére.
+- DialogHelper.MapKeys most figyeli, ha többsoros TextBox az eredeti forrás.
+- BaseMasterView InputBindingek átkerültek a DataGridre.

--- a/docs/progress/2025-07-03_10-52-30_docs_agent.md
+++ b/docs/progress/2025-07-03_10-52-30_docs_agent.md
@@ -1,0 +1,2 @@
+- KeyboardFlow.md frissítve a többsoros TextBox és DataGrid InputBinding szabállyal.
+- Rögzítettük, hogy csak a SmartLookup és EditLookup használ PreviewKeyDown eseményt.


### PR DESCRIPTION
## Summary
- fix arrow navigation for ComboBox & TreeView
- ignore Enter in multiline dialog textboxes
- keep master view bindings inside the grid
- clarify modal behavior and event types in KeyboardFlow docs
- log keyboard handler updates

## Testing
- `dotnet test --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_686659f9c404832295f1ac22443e93ab