### PR TITLE
Handle multi-line textbox shortcuts

### DIFF
--- a/Wrecept.Wpf/NavigationHelper.cs
+++ b/Wrecept.Wpf/NavigationHelper.cs
@@ -23,6 +23,13 @@ public static class NavigationHelper
             }
         }
 
+        if ((e.Key is Key.Enter or Key.Escape) &&
+            e.OriginalSource is TextBox box &&
+            box.AcceptsReturn)
+        {
+            return;
+        }
+
         switch (e.Key)
         {
             case Key.Down:

--- a/docs/KeyboardFlow.md
+++ b/docs/KeyboardFlow.md
@@ -44,7 +44,7 @@ Az InputBindingek mostantól a rács vezérlőn vannak, így szövegmezők szerk
 Az `ArchivePromptView`, `SaveLinePromptView` és `InvoiceCreatePromptView` egyaránt követi:
 - `Enter` a megerősítő parancsot futtatja.
 - `Escape` a mégse parancsot hívja.
-- Többsoros `TextBox` esetén az `Enter` nem kerül lekezelésre, hogy az új sor bevitele működjön.
+- Többsoros `TextBox` (`AcceptsReturn=true`) esetén a `NavigationHelper` sem az `Enter`, sem az `Escape` billentyűt nem kezeli, így az új sor bevitele és a vezérlő saját művelete zavartalan.
 A fókusz a prompt bezárása után visszatér a megnyitó nézethez.
 
 ## 📋 Focus Reset Rules

--- a/docs/progress/2025-07-03_11-05-31_docs_agent.md
+++ b/docs/progress/2025-07-03_11-05-31_docs_agent.md
@@ -1,0 +1,1 @@
+- KeyboardFlow.md kiegészült: a többsoros TextBoxon a NavigationHelper nem kezeli az Enter és Escape gombokat.

--- a/docs/progress/2025-07-03_11-05-31_logic_agent.md
+++ b/docs/progress/2025-07-03_11-05-31_logic_agent.md
@@ -1,0 +1,1 @@
+- NavigationHelper.Handle most már figyeli, ha a fókusz többsoros TextBoxon van; Enter vagy Escape esetén nem mozgat fókuszt.


### PR DESCRIPTION
## Summary
- avoid handling Enter/Escape when multiline TextBox has focus
- document NavigationHelper behaviour
- log progress

## Testing
- `dotnet test tests/Wrecept.Tests/Wrecept.Tests.csproj --no-build` *(fails: Wrecept.Wpf not compatible with net8.0)*

------
https://chatgpt.com/codex/tasks/task_e_6866635d33ac8322afa3eeca4a0915cd