### PR TITLE
Improve keyboard flow

### DIFF
--- a/Wrecept.Wpf/Dialogs/DialogHelper.cs
+++ b/Wrecept.Wpf/Dialogs/DialogHelper.cs
@@ -23,13 +23,19 @@ public static class DialogHelper
                 if (e.OriginalSource is TextBox box && box.AcceptsReturn)
                     return;
 
-                ok.Execute(null);
-                e.Handled = true;
+                if (ok.CanExecute(null))
+                {
+                    ok.Execute(null);
+                    e.Handled = true;
+                }
             }
             else if (e.Key == Key.Escape)
             {
-                cancel.Execute(null);
-                e.Handled = true;
+                if (cancel.CanExecute(null))
+                {
+                    cancel.Execute(null);
+                    e.Handled = true;
+                }
             }
         };
     }

--- a/Wrecept.Wpf/NavigationHelper.cs
+++ b/Wrecept.Wpf/NavigationHelper.cs
@@ -42,8 +42,11 @@ public static class NavigationHelper
                 element?.MoveFocus(new TraversalRequest(FocusNavigationDirection.Previous));
                 break;
             case Key.Escape:
-                e.Handled = true;
-                Application.Current.MainWindow?.Focus();
+                if (Window.GetWindow(element) == Application.Current.MainWindow)
+                {
+                    e.Handled = true;
+                    Application.Current.MainWindow?.Focus();
+                }
                 break;
         }
     }

--- a/Wrecept.Wpf/ViewModels/EditableMasterDataViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/EditableMasterDataViewModel.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 
 namespace Wrecept.Wpf.ViewModels;
 
-public abstract partial class EditableMasterDataViewModel<T> : MasterDataBaseViewModel<T>
+public abstract partial class EditableMasterDataViewModel<T> : MasterDataBaseViewModel<T>, IEditableMasterDataViewModel
 {
     [ObservableProperty]
     private bool isEditing;

--- a/Wrecept.Wpf/ViewModels/IEditableMasterDataViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/IEditableMasterDataViewModel.cs
@@ -1,0 +1,10 @@
+using CommunityToolkit.Mvvm.Input;
+
+namespace Wrecept.Wpf.ViewModels;
+
+public interface IEditableMasterDataViewModel : IMasterDataViewModel
+{
+    IRelayCommand EditSelectedCommand { get; }
+    IRelayCommand DeleteSelectedCommand { get; }
+    IRelayCommand CloseDetailsCommand { get; }
+}

--- a/Wrecept.Wpf/Views/Controls/BaseMasterView.cs
+++ b/Wrecept.Wpf/Views/Controls/BaseMasterView.cs
@@ -40,18 +40,7 @@ public abstract class BaseMasterView : UserControl
         dataGrid.RowDetailsVisibilityChanged += Grid_RowDetailsVisibilityChanged;
         grid.Children.Add(dataGrid);
 
-        var commands = new[]
-        {
-            new KeyBinding { Key = Key.Enter },
-            new KeyBinding { Key = Key.Delete },
-            new KeyBinding { Key = Key.Escape }
-        };
-        dataGrid.InputBindings.Add(commands[0]);
-        dataGrid.InputBindings.Add(commands[1]);
-        dataGrid.InputBindings.Add(commands[2]);
-        BindingOperations.SetBinding(commands[0], InputBinding.CommandProperty, new Binding("EditSelectedCommand"));
-        BindingOperations.SetBinding(commands[1], InputBinding.CommandProperty, new Binding("DeleteSelectedCommand"));
-        BindingOperations.SetBinding(commands[2], InputBinding.CommandProperty, new Binding("CloseDetailsCommand"));
+        dataGrid.PreviewKeyDown += Grid_PreviewKeyDown;
 
         var hint = new TextBlock
         {
@@ -92,6 +81,31 @@ public abstract class BaseMasterView : UserControl
 
     private void OnKeyDown(object? sender, KeyEventArgs e)
         => NavigationHelper.Handle(e);
+
+    private void Grid_PreviewKeyDown(object? sender, KeyEventArgs e)
+    {
+        if (e.OriginalSource is TextBox)
+            return;
+
+        if (DataContext is not IEditableMasterDataViewModel vm)
+            return;
+
+        if (e.Key == Key.Enter && vm.EditSelectedCommand.CanExecute(null))
+        {
+            vm.EditSelectedCommand.Execute(null);
+            e.Handled = true;
+        }
+        else if (e.Key == Key.Delete && vm.DeleteSelectedCommand.CanExecute(null))
+        {
+            vm.DeleteSelectedCommand.Execute(null);
+            e.Handled = true;
+        }
+        else if (e.Key == Key.Escape && vm.CloseDetailsCommand.CanExecute(null))
+        {
+            vm.CloseDetailsCommand.Execute(null);
+            e.Handled = true;
+        }
+    }
 
     private void Grid_RowDetailsVisibilityChanged(object? sender, DataGridRowDetailsEventArgs e)
     {

--- a/Wrecept.Wpf/Views/InvoiceEditorView.xaml
+++ b/Wrecept.Wpf/Views/InvoiceEditorView.xaml
@@ -166,7 +166,7 @@
                                Watermark="Me.e."
                                CreateCommand="{Binding DataContext.ShowUnitCreatorCommand, RelativeSource={RelativeSource AncestorType=UserControl}}" />
                 <TextBox x:Name="EntryPrice" Width="80" Margin="4,0" Text="{Binding UnitPrice, Mode=TwoWay}"/>
-                <c:EditLookup x:Name="EntryTax" Width="100"
+                <c:EditLookup x:Name="EntryTax" Width="100" Tag="LastEntry"
                               ItemsSource="{Binding DataContext.TaxRates, RelativeSource={RelativeSource AncestorType=UserControl}}"
                               DisplayMemberPath="Name"
                               SelectedValuePath="Id"

--- a/Wrecept.Wpf/Views/InvoiceEditorView.xaml.cs
+++ b/Wrecept.Wpf/Views/InvoiceEditorView.xaml.cs
@@ -56,7 +56,7 @@ public partial class InvoiceEditorView : UserControl
         if (fe is not null)
             vm.LastFocusedField = fe.Name;
 
-        if (e.Key == Key.Enter && fe?.Name == "EntryTax")
+        if (e.Key == Key.Enter && fe?.Tag?.ToString() == "LastEntry")
         {
             if (vm.EditableItem.IsEditingExisting)
                 vm.SaveEditedItemCommand.Execute(null);

--- a/Wrecept.Wpf/Views/ScreenModeWindow.xaml.cs
+++ b/Wrecept.Wpf/Views/ScreenModeWindow.xaml.cs
@@ -13,5 +13,10 @@ public partial class ScreenModeWindow : Window
     }
 
     private void OnKeyDown(object sender, KeyEventArgs e)
-        => NavigationHelper.Handle(e);
+    {
+        if (e.Key == Key.Escape)
+            return;
+
+        NavigationHelper.Handle(e);
+    }
 }

--- a/docs/KeyboardFlow.md
+++ b/docs/KeyboardFlow.md
@@ -28,7 +28,7 @@ A Wrecept minden felületén a billentyűzet az elsődleges vezérlő eszköz. A
 - A fejmezőkben `Enter` vagy `Down` továbbítja a fókuszt.
 - `Escape` visszaviszi a főablak listájához.
 - Az „Inline Item Entry” sor a `OnEntryKeyDown` eseményt használja:
-  - `Enter` az utolsó mezőben (`EntryTax`) meghívja az `AddLineItemCommand`-et.
+  - `Enter` az utolsó mezőben (jelölés: `Tag="LastEntry"`) meghívja az `AddLineItemCommand`-et.
   - Egyébként a `NavigationHelper` lép közbe.
 - Az `InvoiceItemsGrid`-en `Enter` az aktuális tétel szerkesztését indítja.
 
@@ -37,7 +37,8 @@ A Wrecept minden felületén a billentyűzet az elsődleges vezérlő eszköz. A
 - `Delete`: kijelölt sor törlése.
 - `Escape`: részletes nézetből vissza a listához.
 Az összes mesteradat ViewModel az `EditableMasterDataViewModel` leszármazottja, így ezek a billentyűk minden listában azonos módon viselkednek.
-Az InputBindingek mostantól a rács vezérlőn vannak, így szövegmezők szerkesztésekor az `Enter` nem zárja le véletlenül a részleteket.
+Az InputBindingek helyett a rács `PreviewKeyDown` eseménye futtatja a parancsokat,
+így szövegmezők szerkesztésekor az `Enter` nem zárja le véletlenül a részleteteket.
 
 ## 📦 Modal Prompt Behavior
 
@@ -49,10 +50,11 @@ A fókusz a prompt bezárása után visszatér a megnyitó nézethez.
 
 ## 📋 Focus Reset Rules
 
-Globálisan az `Escape` mindig a főablakra helyezi a fókuszt:
+Globálisan az `Escape` csak a főablakból indítva helyezi a fókuszt vissza a főablakra:
 ```csharp
 Application.Current.MainWindow?.Focus();
 ```
+Más ablakokban a billentyűt a saját logikájuk kezeli.
 Az `Enter` alapértelmezésben a következő vezérlőre ugrik, ha az aktuális kezelő nem nyeli el.
 
 ## 💡 Design Philosophy

--- a/docs/progress/2025-07-03_11-27-24_docs_agent.md
+++ b/docs/progress/2025-07-03_11-27-24_docs_agent.md
@@ -1,0 +1,2 @@
+- KeyboardFlow frissítve a PreviewKeyDown kezelésre és a `LastEntry` jelölésre.
+- Escape fókuszszabály kiegészítve: csak a főablakra érvényes.

--- a/docs/progress/2025-07-03_11-27-24_logic_agent.md
+++ b/docs/progress/2025-07-03_11-27-24_logic_agent.md
@@ -1,0 +1,5 @@
+- BaseMasterView most PreviewKeyDown eseményt használ a parancsokhoz, így a TextBox szerkesztés nem fut bele a billentyűparancsokba.
+- NavigationHelper csak a főablakból indítva kezeli az Escape fókuszváltást.
+- ScreenModeWindow Esc gombja nem kerül átirányításra, így az IsCancel logika érvényesül.
+- DialogHelper.MapKeys ellenőrzi a CanExecute állapotot.
+- InvoiceEditorView az utolsó mezőt Tag szerint azonosítja.


### PR DESCRIPTION
## Summary
- stop global focus change if Escape not from main window
- handle master view keys via PreviewKeyDown
- ignore Escape in screen mode dialog
- check CanExecute in dialog key mapping
- mark last entry field with Tag instead of name
- document new rules

## Testing
- `dotnet test Wrecept.sln -c Release` *(fails: Microsoft.NET.Sdk.WindowsDesktop/targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_686664d1cb988322bfee072c649f27a8