### PR TITLE
StageView Esc null check

### DIFF
--- a/Wrecept.Wpf/Views/StageView.xaml.cs
+++ b/Wrecept.Wpf/Views/StageView.xaml.cs
@@ -22,8 +22,16 @@ public partial class StageView : UserControl
     {
         if (e.Key == Key.Escape)
         {
-            _lastMenuItem?.Focus();
-            e.Handled = true;
+            if (_lastMenuItem is not null)
+            {
+                _lastMenuItem.Focus();
+                e.Handled = true;
+            }
+            else
+            {
+                NavigationHelper.Handle(e);
+            }
+
             return;
         }
 

--- a/docs/KeyboardFlow.md
+++ b/docs/KeyboardFlow.md
@@ -40,6 +40,10 @@ Az összes mesteradat ViewModel az `EditableMasterDataViewModel` leszármazottja
 Az InputBindingek helyett a rács `PreviewKeyDown` eseménye futtatja a parancsokat,
 így szövegmezők szerkesztésekor az `Enter` nem zárja le véletlenül a részleteteket.
 
+### StageView
+- `Escape`: visszateszi a fókuszt az utoljára aktivált menüpontra, ha az elérhető.
+- Ha nincs korábbi menüpont, a `NavigationHelper` globális fókusz-visszaállítása lép életbe.
+
 ## 📦 Modal Prompt Behavior
 
 Az `ArchivePromptView`, `SaveLinePromptView` és `InvoiceCreatePromptView` egyaránt követi:

--- a/docs/progress/2025-07-03_11-47-44_docs_agent.md
+++ b/docs/progress/2025-07-03_11-47-44_docs_agent.md
@@ -1,0 +1,1 @@
+- KeyboardFlow.md bővítve a StageView viselkedésével.

--- a/docs/progress/2025-07-03_11-47-44_logic_agent.md
+++ b/docs/progress/2025-07-03_11-47-44_logic_agent.md
@@ -1,0 +1,2 @@
+- StageView Escape kezelése most ellenőrzi, hogy van-e korábban aktivált menüelem.
+- Ha nincs, a NavigationHelper globális fókusz-visszaállítása érvényesül.


### PR DESCRIPTION
## Summary
- update StageView Escape handler to call NavigationHelper when no menu item
- document StageView Escape behaviour in KeyboardFlow
- log progress

## Testing
- `dotnet test Wrecept.Core.Tests/Wrecept.Core.Tests.csproj --no-build --no-restore --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_68666d138d448322a2adc0cc02096fbf