### PR TITLE
View-scoped focus search

### DIFF
--- a/Wrecept.Wpf/ViewModels/InvoiceEditorViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/InvoiceEditorViewModel.cs
@@ -369,7 +369,7 @@ private void UpdateSupplierId(string name)
             EditableItem = new NewLineItemViewModel(this) { IsFirstRow = true };
             Items.Add(EditableItem);
             RecalculateTotals();
-            FormNavigator.RequestFocus("EntryProduct");
+            FormNavigator.RequestFocus("EntryProduct", typeof(InvoiceEditorView));
             return;
         }
 
@@ -409,7 +409,7 @@ private void UpdateSupplierId(string name)
             Items.Add(row);
         }
         RecalculateTotals();
-        FormNavigator.RequestFocus("InvoiceList");
+        FormNavigator.RequestFocus("InvoiceList", typeof(InvoiceEditorView));
     }
 
     public void EditLineFromSelection(InvoiceItemRowViewModel selected)
@@ -597,7 +597,7 @@ private void UpdateSupplierId(string name)
         edit.ProductGroup = string.Empty;
         edit.IsEditingExisting = false;
         edit.TargetRow = null;
-        FormNavigator.RequestFocus("EntryProduct");
+        FormNavigator.RequestFocus("EntryProduct", typeof(InvoiceEditorView));
     }
 
     [RelayCommand]

--- a/Wrecept.Wpf/ViewModels/SaveLinePromptViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/SaveLinePromptViewModel.cs
@@ -1,6 +1,7 @@
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Wrecept.Wpf.Views;
 
 namespace Wrecept.Wpf.ViewModels;
 
@@ -36,7 +37,7 @@ public partial class SaveLinePromptViewModel : ObservableObject
     {
         _parent.SavePrompt = null;
         if (_finalize)
-            FormNavigator.RequestFocus(_parent.LastFocusedField);
+            FormNavigator.RequestFocus(_parent.LastFocusedField, typeof(InvoiceEditorView));
         _parent.IsInLineFinalizationPrompt = false;
     }
 }

--- a/Wrecept.Wpf/Views/InvoiceEditorView.xaml.cs
+++ b/Wrecept.Wpf/Views/InvoiceEditorView.xaml.cs
@@ -33,7 +33,7 @@ public partial class InvoiceEditorView : UserControl
             });
             await viewModel.LoadAsync(progress);
             progressWindow.Close();
-            FormNavigator.RequestFocus("InvoiceList");
+            FormNavigator.RequestFocus("InvoiceList", typeof(InvoiceEditorView));
         };
     }
 

--- a/docs/UI_FLOW.md
+++ b/docs/UI_FLOW.md
@@ -131,6 +131,9 @@ Inline creators must not shift focus away from the current context
 Views are loaded in-place inside StageView, avoiding modal disruptions
 
 Menu state persists across Escape presses to return user to most recent focus
+The FormNavigator.RequestFocus helper now accepts an optional view-type
+parameter to narrow the search scope; dynamic elements therefore need not use
+globally unique identifiers.
 
 📚 Future List Views
 

--- a/docs/progress/2025-07-03_12-52-15_code_agent.md
+++ b/docs/progress/2025-07-03_12-52-15_code_agent.md
@@ -1,0 +1,2 @@
+- FormNavigator.RequestFocus opcionális nézettípus paraméterrel bővítve.
+- InvoiceEditorView és ViewModel hívások frissítve a típus megadására.

--- a/docs/progress/2025-07-03_12-52-15_docs_agent.md
+++ b/docs/progress/2025-07-03_12-52-15_docs_agent.md
@@ -1,0 +1,1 @@
+- UI_FLOW.md kiegészítve a nézettípus szerinti fókuszkeresés szabályával.


### PR DESCRIPTION
## Summary
- extend `FormNavigator.RequestFocus` with optional view type
- update InvoiceEditorView and InvoiceEditorViewModel calls
- restore focus properly from SaveLinePrompt
- note view-scoped focus in UI flow docs
- log progress for code and docs agents

## Testing
- `dotnet restore`
- `dotnet build --no-restore` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*
- `dotnet test tests/Wrecept.Tests/Wrecept.Tests.csproj --no-build -v diag`

------
https://chatgpt.com/codex/tasks/task_e_68667bbde2348322bae7d2bf6dd15323