### PR TITLE
Implement inline creator popup

### DIFF
--- a/Wrecept.Wpf/ViewModels/InvoiceEditorViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/InvoiceEditorViewModel.cs
@@ -9,6 +9,8 @@ using Wrecept.Core.Models;
 using Wrecept.Core.Utilities;
 using Wrecept.Wpf.Resources;
 using Wrecept.Core.Services;
+using System.Windows;
+using Wrecept.Wpf.Views.Controls;
 
 namespace Wrecept.Wpf.ViewModels;
 
@@ -178,10 +180,17 @@ partial void OnSupplierChanged(string value) => UpdateSupplierId(value);
     [ObservableProperty]
     private object? inlineCreator;
 
+    [ObservableProperty]
+    private UIElement? inlineCreatorTarget;
+
     public bool IsInlineCreatorVisible => InlineCreator != null;
 
     partial void OnInlineCreatorChanged(object? value)
-        => OnPropertyChanged(nameof(IsInlineCreatorVisible));
+    {
+        OnPropertyChanged(nameof(IsInlineCreatorVisible));
+        if (value is null)
+            InlineCreatorTarget = null;
+    }
 
     public bool IsSavePromptVisible => SavePrompt != null;
     public bool IsArchivePromptVisible => ArchivePrompt != null;
@@ -307,41 +316,63 @@ private void UpdateSupplierId(string name)
         SupplierId = match.Id;
 }
     [RelayCommand]
-    private void ShowSupplierCreator(string? name)
+    private void ShowSupplierCreator(object? parameter)
     {
-        InlineCreator = new SupplierCreatorViewModel(this, _suppliers)
+        if (parameter is UIElement target)
         {
-            Name = name ?? string.Empty
-        };
+            InlineCreatorTarget = target;
+            var text = (target as Views.Controls.SmartLookup)?.Text ?? string.Empty;
+            InlineCreator = new SupplierCreatorViewModel(this, _suppliers)
+            {
+                Name = text
+            };
+        }
     }
     [RelayCommand]
-    private void ShowProductCreator(InvoiceItemRowViewModel row)
+    private void ShowProductCreator(object? parameter)
     {
-        InlineCreator = new ProductCreatorViewModel(this, row, _productsService)
+        if (parameter is UIElement target && target is FrameworkElement fe && fe.DataContext is InvoiceItemRowViewModel row)
         {
-            Name = row.Product
-        };
+            InlineCreatorTarget = target;
+            InlineCreator = new ProductCreatorViewModel(this, row, _productsService)
+            {
+                Name = row.Product
+            };
+        }
     }
 
     [RelayCommand]
-    private void ShowTaxRateCreator(string name)
+    private void ShowTaxRateCreator(object? parameter)
     {
-        InlineCreator = new TaxRateCreatorViewModel(this, _taxRates)
+        if (parameter is UIElement target)
         {
-            Name = name
-        };
+            InlineCreatorTarget = target;
+            var name = (target as Controls.EditLookup)?.Box.Text ?? (target as Controls.SmartLookup)?.Text ?? string.Empty;
+            InlineCreator = new TaxRateCreatorViewModel(this, _taxRates)
+            {
+                Name = name
+            };
+        }
     }
 
     [RelayCommand]
-    private void ShowUnitCreator()
+    private void ShowUnitCreator(object? parameter)
     {
-        InlineCreator = new UnitCreatorViewModel(this, _unitsService);
+        if (parameter is UIElement target)
+        {
+            InlineCreatorTarget = target;
+            InlineCreator = new UnitCreatorViewModel(this, _unitsService);
+        }
     }
 
     [RelayCommand]
-    private void ShowPaymentMethodCreator()
+    private void ShowPaymentMethodCreator(object? parameter)
     {
-        InlineCreator = new PaymentMethodCreatorViewModel(this, _paymentMethods);
+        if (parameter is UIElement target)
+        {
+            InlineCreatorTarget = target;
+            InlineCreator = new PaymentMethodCreatorViewModel(this, _paymentMethods);
+        }
     }
 
     [RelayCommand]

--- a/Wrecept.Wpf/Views/InvoiceEditorView.xaml
+++ b/Wrecept.Wpf/Views/InvoiceEditorView.xaml
@@ -93,6 +93,7 @@
                                            SelectedValuePath="Id"
                                            SelectedValue="{Binding SupplierId}"
                                            CreateCommand="{Binding ShowSupplierCreatorCommand}"
+                                           CommandParameter="{Binding RelativeSource={RelativeSource Self}}"
                                            Watermark="Kezdjen el gépelni..."
                                            IsEnabled="{Binding IsEditable}" />
 
@@ -103,6 +104,7 @@
                                           SelectedValuePath="Id"
                                           SelectedValue="{Binding PaymentMethodId}"
                                           CreateCommand="{Binding ShowPaymentMethodCreatorCommand}"
+                                          CommandParameter="{Binding RelativeSource={RelativeSource Self}}"
                                           IsEnabled="{Binding IsEditable}" />
 
                             <CheckBox Grid.Row="2" Grid.ColumnSpan="2" Content="Bruttó ár" Margin="0,4,0,0" IsChecked="{Binding IsGross}" IsEnabled="{Binding IsEditable}" />
@@ -156,7 +158,7 @@
                                SelectedValue="{Binding Product, Mode=TwoWay}"
                                Watermark="Termék neve"
                                CreateCommand="{Binding DataContext.ShowProductCreatorCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
-                               CommandParameter="{Binding}" />
+                               CommandParameter="{Binding RelativeSource={RelativeSource Self}}" />
                 <TextBox x:Name="EntryQuantity" Width="60" Margin="4,0" Text="{Binding Quantity, Mode=TwoWay}"/>
                 <c:SmartLookup x:Name="EntryUnit" Width="80"
                                ItemsSource="{Binding DataContext.Units, RelativeSource={RelativeSource AncestorType=UserControl}}"
@@ -164,17 +166,17 @@
                                SelectedValuePath="Id"
                                SelectedValue="{Binding UnitId, Mode=TwoWay}"
                                Watermark="Me.e."
-                               CreateCommand="{Binding DataContext.ShowUnitCreatorCommand, RelativeSource={RelativeSource AncestorType=UserControl}}" />
+                               CreateCommand="{Binding DataContext.ShowUnitCreatorCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                               CommandParameter="{Binding RelativeSource={RelativeSource Self}}" />
                 <TextBox x:Name="EntryPrice" Width="80" Margin="4,0" Text="{Binding UnitPrice, Mode=TwoWay}"/>
                 <c:EditLookup x:Name="EntryTax" Width="100" Tag="LastEntry"
                               ItemsSource="{Binding DataContext.TaxRates, RelativeSource={RelativeSource AncestorType=UserControl}}"
                               DisplayMemberPath="Name"
                               SelectedValuePath="Id"
                               SelectedValue="{Binding TaxRateId, Mode=TwoWay}"
-                              CreateCommand="{Binding DataContext.ShowTaxRateCreatorCommand, RelativeSource={RelativeSource AncestorType=UserControl}}" />
+                              CreateCommand="{Binding DataContext.ShowTaxRateCreatorCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                              CommandParameter="{Binding RelativeSource={RelativeSource Self}}" />
             </StackPanel>
-
-            <ContentControl Grid.Row="2" Content="{Binding InlineCreator}" Visibility="{Binding IsInlineCreatorVisible, Converter={StaticResource BooleanToVisibilityConverter}}" />
 
             <ScrollViewer Grid.Row="3" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto">
                 <view:InvoiceItemsGrid x:Name="ItemsGrid" Margin="0,0,0,4" />
@@ -204,5 +206,14 @@
             <ContentControl Content="{Binding ArchivePrompt}" Visibility="{Binding IsArchivePromptVisible, Converter={StaticResource BooleanToVisibilityConverter}}" Grid.Row="6" Margin="0,4,0,0" />
             <ContentControl Content="{Binding DeletePrompt}" Visibility="{Binding IsDeletePromptVisible, Converter={StaticResource BooleanToVisibilityConverter}}" Grid.Row="6" Margin="0,8,0,0" />
         </Grid>
+        <Popup Placement="Bottom"
+               PlacementTarget="{Binding InlineCreatorTarget}"
+               IsOpen="{Binding IsInlineCreatorVisible}"
+               StaysOpen="True"
+               AllowsTransparency="True">
+            <Border Background="{DynamicResource ControlBackgroundBrush}" BorderBrush="{DynamicResource HighlightBrush}" BorderThickness="1">
+                <ContentControl Content="{Binding InlineCreator}" />
+            </Border>
+        </Popup>
     </Grid>
 </UserControl>

--- a/docs/InlineEntityCreation.md
+++ b/docs/InlineEntityCreation.md
@@ -9,7 +9,7 @@ date: "2025-06-30"
 
 Az InvoiceEditor nézetben lehetőség nyílik a hiányzó törzsadatok azonnali felvételére. Ha a felhasználó olyan terméket, szállítót, ÁFA-kulcsot vagy mértékegységet ír be, amely nem található az adatbázisban, a program egy kibomló űrlapot jelenít meg az aktuális sor alatt.
 
-Korábban a űrlap a DataGrid `RowDetailsTemplate` elemében jelent meg, ám ez rejtve maradt a sorok összecsukása miatt.  Most egy külön `ContentControl` tartja az űrlapot az adatbeviteli sáv alatt, így mindig látható marad.
+Korábban a űrlap a DataGrid `RowDetailsTemplate` elemében jelent meg, ám ez rejtve maradt a sorok összecsukása miatt.  A legutóbbi frissítés óta a nézet egy lebegő `Popup` segítségével közvetlenül a keresőmező alatt jeleníti meg az űrlapot, így a felhasználó fókusza nem vész el.
 
 ```text
 +-----------------------+
@@ -25,6 +25,7 @@ A kitöltött űrlap mentése azonnal létrehozza az entitást és a szerkesztet
 
 * Minden entitáshoz külön `*CreatorViewModel` és XAML nézet tartozik.
 * Az `InvoiceEditorViewModel.InlineCreator` property tartalmazza az aktuális űrlapot.
+* Az `InlineCreatorTarget` property az adott vezérlőre mutat, amelyhez a `Popup` igazodik.
 * A háttérszín `#F5F5DC`, ezzel emeljük ki az inline űrlapot.
 * Az entitások validálását a megfelelő szolgáltatások (`IProductService`, stb.) végzik.
 

--- a/docs/progress/2025-07-03_17-18-52_ui_agent.md
+++ b/docs/progress/2025-07-03_17-18-52_ui_agent.md
@@ -1,0 +1,5 @@
+- Added InlineCreatorTarget property to InvoiceEditorViewModel.
+- Updated Show*Creator commands to set target from CommandParameter.
+- Replaced ContentControl with floating Popup in InvoiceEditorView.
+- Updated XAML bindings to pass self as CommandParameter.
+- Documented new popup behavior in InlineEntityCreation.md.


### PR DESCRIPTION
## Summary
- add `InlineCreatorTarget` property to `InvoiceEditorViewModel`
- update creator commands to capture triggering control
- swap inline creator area for floating popup
- adjust XAML command parameters
- document new popup behavior

## Testing
- `dotnet restore Wrecept.sln`
- `dotnet build Wrecept.sln --no-restore` *(fails: Microsoft.NET.Sdk.WindowsDesktop missing)*
- `dotnet test Wrecept.Core.Tests/Wrecept.Core.Tests.csproj --verbosity normal`


------
https://chatgpt.com/codex/tasks/task_e_6866b96099948322afc660868fe20b3d