### PR TITLE
Fix namespace issues in WPF project

### DIFF
--- a/Wrecept.Wpf/ViewModels/InvoiceEditorViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/InvoiceEditorViewModel.cs
@@ -11,6 +11,8 @@ using Wrecept.Wpf.Resources;
 using Wrecept.Core.Services;
 using System.Windows;
 using Wrecept.Wpf.Views.Controls;
+using Wrecept.Wpf.Views;
+using Controls = Wrecept.Wpf.Views.Controls;
 
 namespace Wrecept.Wpf.ViewModels;
 

--- a/Wrecept.Wpf/Views/InlinePrompts/InvoiceCreatePromptView.xaml.cs
+++ b/Wrecept.Wpf/Views/InlinePrompts/InvoiceCreatePromptView.xaml.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Windows.Controls;
 using System.Windows.Input;
 using Microsoft.Extensions.DependencyInjection;

--- a/Wrecept.Wpf/Views/InlinePrompts/SaveLinePromptView.xaml.cs
+++ b/Wrecept.Wpf/Views/InlinePrompts/SaveLinePromptView.xaml.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Windows.Controls;
 using System.Windows.Input;
 using Microsoft.Extensions.DependencyInjection;

--- a/docs/progress/2025-07-03_17-45-00_code_agent.md
+++ b/docs/progress/2025-07-03_17-45-00_code_agent.md
@@ -1,0 +1,3 @@
+- Fixed missing namespace references in InvoiceEditorViewModel.
+- Added System namespace to inline prompt views.
+- Build steps attempted; tests for core services pass.


### PR DESCRIPTION
## Summary
- resolve missing Control alias for inline creator lookups
- add required System namespaces to prompt views
- record progress log

## Testing
- `dotnet test Wrecept.Core.Tests/Wrecept.Core.Tests.csproj`
- `dotnet test tests/Wrecept.Tests/Wrecept.Tests.csproj` *(fails: Project Wrecept.Wpf is not compatible with net8.0)*
- `dotnet build Wrecept.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866c0b61cac83229e47802278338859