### PR TITLE
Fix DB seeding migration

### DIFF
--- a/Wrecept.Storage/Data/DbInitializer.cs
+++ b/Wrecept.Storage/Data/DbInitializer.cs
@@ -31,6 +31,7 @@ public static class DbInitializer
             else
             {
                 await db.Database.EnsureCreatedAsync(ct);
+                await db.Database.MigrateAsync(ct);
             }
         }
         catch (Exception ex)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -58,7 +58,8 @@ Minden domain modell tartalmaz `CreatedAt` és `UpdatedAt` mezőket. Ezeket a se
 
  Az alkalmazás indításakor a `DbInitializer` ellenőrzi, létezik‑e az adatbázis
  és a migrációs napló. Új adatbázis esetén lefuttatja a `Database.Migrate()`
- hívást, meglévő, de napló nélküli fájlnál pedig csak `EnsureCreated()` fut.
+ hívást, meglévő, de napló nélküli fájlnál `EnsureCreated()` után azonnal
+ `Database.Migrate()` következik.
  Az `AddStorage` kiterjesztés ehhez `IDbContextFactory`-t használ,
  így a migráció egy külön kontextuson történik és azonnal eldobásra kerül.
 Az indítás során a `DataSeeder` ellenőrzi, hogy az adatbázis teljesen üres‑e.

--- a/docs/BUILD_RUNTIME_NOTES.md
+++ b/docs/BUILD_RUNTIME_NOTES.md
@@ -28,7 +28,7 @@ Ez a jegyzet a fejlesztés során tapasztalt fordítási és futásidejű probl�
 5. Sémafrissítés után futtassuk le az EF Core migrációkat (`Database.Migrate()`),
    különben futásidőben "no such column" hibát kaphatunk.
 6. Indításkor a `DbInitializer` megnézi, létezik‑e az adatbázis és a migrációs napló.
-   Új adatbázis esetén `Database.Migrate()` fut, meglévő, de napló nélküli fájlnál csak `EnsureCreated()`.
+   Új adatbázis esetén `Database.Migrate()` fut, meglévő, de napló nélküli fájlnál `EnsureCreated()` után rögtön `Database.Migrate()`.
    Ha az adatbázis üres, a felhasználó megerősítheti, hogy Bogus segítségével generált mintaadatok kerüljenek be.
 7. Az `AddStorage` kiterjesztés migrációhoz `IDbContextFactory`-t használ, így a munkakontextus az inicializálás végén eldobásra kerül.
 8. Ha a második adatlekérdezés is `SqliteException`-t dob, a `DataSeeder` a `logs/startup.log` fájlba ír és `Failed` állapotot jelez.

--- a/docs/ERROR_HANDLING.md
+++ b/docs/ERROR_HANDLING.md
@@ -46,7 +46,7 @@ private async void OnKeyDown(object sender, KeyEventArgs e)
 
 1. **Adatbázis fájl hiánya vagy hiányzó elérési út** – Ha az adatbázis helye nincs megadva vagy az `app.db` nem található, a Storage réteg a `%AppData%/Wrecept/app.db` fájlt hozza létre, majd figyelmeztető üzenetet jelenítünk meg.
 2. **Üres adatbázis** – Ha egyetlen táblában sincs adat, minta rekordokat szúrunk be és figyelmeztetjük a felhasználót.
-3. **Sémahibák indításkor** – A `DbInitializer` először ellenőrzi, létezik‑e az adatbázis és a migrációs napló. Ha a napló hiányzik, `EnsureCreated()` fut, ellenkező esetben `Database.Migrate()`. A `DataSeeder` külön kontextust használ, így a DI-ből kapott példány nem marad használatban.
+3. **Sémahibák indításkor** – A `DbInitializer` először ellenőrzi, létezik‑e az adatbázis és a migrációs napló. Ha a napló hiányzik, `EnsureCreated()` után azonnal `Database.Migrate()` fut, ellenkező esetben közvetlenül `Database.Migrate()`. A `DataSeeder` külön kontextust használ, így a DI-ből kapott példány nem marad használatban.
 4. **Sérült konfigurációs fájl** – A `settings.json` olvasásakor `JsonException` vagy `IOException` esetén hibaüzenetet írunk a naplóba és alapértelmezett beállításokkal folytatjuk.
 5. **Sérült import fájl** – Hibás formátumú vagy hiányzó adatfájl betöltésekor megszakítjuk a folyamatot, naplózzuk a fájl nevét és a kiváltó hibát, és lehetőséget adunk új fájl kiválasztására.
 6. **Hálózati kimaradás** – Külső frissítések letöltése közben kapcsolatvesztés esetén újrapróbálkozunk, majd offline módra váltunk, miközben a felhasználót tájékoztatjuk.

--- a/docs/progress/2025-07-03_18-06-28_storage_agent.md
+++ b/docs/progress/2025-07-03_18-06-28_storage_agent.md
@@ -1,0 +1,1 @@
+- DbInitializer now migrates after EnsureCreated when migration history is missing.


### PR DESCRIPTION
## Summary
- run `Database.Migrate()` after `EnsureCreated()` when migration history is missing
- update docs for revised initialization logic
- log progress

## Testing
- `dotnet test --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866c5db7c188322a303e077e9db6a8a