### PR TITLE
Fix inline creator popup binding

### DIFF
--- a/Wrecept.Wpf/Views/InvoiceEditorView.xaml
+++ b/Wrecept.Wpf/Views/InvoiceEditorView.xaml
@@ -208,7 +208,7 @@
         </Grid>
         <Popup Placement="Bottom"
                PlacementTarget="{Binding InlineCreatorTarget}"
-               IsOpen="{Binding IsInlineCreatorVisible}"
+               IsOpen="{Binding IsInlineCreatorVisible, Mode=OneWay}"
                StaysOpen="True"
                AllowsTransparency="True">
             <Border Background="{DynamicResource ControlBackgroundBrush}" BorderBrush="{DynamicResource HighlightBrush}" BorderThickness="1">

--- a/docs/progress/2025-07-03_18-22-07_ui_agent.md
+++ b/docs/progress/2025-07-03_18-22-07_ui_agent.md
@@ -1,0 +1,1 @@
+- Popup IsOpen bindelés egyirányúsítva, megszűnt a TwoWay hiba.


### PR DESCRIPTION
## Summary
- ensure InvoiceEditor popup binding uses OneWay mode
- log UI agent progress

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets missing)*

------
https://chatgpt.com/codex/tasks/task_e_6866c9db6c448322a742498faee034ed