### PR TITLE
Implement FocusTrackerService

### DIFF
--- a/Wrecept.Wpf/App.xaml.cs
+++ b/Wrecept.Wpf/App.xaml.cs
@@ -111,6 +111,7 @@ public static IServiceProvider Provider => Services ?? throw new InvalidOperatio
         services.AddSingleton<StatusBarViewModel>();
         services.AddSingleton<INotificationService, MessageBoxNotificationService>();
         services.AddSingleton<ScreenModeManager>();
+        services.AddSingleton<IFocusTrackerService, FocusTrackerService>();
         services.AddTransient<ProgressViewModel>();
         services.AddTransient<SeedOptionsViewModel>();
         services.AddTransient<SeedOptionsWindow>();

--- a/Wrecept.Wpf/Services/FocusTrackerService.cs
+++ b/Wrecept.Wpf/Services/FocusTrackerService.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+using System.Windows.Input;
+
+namespace Wrecept.Wpf.Services;
+
+public class FocusTrackerService : IFocusTrackerService
+{
+    private readonly Dictionary<string, WeakReference<IInputElement>> _map = new();
+
+    public void Update(string viewKey, IInputElement element)
+    {
+        _map[viewKey] = new WeakReference<IInputElement>(element);
+    }
+
+    public IInputElement? GetLast(string viewKey)
+    {
+        if (_map.TryGetValue(viewKey, out var weak) && weak.TryGetTarget(out var element))
+            return element;
+        return null;
+    }
+}

--- a/Wrecept.Wpf/Services/IFocusTrackerService.cs
+++ b/Wrecept.Wpf/Services/IFocusTrackerService.cs
@@ -1,0 +1,10 @@
+using System.Windows;
+using System.Windows.Input;
+
+namespace Wrecept.Wpf.Services;
+
+public interface IFocusTrackerService
+{
+    void Update(string viewKey, IInputElement element);
+    IInputElement? GetLast(string viewKey);
+}

--- a/Wrecept.Wpf/ViewModels/ArchivePromptViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/ArchivePromptViewModel.cs
@@ -1,6 +1,8 @@
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Microsoft.Extensions.DependencyInjection;
+using Wrecept.Wpf.Services;
 
 namespace Wrecept.Wpf.ViewModels;
 
@@ -20,12 +22,16 @@ public partial class ArchivePromptViewModel : ObservableObject
     {
         await _parent.ArchiveAsync();
         _parent.ArchivePrompt = null;
+        var tracker = App.Provider.GetRequiredService<IFocusTrackerService>();
+        FormNavigator.RequestFocus(tracker.GetLast("InvoiceEditorView"));
     }
 
     [RelayCommand]
     private void Cancel()
     {
         _parent.ArchivePrompt = null;
+        var tracker = App.Provider.GetRequiredService<IFocusTrackerService>();
+        FormNavigator.RequestFocus(tracker.GetLast("InvoiceEditorView"));
     }
 }
 

--- a/Wrecept.Wpf/ViewModels/DeleteItemPromptViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/DeleteItemPromptViewModel.cs
@@ -1,5 +1,7 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Microsoft.Extensions.DependencyInjection;
+using Wrecept.Wpf.Services;
 
 namespace Wrecept.Wpf.ViewModels;
 
@@ -21,11 +23,15 @@ public partial class DeleteItemPromptViewModel : ObservableObject
     {
         _parent.DeleteItemConfirmed(_row);
         _parent.DeletePrompt = null;
+        var tracker = App.Provider.GetRequiredService<IFocusTrackerService>();
+        FormNavigator.RequestFocus(tracker.GetLast("InvoiceEditorView"));
     }
 
     [RelayCommand]
     private void Cancel()
     {
         _parent.DeletePrompt = null;
+        var tracker = App.Provider.GetRequiredService<IFocusTrackerService>();
+        FormNavigator.RequestFocus(tracker.GetLast("InvoiceEditorView"));
     }
 }

--- a/Wrecept.Wpf/ViewModels/InvoiceCreatePromptViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/InvoiceCreatePromptViewModel.cs
@@ -1,6 +1,8 @@
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Microsoft.Extensions.DependencyInjection;
+using Wrecept.Wpf.Services;
 
 namespace Wrecept.Wpf.ViewModels;
 
@@ -23,11 +25,15 @@ public partial class InvoiceCreatePromptViewModel : ObservableObject
     {
         await _parent.CreateInvoiceAsync(Number);
         _parent.InlinePrompt = null;
+        var tracker = App.Provider.GetRequiredService<IFocusTrackerService>();
+        FormNavigator.RequestFocus(tracker.GetLast("InvoiceEditorView"));
     }
 
     [RelayCommand]
     private void Cancel()
     {
         _parent.InlinePrompt = null;
+        var tracker = App.Provider.GetRequiredService<IFocusTrackerService>();
+        FormNavigator.RequestFocus(tracker.GetLast("InvoiceEditorView"));
     }
 }

--- a/Wrecept.Wpf/ViewModels/SaveLinePromptViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/SaveLinePromptViewModel.cs
@@ -2,6 +2,8 @@ using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Wrecept.Wpf.Views;
+using Microsoft.Extensions.DependencyInjection;
+using Wrecept.Wpf.Services;
 
 namespace Wrecept.Wpf.ViewModels;
 
@@ -30,15 +32,17 @@ public partial class SaveLinePromptViewModel : ObservableObject
             await _parent.AddLineItemAsync();
         _parent.SavePrompt = null;
         _parent.IsInLineFinalizationPrompt = false;
+        var tracker = App.Provider.GetRequiredService<IFocusTrackerService>();
+        FormNavigator.RequestFocus(tracker.GetLast("InvoiceEditorView"));
     }
 
     [RelayCommand]
     private void Cancel()
     {
         _parent.SavePrompt = null;
-        if (_finalize)
-            FormNavigator.RequestFocus(_parent.LastFocusedField, typeof(InvoiceEditorView));
         _parent.IsInLineFinalizationPrompt = false;
+        var tracker = App.Provider.GetRequiredService<IFocusTrackerService>();
+        FormNavigator.RequestFocus(tracker.GetLast("InvoiceEditorView"));
     }
 }
 

--- a/Wrecept.Wpf/Views/Controls/BaseMasterView.cs
+++ b/Wrecept.Wpf/Views/Controls/BaseMasterView.cs
@@ -4,6 +4,8 @@ using System.Windows.Controls;
 using System.Windows.Input;
 using Wrecept.Wpf.ViewModels;
 using System.Windows.Data;
+using Microsoft.Extensions.DependencyInjection;
+using Wrecept.Wpf.Services;
 
 namespace Wrecept.Wpf.Views.Controls;
 
@@ -15,11 +17,15 @@ public abstract class BaseMasterView : UserControl
 
     protected DataGrid Grid { get; }
 
+    private readonly IFocusTrackerService _tracker;
+
     protected BaseMasterView()
     {
         Grid = BuildLayout();
         Loaded += OnLoaded;
         KeyDown += OnKeyDown;
+        _tracker = App.Provider.GetRequiredService<IFocusTrackerService>();
+        Keyboard.AddGotKeyboardFocusHandler(this, OnGotKeyboardFocus);
     }
 
     private DataGrid BuildLayout()
@@ -106,6 +112,9 @@ public abstract class BaseMasterView : UserControl
             e.Handled = true;
         }
     }
+
+    private void OnGotKeyboardFocus(object sender, KeyboardFocusChangedEventArgs e)
+        => _tracker.Update(GetType().Name, e.NewFocus);
 
     private void Grid_RowDetailsVisibilityChanged(object? sender, DataGridRowDetailsEventArgs e)
     {

--- a/Wrecept.Wpf/Views/InvoiceEditorView.xaml.cs
+++ b/Wrecept.Wpf/Views/InvoiceEditorView.xaml.cs
@@ -7,11 +7,13 @@ using Wrecept.Wpf.ViewModels;
 using Wrecept.Core.Services;
 using Wrecept.Core.Utilities;
 using Wrecept.Wpf;
+using Wrecept.Wpf.Services;
 
 namespace Wrecept.Wpf.Views;
 
 public partial class InvoiceEditorView : UserControl
 {
+    private readonly IFocusTrackerService _tracker;
     public InvoiceEditorView() : this(App.Provider.GetRequiredService<InvoiceEditorViewModel>())
     {
     }
@@ -20,6 +22,8 @@ public partial class InvoiceEditorView : UserControl
     {
         InitializeComponent();
         DataContext = viewModel;
+        _tracker = App.Provider.GetRequiredService<IFocusTrackerService>();
+        Keyboard.AddGotKeyboardFocusHandler(this, OnGotKeyboardFocus);
         Loaded += async (_, _) =>
         {
             var progressVm = new ProgressViewModel();
@@ -87,4 +91,7 @@ public partial class InvoiceEditorView : UserControl
             await log.LogError("InvoiceEditorView.OnEntryKeyDown", ex);
         }
     }
+
+    private void OnGotKeyboardFocus(object sender, KeyboardFocusChangedEventArgs e)
+        => _tracker.Update("InvoiceEditorView", e.NewFocus);
 }

--- a/Wrecept.Wpf/Views/StageView.xaml.cs
+++ b/Wrecept.Wpf/Views/StageView.xaml.cs
@@ -2,6 +2,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using Wrecept.Wpf.ViewModels;
+using Wrecept.Wpf.Services;
 
 namespace Wrecept.Wpf.Views;
 
@@ -9,12 +10,14 @@ public partial class StageView : UserControl
 {
     private readonly StageViewModel _viewModel;
     private MenuItem? _lastMenuItem;
+    private readonly IFocusTrackerService _tracker;
 
     public StageView(StageViewModel viewModel)
     {
         InitializeComponent();
         _viewModel = viewModel;
         DataContext = viewModel;
+        _tracker = App.Provider.GetRequiredService<IFocusTrackerService>();
         Keyboard.AddGotKeyboardFocusHandler(this, OnGotKeyboardFocus);
     }
 
@@ -46,6 +49,7 @@ public partial class StageView : UserControl
     private void OnGotKeyboardFocus(object sender, KeyboardFocusChangedEventArgs e)
     {
         var fe = e.NewFocus as FrameworkElement;
+        _tracker.Update("StageView", e.NewFocus);
         _viewModel.StatusBar.FocusedElement = fe?.Name ?? fe?.GetType().Name ?? string.Empty;
     }
 }

--- a/docs/KeyboardFlow.md
+++ b/docs/KeyboardFlow.md
@@ -51,6 +51,7 @@ Az `ArchivePromptView`, `SaveLinePromptView` és `InvoiceCreatePromptView` egyar
 - `Escape` a mégse parancsot hívja.
 - Többsoros `TextBox` (`AcceptsReturn=true`) esetén a `NavigationHelper` sem az `Enter`, sem az `Escape` billentyűt nem kezeli, így az új sor bevitele és a vezérlő saját művelete zavartalan.
 A fókusz a prompt bezárása után visszatér a megnyitó nézethez.
+Ezt a `FocusTrackerService` végzi, amely nézetenként rögzíti az utoljára fókuszba került vezérlőt.
 
 ## 📋 Focus Reset Rules
 

--- a/docs/UI_FLOW.md
+++ b/docs/UI_FLOW.md
@@ -134,6 +134,7 @@ Menu state persists across Escape presses to return user to most recent focus
 The FormNavigator.RequestFocus helper now accepts an optional view-type
 parameter to narrow the search scope; dynamic elements therefore need not use
 globally unique identifiers.
+FocusTrackerService jegyzi meg, melyik vezérlő volt aktív a nézetekben, így a promptok bezárásakor visszaállítható a fókusz.
 
 📚 Future List Views
 

--- a/docs/progress/2025-07-03_19-03-23_code_agent.md
+++ b/docs/progress/2025-07-03_19-03-23_code_agent.md
@@ -1,0 +1,5 @@
+- FocusTrackerService bevezetve, nézetenként tárolja az utolsó fókuszált elemet.
+- StageView, InvoiceEditorView és BaseMasterView frissítve a fókuszkövetéshez.
+- Prompt ViewModel-ek bezáráskor visszaállítják a fókuszt a szolgáltatás segítségével.
+- Dokumentáció kiegészítve a fókuszszabályokkal.
+- Új unit teszt ellenőrzi a FocusTrackerService működését.

--- a/tests/Wrecept.Tests/FocusTrackerServiceTests.cs
+++ b/tests/Wrecept.Tests/FocusTrackerServiceTests.cs
@@ -1,0 +1,30 @@
+using System.Windows.Controls;
+using Xunit;
+using Wrecept.Wpf.Services;
+
+namespace Wrecept.Tests;
+
+public class FocusTrackerServiceTests
+{
+    [Fact]
+    public void GetLast_ReturnsNull_WhenNotTracked()
+    {
+        var tracker = new FocusTrackerService();
+        Assert.Null(tracker.GetLast("Any"));
+    }
+
+    [Fact]
+    public void Update_StoresLastElement_PerView()
+    {
+        var tracker = new FocusTrackerService();
+        var first = new TextBox();
+        var second = new TextBox();
+
+        tracker.Update("ViewA", first);
+        tracker.Update("ViewA", second);
+        tracker.Update("ViewB", first);
+
+        Assert.Same(second, tracker.GetLast("ViewA"));
+        Assert.Same(first, tracker.GetLast("ViewB"));
+    }
+}


### PR DESCRIPTION
## Summary
- add FocusTrackerService to track last focused control per view
- register focus tracking in DI and main views
- use tracker in prompt close logic
- document focus tracking rules
- add unit tests and progress log

## Testing
- `dotnet build --no-restore` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*
- `dotnet test --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866d2136ab08322ab4d975252db0b3a