### PR TITLE
Update focus tracker docs

### DIFF
--- a/docs/KeyboardFlow.md
+++ b/docs/KeyboardFlow.md
@@ -62,6 +62,10 @@ Application.Current.MainWindow?.Focus();
 Más ablakokban a billentyűt a saját logikájuk kezeli.
 Az `Enter` alapértelmezésben a következő vezérlőre ugrik, ha az aktuális kezelő nem nyeli el.
 
+### Fókuszkövető szolgáltatás
+
+Az `IFocusTrackerService` a nézetekhez rendelt kulcs alapján megjegyzi az utoljára fókuszba került vezérlőt. A promptok vagy nézetek bezárásakor a `FormNavigator` ennek segítségével állítja vissza a fókuszt az eredeti elemre. A szolgáltatás singletonként regisztrált, így minden View és ViewModel DI-n keresztül éri el.
+
 ## 💡 Design Philosophy
 
 A billentyűzetes navigációt a sebesség és az időtálló megszokhatóság jegyében terveztük. Minden akció egzaktul megismételhető, vizuális visszajelzéssel kombinálva.

--- a/docs/UI_FLOW.md
+++ b/docs/UI_FLOW.md
@@ -18,6 +18,13 @@ Enter: Activates the selected submenu view and focuses the first control
 
 Escape: Returns to menu with last selected item focused
 
+- Fókuszkezdő pontok nézetenként:
+  - **StageView** – a főmenüsor első eleme
+  - **InvoiceLookupView** – `InvoiceList` `ListBox`
+  - **InvoiceEditorView** – bal oldali `InvoiceList`
+  - **ProductMasterView** – a táblázat (Grid)
+  - **SupplierMasterView** – a táblázat (Grid)
+
 🧾 Invoice Editor Flow (Bejövő szállítólevelek)
 
 1. Invoice Number Field (Lookup & Creation)

--- a/docs/progress/2025-07-03_19-19-43_docs_agent.md
+++ b/docs/progress/2025-07-03_19-19-43_docs_agent.md
@@ -1,0 +1,2 @@
+- KeyboardFlow.md-ben új "Fókuszkövető szolgáltatás" alcím és rövid leírás került a FocusTrackerService-ről.
+- UI_FLOW.md "Navigation Model" alá lista került a fókuszkezdő pontokról.


### PR DESCRIPTION
## Summary
- document focus tracker service usage in `KeyboardFlow.md`
- list focus starting elements under navigation model in `UI_FLOW.md`
- log changes

## Testing
- `dotnet test --no-build` *(fails: missing Microsoft.NET.Sdk.WindowsDesktop)*

------
https://chatgpt.com/codex/tasks/task_e_6866d74efc9083228944fc23e6d3e645