### PR TITLE
Add RequestFocus overload and update viewmodels

### DIFF
--- a/Wrecept.Wpf/FormNavigator.cs
+++ b/Wrecept.Wpf/FormNavigator.cs
@@ -7,6 +7,11 @@ namespace Wrecept.Wpf;
 
 public static class FormNavigator
 {
+    public static void RequestFocus(IInputElement? element)
+    {
+        Application.Current.Dispatcher.BeginInvoke(() => element?.Focus(), DispatcherPriority.Background);
+    }
+
     public static void RequestFocus(string elementName, Type? viewType = null)
     {
         Application.Current.Dispatcher.BeginInvoke(() =>

--- a/Wrecept.Wpf/ViewModels/ArchivePromptViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/ArchivePromptViewModel.cs
@@ -23,7 +23,8 @@ public partial class ArchivePromptViewModel : ObservableObject
         await _parent.ArchiveAsync();
         _parent.ArchivePrompt = null;
         var tracker = App.Provider.GetRequiredService<IFocusTrackerService>();
-        FormNavigator.RequestFocus(tracker.GetLast("InvoiceEditorView"));
+        var last = tracker.GetLast("InvoiceEditorView");
+        FormNavigator.RequestFocus(last);
     }
 
     [RelayCommand]
@@ -31,7 +32,8 @@ public partial class ArchivePromptViewModel : ObservableObject
     {
         _parent.ArchivePrompt = null;
         var tracker = App.Provider.GetRequiredService<IFocusTrackerService>();
-        FormNavigator.RequestFocus(tracker.GetLast("InvoiceEditorView"));
+        var last = tracker.GetLast("InvoiceEditorView");
+        FormNavigator.RequestFocus(last);
     }
 }
 

--- a/Wrecept.Wpf/ViewModels/DeleteItemPromptViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/DeleteItemPromptViewModel.cs
@@ -24,7 +24,8 @@ public partial class DeleteItemPromptViewModel : ObservableObject
         _parent.DeleteItemConfirmed(_row);
         _parent.DeletePrompt = null;
         var tracker = App.Provider.GetRequiredService<IFocusTrackerService>();
-        FormNavigator.RequestFocus(tracker.GetLast("InvoiceEditorView"));
+        var last = tracker.GetLast("InvoiceEditorView");
+        FormNavigator.RequestFocus(last);
     }
 
     [RelayCommand]
@@ -32,6 +33,7 @@ public partial class DeleteItemPromptViewModel : ObservableObject
     {
         _parent.DeletePrompt = null;
         var tracker = App.Provider.GetRequiredService<IFocusTrackerService>();
-        FormNavigator.RequestFocus(tracker.GetLast("InvoiceEditorView"));
+        var last = tracker.GetLast("InvoiceEditorView");
+        FormNavigator.RequestFocus(last);
     }
 }

--- a/Wrecept.Wpf/ViewModels/InvoiceCreatePromptViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/InvoiceCreatePromptViewModel.cs
@@ -26,7 +26,8 @@ public partial class InvoiceCreatePromptViewModel : ObservableObject
         await _parent.CreateInvoiceAsync(Number);
         _parent.InlinePrompt = null;
         var tracker = App.Provider.GetRequiredService<IFocusTrackerService>();
-        FormNavigator.RequestFocus(tracker.GetLast("InvoiceEditorView"));
+        var last = tracker.GetLast("InvoiceEditorView");
+        FormNavigator.RequestFocus(last);
     }
 
     [RelayCommand]
@@ -34,6 +35,7 @@ public partial class InvoiceCreatePromptViewModel : ObservableObject
     {
         _parent.InlinePrompt = null;
         var tracker = App.Provider.GetRequiredService<IFocusTrackerService>();
-        FormNavigator.RequestFocus(tracker.GetLast("InvoiceEditorView"));
+        var last = tracker.GetLast("InvoiceEditorView");
+        FormNavigator.RequestFocus(last);
     }
 }

--- a/Wrecept.Wpf/ViewModels/SaveLinePromptViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/SaveLinePromptViewModel.cs
@@ -33,7 +33,8 @@ public partial class SaveLinePromptViewModel : ObservableObject
         _parent.SavePrompt = null;
         _parent.IsInLineFinalizationPrompt = false;
         var tracker = App.Provider.GetRequiredService<IFocusTrackerService>();
-        FormNavigator.RequestFocus(tracker.GetLast("InvoiceEditorView"));
+        var last = tracker.GetLast("InvoiceEditorView");
+        FormNavigator.RequestFocus(last);
     }
 
     [RelayCommand]
@@ -42,7 +43,8 @@ public partial class SaveLinePromptViewModel : ObservableObject
         _parent.SavePrompt = null;
         _parent.IsInLineFinalizationPrompt = false;
         var tracker = App.Provider.GetRequiredService<IFocusTrackerService>();
-        FormNavigator.RequestFocus(tracker.GetLast("InvoiceEditorView"));
+        var last = tracker.GetLast("InvoiceEditorView");
+        FormNavigator.RequestFocus(last);
     }
 }
 

--- a/docs/progress/2025-07-03_19-33-43_code_agent.md
+++ b/docs/progress/2025-07-03_19-33-43_code_agent.md
@@ -1,0 +1,3 @@
+# FormNavigator kiterjesztése
+- Új `RequestFocus(IInputElement?)` metódus a fókusz visszaállításához.
+- Prompt ViewModel-ek frissítve, hogy az új metódust hívják.


### PR DESCRIPTION
## Summary
- add IInputElement overload to `FormNavigator.RequestFocus`
- use the new overload in prompt viewmodels
- log progress

## Testing
- `dotnet test --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866da4b2dd4832284e16b27d3547f59