### PR TITLE
Fix StageView dependency

### DIFF
--- a/Wrecept.Wpf/Views/StageView.xaml.cs
+++ b/Wrecept.Wpf/Views/StageView.xaml.cs
@@ -1,6 +1,7 @@
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
+using Microsoft.Extensions.DependencyInjection;
 using Wrecept.Wpf.ViewModels;
 using Wrecept.Wpf.Services;
 

--- a/docs/progress/2025-07-03_19-46-57_code_agent.md
+++ b/docs/progress/2025-07-03_19-46-57_code_agent.md
@@ -1,0 +1,2 @@
+- StageView.xaml.cs-ben pótoltam a `Microsoft.Extensions.DependencyInjection` névteret, így a `GetRequiredService` hívás fordul.
+- Build lefuttatva, de hiányzik a WindowsDesktop SDK, ezért a WPF projektek nem fordulnak.


### PR DESCRIPTION
## Summary
- reference Microsoft.Extensions.DependencyInjection for StageView
- log progress

## Testing
- `dotnet build Wrecept.sln -c Debug` *(fails: Microsoft.NET.Sdk.WindowsDesktop missing)*
- `dotnet test tests/Wrecept.Tests/Wrecept.Tests.csproj -c Debug` *(fails: Wrecept.Wpf incompatible)*

------
https://chatgpt.com/codex/tasks/task_e_6866dd52b0488322957d1f4e7f91bfef