### PR TITLE
Fix InlineCreator product name handling

### DIFF
--- a/Wrecept.Wpf/ViewModels/InvoiceEditorViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/InvoiceEditorViewModel.cs
@@ -336,9 +336,10 @@ private void UpdateSupplierId(string name)
         if (parameter is UIElement target && target is FrameworkElement fe && fe.DataContext is InvoiceItemRowViewModel row)
         {
             InlineCreatorTarget = target;
+            var name = (target as Views.Controls.SmartLookup)?.Text ?? row.Product;
             InlineCreator = new ProductCreatorViewModel(this, row, _productsService)
             {
-                Name = row.Product
+                Name = name
             };
         }
     }

--- a/docs/progress/2025-07-03_20-04-10_code_agent.md
+++ b/docs/progress/2025-07-03_20-04-10_code_agent.md
@@ -1,0 +1,1 @@
+- ShowProductCreator most már a SmartLookup.Text értékét használja, így az InlineCreator megkapja a gépelt terméknevet.


### PR DESCRIPTION
## Summary
- ensure SmartLookup text is forwarded to ProductCreator
- log progress

## Testing
- `dotnet test Wrecept.Core.Tests/Wrecept.Core.Tests.csproj --no-build --no-restore -v q`
- `dotnet test tests/Wrecept.Tests/Wrecept.Tests.csproj --no-build --no-restore -v n`
- `dotnet test tests/Wrecept.UiTests/Wrecept.UiTests.csproj --no-build --no-restore -v q` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866e0f78b688322bbfa14393d1bfb81