### PR TITLE
Improve focus behavior for inline creators

### DIFF
--- a/Wrecept.Wpf/Views/InlineCreators/PaymentMethodCreatorView.xaml
+++ b/Wrecept.Wpf/Views/InlineCreators/PaymentMethodCreatorView.xaml
@@ -1,13 +1,14 @@
 <UserControl x:Class="Wrecept.Wpf.Views.InlineCreators.PaymentMethodCreatorView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             KeyDown="OnKeyDown">
+             KeyDown="OnKeyDown"
+             FocusManager.FocusedElement="{Binding ElementName=NameBox}">
     <Border Background="#F5F5DC" Padding="4" Margin="0,4,0,0">
         <StackPanel>
             <TextBlock Text="Új fizetési mód" FontWeight="Bold" />
             <StackPanel Orientation="Horizontal" Margin="0,4,0,0">
                 <TextBlock Text="Név" Width="60" />
-                <TextBox Width="160" Text="{Binding Name}" />
+                <TextBox x:Name="NameBox" Width="160" Text="{Binding Name}" />
             </StackPanel>
             <StackPanel Orientation="Horizontal" Margin="0,4,0,0">
                 <TextBlock Text="Határidő" Width="60" />

--- a/Wrecept.Wpf/Views/InlineCreators/ProductCreatorView.xaml
+++ b/Wrecept.Wpf/Views/InlineCreators/ProductCreatorView.xaml
@@ -2,13 +2,14 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="clr-namespace:Wrecept.Wpf.ViewModels"
-             KeyDown="OnKeyDown">
+             KeyDown="OnKeyDown"
+             FocusManager.FocusedElement="{Binding ElementName=NameBox}">
     <Border Background="#F5F5DC" Padding="4" Margin="0,4,0,0">
         <StackPanel>
             <TextBlock Text="Új termék" FontWeight="Bold" />
             <StackPanel Orientation="Horizontal" Margin="0,4,0,0">
                 <TextBlock Text="Név" Width="60" />
-                <TextBox Width="160" Text="{Binding Name}" />
+                <TextBox x:Name="NameBox" Width="160" Text="{Binding Name}" />
             </StackPanel>
             <StackPanel Orientation="Horizontal" Margin="0,4,0,0">
                 <TextBlock Text="Nettó" Width="60" />

--- a/Wrecept.Wpf/Views/InlineCreators/SupplierCreatorView.xaml
+++ b/Wrecept.Wpf/Views/InlineCreators/SupplierCreatorView.xaml
@@ -1,13 +1,14 @@
 <UserControl x:Class="Wrecept.Wpf.Views.InlineCreators.SupplierCreatorView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             KeyDown="OnKeyDown">
+             KeyDown="OnKeyDown"
+             FocusManager.FocusedElement="{Binding ElementName=NameBox}">
     <Border Background="#F5F5DC" Padding="4" Margin="0,4,0,0">
         <StackPanel>
             <TextBlock Text="Új szállító" FontWeight="Bold" />
             <StackPanel Orientation="Horizontal" Margin="0,4,0,0">
                 <TextBlock Text="Név" Width="60" />
-                <TextBox Width="160" Text="{Binding Name}" />
+                <TextBox x:Name="NameBox" Width="160" Text="{Binding Name}" />
             </StackPanel>
             <StackPanel Orientation="Horizontal" Margin="0,4,0,0">
                 <Button Content="OK" Command="{Binding ConfirmCommand}" Width="60" Margin="0,0,4,0" />

--- a/Wrecept.Wpf/Views/InlineCreators/TaxRateCreatorView.xaml
+++ b/Wrecept.Wpf/Views/InlineCreators/TaxRateCreatorView.xaml
@@ -1,13 +1,14 @@
 <UserControl x:Class="Wrecept.Wpf.Views.InlineCreators.TaxRateCreatorView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             KeyDown="OnKeyDown">
+             KeyDown="OnKeyDown"
+             FocusManager.FocusedElement="{Binding ElementName=NameBox}">
     <Border Background="#F5F5DC" Padding="4" Margin="0,4,0,0">
         <StackPanel>
             <TextBlock Text="Új ÁFA kulcs" FontWeight="Bold" />
             <StackPanel Orientation="Horizontal" Margin="0,4,0,0">
                 <TextBlock Text="Név" Width="60" />
-                <TextBox Width="120" Text="{Binding Name}" />
+                <TextBox x:Name="NameBox" Width="120" Text="{Binding Name}" />
             </StackPanel>
             <StackPanel Orientation="Horizontal" Margin="0,4,0,0">
                 <TextBlock Text="%" Width="60" />

--- a/Wrecept.Wpf/Views/InlineCreators/UnitCreatorView.xaml
+++ b/Wrecept.Wpf/Views/InlineCreators/UnitCreatorView.xaml
@@ -1,13 +1,14 @@
 <UserControl x:Class="Wrecept.Wpf.Views.InlineCreators.UnitCreatorView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             KeyDown="OnKeyDown">
+             KeyDown="OnKeyDown"
+             FocusManager.FocusedElement="{Binding ElementName=NameBox}">
     <Border Background="#F5F5DC" Padding="4" Margin="0,4,0,0">
         <StackPanel>
             <TextBlock Text="Új mértékegység" FontWeight="Bold" />
             <StackPanel Orientation="Horizontal" Margin="0,4,0,0">
                 <TextBlock Text="Név" Width="60" />
-                <TextBox Width="120" Text="{Binding Name}" />
+                <TextBox x:Name="NameBox" Width="120" Text="{Binding Name}" />
             </StackPanel>
             <StackPanel Orientation="Horizontal" Margin="0,4,0,0">
                 <Button Content="OK" Command="{Binding ConfirmCommand}" Width="60" Margin="0,0,4,0" />

--- a/Wrecept.Wpf/Views/InvoiceEditorView.xaml.cs
+++ b/Wrecept.Wpf/Views/InvoiceEditorView.xaml.cs
@@ -101,7 +101,12 @@ public partial class InvoiceEditorView : UserControl
         Dispatcher.BeginInvoke(() =>
         {
             if (InlineCreatorHost.Content is FrameworkElement fe)
-                fe.MoveFocus(new TraversalRequest(FocusNavigationDirection.First));
+            {
+                if (fe.FindName("NameBox") is IInputElement box)
+                    Keyboard.Focus(box);
+                else
+                    fe.MoveFocus(new TraversalRequest(FocusNavigationDirection.First));
+            }
         }, DispatcherPriority.Background);
     }
 }

--- a/docs/InlineEntityCreation.md
+++ b/docs/InlineEntityCreation.md
@@ -2,7 +2,7 @@
 title: "Inline Entity Creation"
 purpose: "Rövid technikai leírás az inline entitás létrehozásáról"
 author: "docs_agent"
-date: "2025-06-30"
+date: "2025-07-03"
 ---
 
 # Inline Entity Creation
@@ -18,6 +18,9 @@ Korábban a űrlap a DataGrid `RowDetailsTemplate` elemében jelent meg, ám ez 
 | [OK] [Mégse]          |
 +-----------------------+
 ```
+
+Az űrlap megnyitásakor a kurzor automatikusan az első mezőre kerül, így a
+felhasználó további billentyűk nélkül kezdheti el a gépelést.
 
 A kitöltött űrlap mentése azonnal létrehozza az entitást és a szerkesztett sorban is frissíti a hivatkozást. Minden más vezérlő ideiglenesen letiltásra kerül, hogy a fókusz az új bejegyzésen maradjon.
 

--- a/docs/progress/2025-07-03_20-22-23_logic_agent.md
+++ b/docs/progress/2025-07-03_20-22-23_logic_agent.md
@@ -1,0 +1,3 @@
+- Inline creator views now set FocusManager.FocusedElement to NameBox.
+- OnInlineCreatorOpened searches NameBox and focuses it.
+- Documentation updated with automatic focus note.


### PR DESCRIPTION
## Summary
- set `NameBox` as the first field in all inline creator views
- ensure popup focus on `NameBox` when opened
- document automatic focus logic
- log progress

## Testing
- `dotnet test Wrecept.sln --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866e597fd2c8322ae93fc7ebaadf90d