### PR TITLE
Fix StageView focus loss when using arrows

### DIFF
--- a/Wrecept.Wpf/Views/StageView.xaml.cs
+++ b/Wrecept.Wpf/Views/StageView.xaml.cs
@@ -39,6 +39,17 @@ public partial class StageView : UserControl
             return;
         }
 
+        if (e.Key is Key.Up or Key.Down && e.OriginalSource == this)
+        {
+            var last = _tracker.GetLast("StageView") as IInputElement;
+            if (last is not null && !ReferenceEquals(last, this))
+            {
+                FormNavigator.RequestFocus(last);
+                e.Handled = true;
+                return;
+            }
+        }
+
         NavigationHelper.Handle(e);
     }
 

--- a/docs/progress/2025-07-03_20-33-13_code_agent.md
+++ b/docs/progress/2025-07-03_20-33-13_code_agent.md
@@ -1,0 +1,2 @@
+- StageView navigáció javítva: ha a fel/le nyíl a StageView-n kap fókuszt, az utolsó vezérlőre áll vissza.
+- Új unit teszt ellenőrzi a viselkedést.

--- a/tests/Wrecept.Tests/StageViewFocusTests.cs
+++ b/tests/Wrecept.Tests/StageViewFocusTests.cs
@@ -63,4 +63,29 @@ public class StageViewFocusTests
         Assert.True(escape.Handled);
         Assert.Same(second, last);
     }
+
+    [Fact]
+    public void ArrowKeyRestoresLastFocusedElement()
+    {
+        var view = CreateView(out _, out _);
+        var type = view.GetType();
+
+        var focusMethod = type.GetMethod("OnGotKeyboardFocus", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        var keyMethod = type.GetMethod("OnKeyDown", BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+        var box = new TextBox();
+        var focusArgs = new KeyboardFocusChangedEventArgs(Keyboard.PrimaryDevice, 0, null, box) { RoutedEvent = Keyboard.GotKeyboardFocusEvent };
+        focusMethod.Invoke(view, new object[] { view, focusArgs });
+
+        var down = new KeyEventArgs(Keyboard.PrimaryDevice, new FakeSource(), 0, Key.Down)
+        {
+            RoutedEvent = Keyboard.KeyDownEvent,
+            Source = view,
+            OriginalSource = view
+        };
+
+        keyMethod.Invoke(view, new object[] { view, down });
+
+        Assert.True(down.Handled);
+    }
 }


### PR DESCRIPTION
## Summary
- keep StageView from jumping to menu when arrow keys are pressed
- test that arrow keys restore the last focused control
- log progress

## Testing
- `dotnet test --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866e5b425648322a098a32c1373fe33