### PR TITLE
Introduce KeyboardManager and FocusManager

### DIFF
--- a/Wrecept.Wpf/App.xaml.cs
+++ b/Wrecept.Wpf/App.xaml.cs
@@ -112,6 +112,8 @@ public static IServiceProvider Provider => Services ?? throw new InvalidOperatio
         services.AddSingleton<INotificationService, MessageBoxNotificationService>();
         services.AddSingleton<ScreenModeManager>();
         services.AddSingleton<IFocusTrackerService, FocusTrackerService>();
+        services.AddSingleton<KeyboardManager>();
+        services.AddSingleton<FocusManager>();
         services.AddTransient<ProgressViewModel>();
         services.AddTransient<SeedOptionsViewModel>();
         services.AddTransient<SeedOptionsWindow>();

--- a/Wrecept.Wpf/Services/FocusManager.cs
+++ b/Wrecept.Wpf/Services/FocusManager.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Windows;
+using System.Windows.Threading;
+using System.Windows.Media;
+
+namespace Wrecept.Wpf.Services;
+
+public class FocusManager
+{
+    public void RequestFocus(IInputElement? element)
+    {
+        Application.Current.Dispatcher.BeginInvoke(() => element?.Focus(), DispatcherPriority.Background);
+    }
+
+    public void RequestFocus(string elementName, Type? viewType = null)
+    {
+        Application.Current.Dispatcher.BeginInvoke(() =>
+        {
+            if (Application.Current.MainWindow is null)
+                return;
+
+            DependencyObject root = Application.Current.MainWindow;
+            if (viewType != null)
+            {
+                var view = FindElement(root, viewType);
+                if (view != null)
+                    root = view;
+            }
+
+            var target = FindElement(root, elementName);
+            (target as IInputElement)?.Focus();
+        }, DispatcherPriority.Background);
+    }
+
+    private static DependencyObject? FindElement(DependencyObject parent, string name)
+    {
+        for (int i = 0; i < VisualTreeHelper.GetChildrenCount(parent); i++)
+        {
+            var child = VisualTreeHelper.GetChild(parent, i);
+            if (child is FrameworkElement fe && fe.Name == name)
+                return fe;
+            var result = FindElement(child, name);
+            if (result != null)
+                return result;
+        }
+        return null;
+    }
+
+    private static DependencyObject? FindElement(DependencyObject parent, Type targetType)
+    {
+        if (parent.GetType() == targetType)
+            return parent;
+
+        for (int i = 0; i < VisualTreeHelper.GetChildrenCount(parent); i++)
+        {
+            var child = VisualTreeHelper.GetChild(parent, i);
+            var result = FindElement(child, targetType);
+            if (result != null)
+                return result;
+        }
+        return null;
+    }
+}

--- a/Wrecept.Wpf/Services/KeyboardManager.cs
+++ b/Wrecept.Wpf/Services/KeyboardManager.cs
@@ -1,0 +1,65 @@
+using System.Windows;
+using System.Windows.Input;
+using System.Windows.Controls;
+
+namespace Wrecept.Wpf.Services;
+
+public enum NavigationProfile
+{
+    Default,
+    Disabled
+}
+
+public class KeyboardManager
+{
+    public NavigationProfile Profile { get; set; } = NavigationProfile.Default;
+
+    public void Handle(KeyEventArgs e)
+    {
+        if (Profile == NavigationProfile.Disabled)
+            return;
+
+        var element = e.OriginalSource as UIElement;
+
+        if (e.OriginalSource is DependencyObject d)
+        {
+            if ((e.Key is Key.Up or Key.Down) &&
+                (d.FindAncestor<ListBox>() is not null ||
+                 d.FindAncestor<DataGrid>() is not null ||
+                 d.FindAncestor<ComboBox>() is not null ||
+                 d.FindAncestor<TreeView>() is not null ||
+                 d.FindAncestor<Menu>() is not null ||
+                 d.FindAncestor<MenuItem>() is not null))
+            {
+                return;
+            }
+        }
+
+        if ((e.Key is Key.Enter or Key.Escape) &&
+            e.OriginalSource is TextBox box &&
+            box.AcceptsReturn)
+        {
+            return;
+        }
+
+        switch (e.Key)
+        {
+            case Key.Down:
+            case Key.Enter:
+                e.Handled = true;
+                element?.MoveFocus(new TraversalRequest(FocusNavigationDirection.Next));
+                break;
+            case Key.Up:
+                e.Handled = true;
+                element?.MoveFocus(new TraversalRequest(FocusNavigationDirection.Previous));
+                break;
+            case Key.Escape:
+                if (Window.GetWindow(element) == Application.Current.MainWindow)
+                {
+                    e.Handled = true;
+                    Application.Current.MainWindow?.Focus();
+                }
+                break;
+        }
+    }
+}

--- a/Wrecept.Wpf/ViewModels/ArchivePromptViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/ArchivePromptViewModel.cs
@@ -23,8 +23,9 @@ public partial class ArchivePromptViewModel : ObservableObject
         await _parent.ArchiveAsync();
         _parent.ArchivePrompt = null;
         var tracker = App.Provider.GetRequiredService<IFocusTrackerService>();
+        var focus = App.Provider.GetRequiredService<FocusManager>();
         var last = tracker.GetLast("InvoiceEditorView");
-        FormNavigator.RequestFocus(last);
+        focus.RequestFocus(last);
     }
 
     [RelayCommand]
@@ -32,8 +33,9 @@ public partial class ArchivePromptViewModel : ObservableObject
     {
         _parent.ArchivePrompt = null;
         var tracker = App.Provider.GetRequiredService<IFocusTrackerService>();
+        var focus = App.Provider.GetRequiredService<FocusManager>();
         var last = tracker.GetLast("InvoiceEditorView");
-        FormNavigator.RequestFocus(last);
+        focus.RequestFocus(last);
     }
 }
 

--- a/Wrecept.Wpf/ViewModels/DeleteItemPromptViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/DeleteItemPromptViewModel.cs
@@ -24,8 +24,9 @@ public partial class DeleteItemPromptViewModel : ObservableObject
         _parent.DeleteItemConfirmed(_row);
         _parent.DeletePrompt = null;
         var tracker = App.Provider.GetRequiredService<IFocusTrackerService>();
+        var focus = App.Provider.GetRequiredService<FocusManager>();
         var last = tracker.GetLast("InvoiceEditorView");
-        FormNavigator.RequestFocus(last);
+        focus.RequestFocus(last);
     }
 
     [RelayCommand]
@@ -33,7 +34,8 @@ public partial class DeleteItemPromptViewModel : ObservableObject
     {
         _parent.DeletePrompt = null;
         var tracker = App.Provider.GetRequiredService<IFocusTrackerService>();
+        var focus = App.Provider.GetRequiredService<FocusManager>();
         var last = tracker.GetLast("InvoiceEditorView");
-        FormNavigator.RequestFocus(last);
+        focus.RequestFocus(last);
     }
 }

--- a/Wrecept.Wpf/ViewModels/InvoiceCreatePromptViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/InvoiceCreatePromptViewModel.cs
@@ -26,8 +26,9 @@ public partial class InvoiceCreatePromptViewModel : ObservableObject
         await _parent.CreateInvoiceAsync(Number);
         _parent.InlinePrompt = null;
         var tracker = App.Provider.GetRequiredService<IFocusTrackerService>();
+        var focus = App.Provider.GetRequiredService<FocusManager>();
         var last = tracker.GetLast("InvoiceEditorView");
-        FormNavigator.RequestFocus(last);
+        focus.RequestFocus(last);
     }
 
     [RelayCommand]
@@ -35,7 +36,8 @@ public partial class InvoiceCreatePromptViewModel : ObservableObject
     {
         _parent.InlinePrompt = null;
         var tracker = App.Provider.GetRequiredService<IFocusTrackerService>();
+        var focus = App.Provider.GetRequiredService<FocusManager>();
         var last = tracker.GetLast("InvoiceEditorView");
-        FormNavigator.RequestFocus(last);
+        focus.RequestFocus(last);
     }
 }

--- a/Wrecept.Wpf/ViewModels/InvoiceEditorViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/InvoiceEditorViewModel.cs
@@ -403,7 +403,8 @@ private void UpdateSupplierId(string name)
             EditableItem = new NewLineItemViewModel(this) { IsFirstRow = true };
             Items.Add(EditableItem);
             RecalculateTotals();
-            FormNavigator.RequestFocus("EntryProduct", typeof(InvoiceEditorView));
+            var focus = App.Provider.GetRequiredService<FocusManager>();
+            focus.RequestFocus("EntryProduct", typeof(InvoiceEditorView));
             return;
         }
 
@@ -443,7 +444,8 @@ private void UpdateSupplierId(string name)
             Items.Add(row);
         }
         RecalculateTotals();
-        FormNavigator.RequestFocus("InvoiceList", typeof(InvoiceEditorView));
+        var focusAfterLoad = App.Provider.GetRequiredService<FocusManager>();
+        focusAfterLoad.RequestFocus("InvoiceList", typeof(InvoiceEditorView));
     }
 
     public void EditLineFromSelection(InvoiceItemRowViewModel selected)
@@ -631,7 +633,8 @@ private void UpdateSupplierId(string name)
         edit.ProductGroup = string.Empty;
         edit.IsEditingExisting = false;
         edit.TargetRow = null;
-        FormNavigator.RequestFocus("EntryProduct", typeof(InvoiceEditorView));
+        var focus = App.Provider.GetRequiredService<FocusManager>();
+        focus.RequestFocus("EntryProduct", typeof(InvoiceEditorView));
     }
 
     [RelayCommand]

--- a/Wrecept.Wpf/ViewModels/SaveLinePromptViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/SaveLinePromptViewModel.cs
@@ -33,8 +33,9 @@ public partial class SaveLinePromptViewModel : ObservableObject
         _parent.SavePrompt = null;
         _parent.IsInLineFinalizationPrompt = false;
         var tracker = App.Provider.GetRequiredService<IFocusTrackerService>();
+        var focus = App.Provider.GetRequiredService<FocusManager>();
         var last = tracker.GetLast("InvoiceEditorView");
-        FormNavigator.RequestFocus(last);
+        focus.RequestFocus(last);
     }
 
     [RelayCommand]
@@ -43,8 +44,9 @@ public partial class SaveLinePromptViewModel : ObservableObject
         _parent.SavePrompt = null;
         _parent.IsInLineFinalizationPrompt = false;
         var tracker = App.Provider.GetRequiredService<IFocusTrackerService>();
+        var focus = App.Provider.GetRequiredService<FocusManager>();
         var last = tracker.GetLast("InvoiceEditorView");
-        FormNavigator.RequestFocus(last);
+        focus.RequestFocus(last);
     }
 }
 

--- a/Wrecept.Wpf/Views/AboutView.xaml.cs
+++ b/Wrecept.Wpf/Views/AboutView.xaml.cs
@@ -5,11 +5,13 @@ namespace Wrecept.Wpf.Views;
 
 public partial class AboutView : UserControl
 {
+    private readonly KeyboardManager _keyboard = App.Provider.GetRequiredService<KeyboardManager>();
+
     public AboutView()
     {
         InitializeComponent();
     }
 
     private void OnKeyDown(object sender, KeyEventArgs e)
-        => NavigationHelper.Handle(e);
+        => _keyboard.Handle(e);
 }

--- a/Wrecept.Wpf/Views/Controls/BaseMasterView.cs
+++ b/Wrecept.Wpf/Views/Controls/BaseMasterView.cs
@@ -85,8 +85,10 @@ public abstract class BaseMasterView : UserControl
             Grid.RowDetailsTemplate = RowDetailsTemplate;
     }
 
+    private readonly KeyboardManager _keyboard = App.Provider.GetRequiredService<KeyboardManager>();
+
     private void OnKeyDown(object? sender, KeyEventArgs e)
-        => NavigationHelper.Handle(e);
+        => _keyboard.Handle(e);
 
     private void Grid_PreviewKeyDown(object? sender, KeyEventArgs e)
     {

--- a/Wrecept.Wpf/Views/EditDialogs/ProductEditorView.xaml.cs
+++ b/Wrecept.Wpf/Views/EditDialogs/ProductEditorView.xaml.cs
@@ -5,11 +5,12 @@ namespace Wrecept.Wpf.Views.EditDialogs;
 
 public partial class ProductEditorView : UserControl
 {
+    private readonly KeyboardManager _keyboard = App.Provider.GetRequiredService<KeyboardManager>();
     public ProductEditorView()
     {
         InitializeComponent();
     }
 
     private void OnKeyDown(object sender, KeyEventArgs e)
-        => NavigationHelper.Handle(e);
+        => _keyboard.Handle(e);
 }

--- a/Wrecept.Wpf/Views/InlineCreators/PaymentMethodCreatorView.xaml.cs
+++ b/Wrecept.Wpf/Views/InlineCreators/PaymentMethodCreatorView.xaml.cs
@@ -5,11 +5,12 @@ namespace Wrecept.Wpf.Views.InlineCreators;
 
 public partial class PaymentMethodCreatorView : UserControl
 {
+    private readonly KeyboardManager _keyboard = App.Provider.GetRequiredService<KeyboardManager>();
     public PaymentMethodCreatorView()
     {
         InitializeComponent();
     }
 
     private void OnKeyDown(object sender, KeyEventArgs e)
-        => NavigationHelper.Handle(e);
+        => _keyboard.Handle(e);
 }

--- a/Wrecept.Wpf/Views/InlineCreators/ProductCreatorView.xaml.cs
+++ b/Wrecept.Wpf/Views/InlineCreators/ProductCreatorView.xaml.cs
@@ -5,6 +5,7 @@ namespace Wrecept.Wpf.Views.InlineCreators;
 
 public partial class ProductCreatorView : UserControl
 {
+    private readonly KeyboardManager _keyboard = App.Provider.GetRequiredService<KeyboardManager>();
     public ProductCreatorView()
     {
         InitializeComponent();
@@ -18,6 +19,6 @@ public partial class ProductCreatorView : UserControl
             e.Handled = true;
             return;
         }
-        NavigationHelper.Handle(e);
+        _keyboard.Handle(e);
     }
 }

--- a/Wrecept.Wpf/Views/InlineCreators/SupplierCreatorView.xaml.cs
+++ b/Wrecept.Wpf/Views/InlineCreators/SupplierCreatorView.xaml.cs
@@ -5,11 +5,12 @@ namespace Wrecept.Wpf.Views.InlineCreators;
 
 public partial class SupplierCreatorView : UserControl
 {
+    private readonly KeyboardManager _keyboard = App.Provider.GetRequiredService<KeyboardManager>();
     public SupplierCreatorView()
     {
         InitializeComponent();
     }
 
     private void OnKeyDown(object sender, KeyEventArgs e)
-        => NavigationHelper.Handle(e);
+        => _keyboard.Handle(e);
 }

--- a/Wrecept.Wpf/Views/InlineCreators/TaxRateCreatorView.xaml.cs
+++ b/Wrecept.Wpf/Views/InlineCreators/TaxRateCreatorView.xaml.cs
@@ -5,11 +5,12 @@ namespace Wrecept.Wpf.Views.InlineCreators;
 
 public partial class TaxRateCreatorView : UserControl
 {
+    private readonly KeyboardManager _keyboard = App.Provider.GetRequiredService<KeyboardManager>();
     public TaxRateCreatorView()
     {
         InitializeComponent();
     }
 
     private void OnKeyDown(object sender, KeyEventArgs e)
-        => NavigationHelper.Handle(e);
+        => _keyboard.Handle(e);
 }

--- a/Wrecept.Wpf/Views/InlineCreators/UnitCreatorView.xaml.cs
+++ b/Wrecept.Wpf/Views/InlineCreators/UnitCreatorView.xaml.cs
@@ -5,11 +5,12 @@ namespace Wrecept.Wpf.Views.InlineCreators;
 
 public partial class UnitCreatorView : UserControl
 {
+    private readonly KeyboardManager _keyboard = App.Provider.GetRequiredService<KeyboardManager>();
     public UnitCreatorView()
     {
         InitializeComponent();
     }
 
     private void OnKeyDown(object sender, KeyEventArgs e)
-        => NavigationHelper.Handle(e);
+        => _keyboard.Handle(e);
 }

--- a/Wrecept.Wpf/Views/InvoiceEditorView.xaml.cs
+++ b/Wrecept.Wpf/Views/InvoiceEditorView.xaml.cs
@@ -15,6 +15,8 @@ namespace Wrecept.Wpf.Views;
 public partial class InvoiceEditorView : UserControl
 {
     private readonly IFocusTrackerService _tracker;
+    private readonly KeyboardManager _keyboard;
+    private readonly FocusManager _focus;
     public InvoiceEditorView() : this(App.Provider.GetRequiredService<InvoiceEditorViewModel>())
     {
     }
@@ -24,6 +26,8 @@ public partial class InvoiceEditorView : UserControl
         InitializeComponent();
         DataContext = viewModel;
         _tracker = App.Provider.GetRequiredService<IFocusTrackerService>();
+        _keyboard = App.Provider.GetRequiredService<KeyboardManager>();
+        _focus = App.Provider.GetRequiredService<FocusManager>();
         Keyboard.AddGotKeyboardFocusHandler(this, OnGotKeyboardFocus);
         Loaded += async (_, _) =>
         {
@@ -38,7 +42,7 @@ public partial class InvoiceEditorView : UserControl
             });
             await viewModel.LoadAsync(progress);
             progressWindow.Close();
-            FormNavigator.RequestFocus("InvoiceList", typeof(InvoiceEditorView));
+            _focus.RequestFocus("InvoiceList", typeof(InvoiceEditorView));
         };
     }
 
@@ -50,7 +54,7 @@ public partial class InvoiceEditorView : UserControl
             e.Handled = true;
             return;
         }
-        NavigationHelper.Handle(e);
+        _keyboard.Handle(e);
     }
 
     private async void OnEntryKeyDown(object sender, KeyEventArgs e)
@@ -84,7 +88,7 @@ public partial class InvoiceEditorView : UserControl
                 return;
             }
 
-            NavigationHelper.Handle(e);
+            _keyboard.Handle(e);
         }
         catch (Exception ex)
         {

--- a/Wrecept.Wpf/Views/InvoiceItemsGrid.xaml.cs
+++ b/Wrecept.Wpf/Views/InvoiceItemsGrid.xaml.cs
@@ -31,13 +31,17 @@ public partial class InvoiceItemsGrid : UserControl
             }
             else if (e.Key is not (Key.Up or Key.Down))
             {
-                NavigationHelper.Handle(e);
+                var keyboard = App.Provider.GetRequiredService<KeyboardManager>();
+                keyboard.Handle(e);
             }
         }
         else
         {
             if (e.Key is not (Key.Up or Key.Down))
-                NavigationHelper.Handle(e);
+            {
+                var keyboard = App.Provider.GetRequiredService<KeyboardManager>();
+                keyboard.Handle(e);
+            }
         }
     }
 }

--- a/Wrecept.Wpf/Views/InvoiceLookupView.xaml.cs
+++ b/Wrecept.Wpf/Views/InvoiceLookupView.xaml.cs
@@ -80,7 +80,8 @@ public partial class InvoiceLookupView : UserControl
             if (e.Key is Key.Up or Key.Down)
                 return;
 
-            NavigationHelper.Handle(e);
+            var keyboard = App.Provider.GetRequiredService<KeyboardManager>();
+            keyboard.Handle(e);
         }
         catch (Exception ex)
         {

--- a/Wrecept.Wpf/Views/ScreenModeWindow.xaml.cs
+++ b/Wrecept.Wpf/Views/ScreenModeWindow.xaml.cs
@@ -6,10 +6,13 @@ namespace Wrecept.Wpf.Views;
 
 public partial class ScreenModeWindow : Window
 {
+    private readonly KeyboardManager _keyboard;
+
     public ScreenModeWindow(ScreenModeViewModel viewModel)
     {
         InitializeComponent();
         DataContext = viewModel;
+        _keyboard = App.Provider.GetRequiredService<KeyboardManager>();
     }
 
     private void OnKeyDown(object sender, KeyEventArgs e)
@@ -17,6 +20,6 @@ public partial class ScreenModeWindow : Window
         if (e.Key == Key.Escape)
             return;
 
-        NavigationHelper.Handle(e);
+        _keyboard.Handle(e);
     }
 }

--- a/Wrecept.Wpf/Views/StageView.xaml.cs
+++ b/Wrecept.Wpf/Views/StageView.xaml.cs
@@ -12,6 +12,8 @@ public partial class StageView : UserControl
     private readonly StageViewModel _viewModel;
     private MenuItem? _lastMenuItem;
     private readonly IFocusTrackerService _tracker;
+    private readonly KeyboardManager _keyboard;
+    private readonly FocusManager _focus;
 
     public StageView(StageViewModel viewModel)
     {
@@ -19,6 +21,8 @@ public partial class StageView : UserControl
         _viewModel = viewModel;
         DataContext = viewModel;
         _tracker = App.Provider.GetRequiredService<IFocusTrackerService>();
+        _keyboard = App.Provider.GetRequiredService<KeyboardManager>();
+        _focus = App.Provider.GetRequiredService<FocusManager>();
         Keyboard.AddGotKeyboardFocusHandler(this, OnGotKeyboardFocus);
     }
 
@@ -33,7 +37,7 @@ public partial class StageView : UserControl
             }
             else
             {
-                NavigationHelper.Handle(e);
+                _keyboard.Handle(e);
             }
 
             return;
@@ -44,13 +48,13 @@ public partial class StageView : UserControl
             var last = _tracker.GetLast("StageView") as IInputElement;
             if (last is not null && !ReferenceEquals(last, this))
             {
-                FormNavigator.RequestFocus(last);
+                _focus.RequestFocus(last);
                 e.Handled = true;
                 return;
             }
         }
 
-        NavigationHelper.Handle(e);
+        _keyboard.Handle(e);
     }
 
     private void MenuItem_Click(object sender, RoutedEventArgs e)

--- a/docs/KeyboardFlow.md
+++ b/docs/KeyboardFlow.md
@@ -9,7 +9,7 @@
 
 ## 🧭 Navigation Principles
 
-A Wrecept minden felületén a billentyűzet az elsődleges vezérlő eszköz. A `NavigationHelper.Handle` segít az általános, fokozatmentes fókuszmozgatásban, míg az egyes nézetek saját `KeyDown` kezelőkkel finomítják a viselkedést.
+A Wrecept minden felületén a billentyűzet az elsődleges vezérlő eszköz. A `KeyboardManager.Handle` segít az általános, fokozatmentes fókuszmozgatásban. A viselkedés profil alapján szabható, az egyes nézetek saját `KeyDown` kezelőkkel finomítják a működést.
 
 ## 🔑 Key Bindings Overview
 
@@ -29,7 +29,7 @@ A Wrecept minden felületén a billentyűzet az elsődleges vezérlő eszköz. A
 - `Escape` visszaviszi a főablak listájához.
 - Az „Inline Item Entry” sor a `OnEntryKeyDown` eseményt használja:
   - `Enter` az utolsó mezőben (jelölés: `Tag="LastEntry"`) meghívja az `AddLineItemCommand`-et.
-  - Egyébként a `NavigationHelper` lép közbe.
+  - Egyébként a `KeyboardManager` lép közbe.
 - Az `InvoiceItemsGrid`-en `Enter` az aktuális tétel szerkesztését indítja.
 
 ### BaseMasterView
@@ -42,14 +42,14 @@ Az InputBindingek helyett a rács `PreviewKeyDown` eseménye futtatja a parancso
 
 ### StageView
 - `Escape`: visszateszi a fókuszt az utoljára aktivált menüpontra, ha az elérhető.
-- Ha nincs korábbi menüpont, a `NavigationHelper` globális fókusz-visszaállítása lép életbe.
+- Ha nincs korábbi menüpont, a `KeyboardManager` globális fókusz-visszaállítása lép életbe.
 
 ## 📦 Modal Prompt Behavior
 
 Az `ArchivePromptView`, `SaveLinePromptView` és `InvoiceCreatePromptView` egyaránt követi:
 - `Enter` a megerősítő parancsot futtatja.
 - `Escape` a mégse parancsot hívja.
-- Többsoros `TextBox` (`AcceptsReturn=true`) esetén a `NavigationHelper` sem az `Enter`, sem az `Escape` billentyűt nem kezeli, így az új sor bevitele és a vezérlő saját művelete zavartalan.
+- Többsoros `TextBox` (`AcceptsReturn=true`) esetén a `KeyboardManager` sem az `Enter`, sem az `Escape` billentyűt nem kezeli, így az új sor bevitele és a vezérlő saját művelete zavartalan.
 A fókusz a prompt bezárása után visszatér a megnyitó nézethez.
 Ezt a `FocusTrackerService` végzi, amely nézetenként rögzíti az utoljára fókuszba került vezérlőt.
 
@@ -64,7 +64,7 @@ Az `Enter` alapértelmezésben a következő vezérlőre ugrik, ha az aktuális 
 
 ### Fókuszkövető szolgáltatás
 
-Az `IFocusTrackerService` a nézetekhez rendelt kulcs alapján megjegyzi az utoljára fókuszba került vezérlőt. A promptok vagy nézetek bezárásakor a `FormNavigator` ennek segítségével állítja vissza a fókuszt az eredeti elemre. A szolgáltatás singletonként regisztrált, így minden View és ViewModel DI-n keresztül éri el.
+Az `IFocusTrackerService` a nézetekhez rendelt kulcs alapján megjegyzi az utoljára fókuszba került vezérlőt. A promptok vagy nézetek bezárásakor a `FocusManager` ennek segítségével állítja vissza a fókuszt az eredeti elemre. A szolgáltatás singletonként regisztrált, így minden View és ViewModel DI-n keresztül éri el.
 
 ## 💡 Design Philosophy
 
@@ -73,7 +73,7 @@ A billentyűzetes navigációt a sebesség és az időtálló megszokhatóság j
 1. A mesteradat listákat megjelenítő `DataGrid` (BaseMasterView) a sor műveletekhez.
 2. A dialógusok (`DialogHelper`) `Enter`/`Escape` kezeléséhez.
 3. Az `EditLookup` és `SmartLookup` szövegmezőinél a legördülő lista navigációjához.
-- A `ListBox`, `DataGrid`, `ComboBox`, `TreeView`, valamint a `Menu` és `MenuItem` saját nyílkezelése elsőbbséget élvez; a `NavigationHelper` ilyen őst találva nem mozdít fókuszt.
+- A `ListBox`, `DataGrid`, `ComboBox`, `TreeView`, valamint a `Menu` és `MenuItem` saját nyílkezelése elsőbbséget élvez; a `KeyboardManager` ilyen őst találva nem mozdít fókuszt.
 
 ## 🔧 Future Enhancements
 

--- a/docs/UI_FLOW.md
+++ b/docs/UI_FLOW.md
@@ -138,7 +138,7 @@ Inline creators must not shift focus away from the current context
 Views are loaded in-place inside StageView, avoiding modal disruptions
 
 Menu state persists across Escape presses to return user to most recent focus
-The FormNavigator.RequestFocus helper now accepts an optional view-type
+The FocusManager.RequestFocus helper accepts an optional view-type
 parameter to narrow the search scope; dynamic elements therefore need not use
 globally unique identifiers.
 FocusTrackerService jegyzi meg, melyik vezérlő volt aktív a nézetekben, így a promptok bezárásakor visszaállítható a fókusz.

--- a/docs/progress/2025-07-03_20-51-44_code_agent.md
+++ b/docs/progress/2025-07-03_20-51-44_code_agent.md
@@ -1,0 +1,3 @@
+- KeyboardManager es FocusManager szolgáltatások létrehozva.
+- Minden korábbi NavigationHelper/FormNavigator hívás ezekre cserélve.
+- App.xaml.cs singleton regisztrációval bővült.

--- a/docs/progress/2025-07-03_20-51-44_docs_agent.md
+++ b/docs/progress/2025-07-03_20-51-44_docs_agent.md
@@ -1,0 +1,2 @@
+- KeyboardFlow.md és UI_FLOW.md frissítve az új manager nevekkel.
+- Dokumentumok említik a profilalapú billentyűkezelést.

--- a/docs/progress/2025-07-03_20-51-44_test_agent.md
+++ b/docs/progress/2025-07-03_20-51-44_test_agent.md
@@ -1,0 +1,2 @@
+- Új KeyboardManagerTests a profilalapú navigáció ellenőrzésére.
+- StageViewFocusTests módosítva az új szolgáltatások miatt.

--- a/tests/Wrecept.Tests/StageViewFocusTests.cs
+++ b/tests/Wrecept.Tests/StageViewFocusTests.cs
@@ -27,6 +27,8 @@ public class StageViewFocusTests
         var view = (StageView)FormatterServices.GetUninitializedObject(typeof(StageView));
         typeof(StageView).GetField("_viewModel", BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(view, vm);
         typeof(StageView).GetField("_tracker", BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(view, new FocusTrackerService());
+        typeof(StageView).GetField("_keyboard", BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(view, new KeyboardManager());
+        typeof(StageView).GetField("_focus", BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(view, new FocusManager());
 
         first = new MenuItem { Header = "A" };
         second = new MenuItem { Header = "B" };

--- a/tests/viewmodels/KeyboardManagerTests.cs
+++ b/tests/viewmodels/KeyboardManagerTests.cs
@@ -1,11 +1,11 @@
 using System.Windows.Controls;
 using System.Windows.Input;
 using Xunit;
-using Wrecept.Wpf;
+using Wrecept.Wpf.Services;
 
 namespace Wrecept.Tests.ViewModels;
 
-public class NavigationHelperTests
+public class KeyboardManagerTests
 {
     private class FakeSource : System.Windows.PresentationSource
     {
@@ -28,7 +28,25 @@ public class NavigationHelperTests
             OriginalSource = item
         };
 
-        NavigationHelper.Handle(args);
+        var manager = new KeyboardManager();
+        manager.Handle(args);
+
+        Assert.False(args.Handled);
+    }
+
+    [Fact]
+    public void DisabledProfile_DoesNotHandleKeys()
+    {
+        var box = new TextBox();
+        var args = new KeyEventArgs(Keyboard.PrimaryDevice, new FakeSource(), 0, Key.Down)
+        {
+            RoutedEvent = Keyboard.KeyDownEvent,
+            Source = box,
+            OriginalSource = box
+        };
+
+        var manager = new KeyboardManager { Profile = NavigationProfile.Disabled };
+        manager.Handle(args);
 
         Assert.False(args.Handled);
     }


### PR DESCRIPTION
## Summary
- add new `KeyboardManager` and `FocusManager` services
- replace `NavigationHelper` and `FormNavigator` usage
- register services in `App` via DI
- update docs with manager names and profiles
- add unit tests for profile-based navigation

## Testing
- `dotnet restore Wrecept.sln`
- `dotnet build Wrecept.sln --no-restore` *(fails: Microsoft.NET.Sdk.WindowsDesktop missing)*

------
https://chatgpt.com/codex/tasks/task_e_6866eb0c1c3483229a94530c84eb8392