### PR TITLE
Update docs with keyboard profile details

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -49,6 +49,8 @@ Minden hibát az `ILogService` rögzít, amelyet a Storage réteg `LogService` i
 Felhasználói üzenetekhez az `INotificationService` ad egységes felületet. WPF alatt a `MessageBoxNotificationService` jeleníti meg a dialógusokat, míg a tesztekben egy csonk "MockNotificationService" működik.
 Az alapvető cégadatokat a `UserInfoService` kezeli. Az adatok a `%AppData%/Wrecept/wrecept.json` fájlban tárolódnak, betöltésük az alkalmazás futása közben történik.
 Az aktuális képernyőmódot a `SettingsService` tartja nyilván `settings.json` fájlban, amit a `ScreenModeManager` olvas be induláskor.
+A `KeyboardManager` a `KeyboardProfile` alapján kezeli a globális billentyűkiosztást. A profil a `wrecept.json` fájl `Keyboard` szekciójából töltődik be.
+A `FocusManager` rögzíti és visszaállítja a nézetenként utoljára fókuszba került vezérlőt, így a promptok bezárása után a fókusz konzisztensen tér vissza.
 
 ### Törzsadatok szerkesztése
 

--- a/docs/KeyboardFlow.md
+++ b/docs/KeyboardFlow.md
@@ -10,6 +10,7 @@
 ## 🧭 Navigation Principles
 
 A Wrecept minden felületén a billentyűzet az elsődleges vezérlő eszköz. A `KeyboardManager.Handle` segít az általános, fokozatmentes fókuszmozgatásban. A viselkedés profil alapján szabható, az egyes nézetek saját `KeyDown` kezelőkkel finomítják a működést.
+Az alkalmazás indításakor a `KeyboardManager` betölti a `KeyboardProfile` beállításait a `wrecept.json` fájl `Keyboard` szekciójából, így a felhasználó tetszés szerint módosíthatja a `Next`, `Previous`, `Confirm` és `Cancel` billentyűket.
 
 ## 🔑 Key Bindings Overview
 
@@ -78,7 +79,7 @@ A billentyűzetes navigációt a sebesség és az időtálló megszokhatóság j
 ## 🔧 Future Enhancements
 
 - [ ] AccessKey-k hozzárendelése a címkékhez
-- [ ] Testreszabható billentyűzetprofil `wrecept.json`-on keresztül
+- [x] Testreszabható billentyűzetprofil `wrecept.json`-on keresztül
 - [ ] `Ctrl+Z` visszavonás a sor szerkesztésben
 - [ ] Tesztesetek bővítése a `TEST_MATRIX.md`-ben
 

--- a/docs/UI_FLOW.md
+++ b/docs/UI_FLOW.md
@@ -132,6 +132,7 @@ The SmartLookup behavior ensures consistent UX and keyboard flow across invoice 
 🔁 Special Behavior
 
 All views must support full keyboard navigation
+Key mappings are loaded from `wrecept.json` via `KeyboardProfile`, allowing users to redefine the Next, Previous, Confirm and Cancel keys.
 
 Inline creators must not shift focus away from the current context
 

--- a/docs/progress/2025-07-03_21-40-05_docs_agent.md
+++ b/docs/progress/2025-07-03_21-40-05_docs_agent.md
@@ -1,0 +1,3 @@
+- KeyboardProfile betöltése dokumentálva a KeyboardFlow és UI_FLOW fájlokban.
+- FocusTrackerService megszűnt, a FocusManager kezeli a fókusz visszaállítását.
+- ARCHITECTURE.md kiegészült a KeyboardManager és FocusManager szolgáltatásokkal.


### PR DESCRIPTION
## Summary
- document keyboard profile loading in KeyboardFlow
- note customizable mappings in UI_FLOW
- add KeyboardManager/FocusManager to architecture
- log progress

## Testing
- `dotnet test --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop missing)*

------
https://chatgpt.com/codex/tasks/task_e_6866f7dca63883229f092a02cd9b7687