### PR TITLE
Fix missing service usings and alias FocusManager

### DIFF
--- a/Wrecept.Wpf/Views/AboutView.xaml.cs
+++ b/Wrecept.Wpf/Views/AboutView.xaml.cs
@@ -1,5 +1,6 @@
 using System.Windows.Controls;
 using System.Windows.Input;
+using Wrecept.Wpf.Services;
 
 namespace Wrecept.Wpf.Views;
 

--- a/Wrecept.Wpf/Views/Controls/BaseMasterView.cs
+++ b/Wrecept.Wpf/Views/Controls/BaseMasterView.cs
@@ -6,6 +6,7 @@ using Wrecept.Wpf.ViewModels;
 using System.Windows.Data;
 using Microsoft.Extensions.DependencyInjection;
 using Wrecept.Wpf.Services;
+using FocusManager = Wrecept.Wpf.Services.FocusManager;
 
 namespace Wrecept.Wpf.Views.Controls;
 

--- a/Wrecept.Wpf/Views/EditDialogs/ProductEditorView.xaml.cs
+++ b/Wrecept.Wpf/Views/EditDialogs/ProductEditorView.xaml.cs
@@ -1,5 +1,6 @@
 using System.Windows.Controls;
 using System.Windows.Input;
+using Wrecept.Wpf.Services;
 
 namespace Wrecept.Wpf.Views.EditDialogs;
 

--- a/Wrecept.Wpf/Views/InlineCreators/PaymentMethodCreatorView.xaml.cs
+++ b/Wrecept.Wpf/Views/InlineCreators/PaymentMethodCreatorView.xaml.cs
@@ -1,5 +1,6 @@
 using System.Windows.Controls;
 using System.Windows.Input;
+using Wrecept.Wpf.Services;
 
 namespace Wrecept.Wpf.Views.InlineCreators;
 

--- a/Wrecept.Wpf/Views/InlineCreators/ProductCreatorView.xaml.cs
+++ b/Wrecept.Wpf/Views/InlineCreators/ProductCreatorView.xaml.cs
@@ -1,5 +1,6 @@
 using System.Windows.Controls;
 using System.Windows.Input;
+using Wrecept.Wpf.Services;
 
 namespace Wrecept.Wpf.Views.InlineCreators;
 

--- a/Wrecept.Wpf/Views/InlineCreators/SupplierCreatorView.xaml.cs
+++ b/Wrecept.Wpf/Views/InlineCreators/SupplierCreatorView.xaml.cs
@@ -1,5 +1,6 @@
 using System.Windows.Controls;
 using System.Windows.Input;
+using Wrecept.Wpf.Services;
 
 namespace Wrecept.Wpf.Views.InlineCreators;
 

--- a/Wrecept.Wpf/Views/InlineCreators/TaxRateCreatorView.xaml.cs
+++ b/Wrecept.Wpf/Views/InlineCreators/TaxRateCreatorView.xaml.cs
@@ -1,5 +1,6 @@
 using System.Windows.Controls;
 using System.Windows.Input;
+using Wrecept.Wpf.Services;
 
 namespace Wrecept.Wpf.Views.InlineCreators;
 

--- a/Wrecept.Wpf/Views/InlineCreators/UnitCreatorView.xaml.cs
+++ b/Wrecept.Wpf/Views/InlineCreators/UnitCreatorView.xaml.cs
@@ -1,5 +1,6 @@
 using System.Windows.Controls;
 using System.Windows.Input;
+using Wrecept.Wpf.Services;
 
 namespace Wrecept.Wpf.Views.InlineCreators;
 

--- a/Wrecept.Wpf/Views/InvoiceEditorView.xaml.cs
+++ b/Wrecept.Wpf/Views/InvoiceEditorView.xaml.cs
@@ -9,6 +9,7 @@ using Wrecept.Core.Services;
 using Wrecept.Core.Utilities;
 using Wrecept.Wpf;
 using Wrecept.Wpf.Services;
+using FocusManager = Wrecept.Wpf.Services.FocusManager;
 
 namespace Wrecept.Wpf.Views;
 

--- a/Wrecept.Wpf/Views/InvoiceItemsGrid.xaml.cs
+++ b/Wrecept.Wpf/Views/InvoiceItemsGrid.xaml.cs
@@ -1,6 +1,7 @@
 using System.Windows.Controls;
 using System.Windows.Input;
 using Wrecept.Wpf.ViewModels;
+using Wrecept.Wpf.Services;
 
 namespace Wrecept.Wpf.Views;
 

--- a/Wrecept.Wpf/Views/ScreenModeWindow.xaml.cs
+++ b/Wrecept.Wpf/Views/ScreenModeWindow.xaml.cs
@@ -1,5 +1,6 @@
 using System.Windows;
 using System.Windows.Input;
+using Wrecept.Wpf.Services;
 using Wrecept.Wpf.ViewModels;
 
 namespace Wrecept.Wpf.Views;

--- a/Wrecept.Wpf/Views/StageView.xaml.cs
+++ b/Wrecept.Wpf/Views/StageView.xaml.cs
@@ -4,6 +4,7 @@ using System.Windows.Input;
 using Microsoft.Extensions.DependencyInjection;
 using Wrecept.Wpf.ViewModels;
 using Wrecept.Wpf.Services;
+using FocusManager = Wrecept.Wpf.Services.FocusManager;
 
 namespace Wrecept.Wpf.Views;
 

--- a/docs/progress/2025-07-03_21-49-33_code_agent.md
+++ b/docs/progress/2025-07-03_21-49-33_code_agent.md
@@ -1,0 +1,3 @@
+- Billentyűkezelő szolgáltatások (KeyboardManager, FocusManager) névtér problémái javítva.
+- Minden érintett view *.xaml.cs fájlja bővült a `Wrecept.Wpf.Services` usinggal.
+- FocusManager hivatkozások pontosítva alias segítségével, hogy elkerüljük a System.Windows.Input ütközést.


### PR DESCRIPTION
## Summary
- add missing `Wrecept.Wpf.Services` usings to creator/editor views
- alias `FocusManager` to avoid clash with `System.Windows.Input`
- document update in progress log

## Testing
- `dotnet build Wrecept.sln -c Release` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*
- `dotnet test Wrecept.sln --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866fa1d00fc8322b5717333b10bf8b3