### PR TITLE
Fix missing DI using directives

### DIFF
--- a/Wrecept.Wpf/ViewModels/InvoiceEditorViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/InvoiceEditorViewModel.cs
@@ -13,6 +13,8 @@ using System.Windows;
 using Wrecept.Wpf.Views.Controls;
 using Wrecept.Wpf.Views;
 using Controls = Wrecept.Wpf.Views.Controls;
+using Wrecept.Wpf.Services;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Wrecept.Wpf.ViewModels;
 

--- a/Wrecept.Wpf/Views/AboutView.xaml.cs
+++ b/Wrecept.Wpf/Views/AboutView.xaml.cs
@@ -1,6 +1,7 @@
 using System.Windows.Controls;
 using System.Windows.Input;
 using Wrecept.Wpf.Services;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Wrecept.Wpf.Views;
 

--- a/Wrecept.Wpf/Views/EditDialogs/ProductEditorView.xaml.cs
+++ b/Wrecept.Wpf/Views/EditDialogs/ProductEditorView.xaml.cs
@@ -1,6 +1,7 @@
 using System.Windows.Controls;
 using System.Windows.Input;
 using Wrecept.Wpf.Services;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Wrecept.Wpf.Views.EditDialogs;
 

--- a/Wrecept.Wpf/Views/InlineCreators/PaymentMethodCreatorView.xaml.cs
+++ b/Wrecept.Wpf/Views/InlineCreators/PaymentMethodCreatorView.xaml.cs
@@ -1,6 +1,7 @@
 using System.Windows.Controls;
 using System.Windows.Input;
 using Wrecept.Wpf.Services;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Wrecept.Wpf.Views.InlineCreators;
 

--- a/Wrecept.Wpf/Views/InlineCreators/ProductCreatorView.xaml.cs
+++ b/Wrecept.Wpf/Views/InlineCreators/ProductCreatorView.xaml.cs
@@ -1,6 +1,7 @@
 using System.Windows.Controls;
 using System.Windows.Input;
 using Wrecept.Wpf.Services;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Wrecept.Wpf.Views.InlineCreators;
 

--- a/Wrecept.Wpf/Views/InlineCreators/SupplierCreatorView.xaml.cs
+++ b/Wrecept.Wpf/Views/InlineCreators/SupplierCreatorView.xaml.cs
@@ -1,6 +1,7 @@
 using System.Windows.Controls;
 using System.Windows.Input;
 using Wrecept.Wpf.Services;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Wrecept.Wpf.Views.InlineCreators;
 

--- a/Wrecept.Wpf/Views/InlineCreators/TaxRateCreatorView.xaml.cs
+++ b/Wrecept.Wpf/Views/InlineCreators/TaxRateCreatorView.xaml.cs
@@ -1,6 +1,7 @@
 using System.Windows.Controls;
 using System.Windows.Input;
 using Wrecept.Wpf.Services;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Wrecept.Wpf.Views.InlineCreators;
 

--- a/Wrecept.Wpf/Views/InlineCreators/UnitCreatorView.xaml.cs
+++ b/Wrecept.Wpf/Views/InlineCreators/UnitCreatorView.xaml.cs
@@ -1,6 +1,7 @@
 using System.Windows.Controls;
 using System.Windows.Input;
 using Wrecept.Wpf.Services;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Wrecept.Wpf.Views.InlineCreators;
 

--- a/Wrecept.Wpf/Views/InvoiceItemsGrid.xaml.cs
+++ b/Wrecept.Wpf/Views/InvoiceItemsGrid.xaml.cs
@@ -2,6 +2,7 @@ using System.Windows.Controls;
 using System.Windows.Input;
 using Wrecept.Wpf.ViewModels;
 using Wrecept.Wpf.Services;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Wrecept.Wpf.Views;
 

--- a/Wrecept.Wpf/Views/InvoiceLookupView.xaml.cs
+++ b/Wrecept.Wpf/Views/InvoiceLookupView.xaml.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Wrecept.Core.Services;
 using Wrecept.Wpf.ViewModels;
 using Wrecept.Wpf;
+using Wrecept.Wpf.Services;
 
 namespace Wrecept.Wpf.Views;
 

--- a/Wrecept.Wpf/Views/ScreenModeWindow.xaml.cs
+++ b/Wrecept.Wpf/Views/ScreenModeWindow.xaml.cs
@@ -2,6 +2,7 @@ using System.Windows;
 using System.Windows.Input;
 using Wrecept.Wpf.Services;
 using Wrecept.Wpf.ViewModels;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Wrecept.Wpf.Views;
 

--- a/docs/progress/2025-07-03_21-58-19_code_agent.md
+++ b/docs/progress/2025-07-03_21-58-19_code_agent.md
@@ -1,0 +1,3 @@
+- Csúszó fordítási hibák (CS1061, CS0246) javítva: hiányzó using direktívák hozzáadva.
+- `Microsoft.Extensions.DependencyInjection` és `Wrecept.Wpf.Services` beemelve több ViewModel és View file tetejére.
+- A `dotnet build` parancs WindowsDesktop SDK hiányában nem futott le sikeresen.


### PR DESCRIPTION
## Summary
- reference `Microsoft.Extensions.DependencyInjection` where `GetRequiredService` is used
- add `Wrecept.Wpf.Services` to ViewModel for focus support
- log progress

## Testing
- `dotnet build Wrecept.sln -c Debug` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866fbbb67d48322a07a680a15474226