### PR TITLE
Implement first-run confirmation and owner setup

### DIFF
--- a/Wrecept.Wpf/App.xaml.cs
+++ b/Wrecept.Wpf/App.xaml.cs
@@ -65,9 +65,40 @@ public static IServiceProvider Provider => Services ?? throw new InvalidOperatio
 
         var defaultDb = Path.Combine(Environment.CurrentDirectory, "app.db");
         var defaultCfg = Path.Combine(Environment.CurrentDirectory, "wrecept.json");
+
+        if (MessageBox.Show(
+                "Biztos, hogy elölrõl kezded?",
+                "Első indítás",
+                MessageBoxButton.YesNo,
+                MessageBoxImage.Question) != MessageBoxResult.Yes)
+        {
+            Current.Shutdown();
+            Environment.Exit(0);
+        }
+
         var vm = new SetupViewModel(defaultDb, defaultCfg);
         var win = new SetupWindow { DataContext = vm };
-        win.ShowDialog();
+        if (win.ShowDialog() != true)
+        {
+            Current.Shutdown();
+            Environment.Exit(0);
+        }
+
+        var infoVm = new UserInfoEditorViewModel();
+        var infoWin = new UserInfoWindow { DataContext = infoVm };
+        if (infoWin.ShowDialog() != true)
+        {
+            Current.Shutdown();
+            Environment.Exit(0);
+        }
+        var userInfoService = new Wrecept.Storage.Services.UserInfoService(vm.ConfigPath);
+        await userInfoService.SaveAsync(new UserInfo
+        {
+            CompanyName = infoVm.CompanyName,
+            Address = infoVm.Address,
+            Phone = infoVm.Phone,
+            Email = infoVm.Email
+        });
 
         var settings = new AppSettings
         {

--- a/Wrecept.Wpf/ViewModels/UserInfoEditorViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/UserInfoEditorViewModel.cs
@@ -1,0 +1,27 @@
+using System;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+
+namespace Wrecept.Wpf.ViewModels;
+
+public partial class UserInfoEditorViewModel : ObservableObject
+{
+    [ObservableProperty] private string companyName = string.Empty;
+    [ObservableProperty] private string address = string.Empty;
+    [ObservableProperty] private string phone = string.Empty;
+    [ObservableProperty] private string email = string.Empty;
+
+    public IRelayCommand OkCommand { get; }
+    public IRelayCommand CancelCommand { get; }
+
+    public UserInfoEditorViewModel()
+    {
+        OkCommand = new RelayCommand(() => OnOk?.Invoke(this), () => IsValid);
+        CancelCommand = new RelayCommand(() => OnCancel?.Invoke());
+    }
+
+    public bool IsValid => !string.IsNullOrWhiteSpace(CompanyName);
+
+    public Action<UserInfoEditorViewModel>? OnOk;
+    public Action? OnCancel;
+}

--- a/Wrecept.Wpf/Views/EditDialogs/UserInfoEditorView.xaml
+++ b/Wrecept.Wpf/Views/EditDialogs/UserInfoEditorView.xaml
@@ -1,0 +1,19 @@
+<UserControl x:Class="Wrecept.Wpf.Views.EditDialogs.UserInfoEditorView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             KeyDown="OnKeyDown">
+    <StackPanel Margin="10">
+        <TextBlock Text="Cégnév" />
+        <TextBox x:Name="InitialFocus" Text="{Binding CompanyName}" Width="280" />
+        <TextBlock Text="Cím" Margin="0,5,0,0" />
+        <TextBox Text="{Binding Address}" Width="280" />
+        <TextBlock Text="Telefonszám" Margin="0,5,0,0" />
+        <TextBox Text="{Binding Phone}" Width="280" />
+        <TextBlock Text="E-mail" Margin="0,5,0,0" />
+        <TextBox Text="{Binding Email}" Width="280" />
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
+            <Button Content="OK" Width="80" Margin="0,0,8,0" Command="{Binding OkCommand}" />
+            <Button Content="Mégse" Width="80" Command="{Binding CancelCommand}" />
+        </StackPanel>
+    </StackPanel>
+</UserControl>

--- a/Wrecept.Wpf/Views/EditDialogs/UserInfoEditorView.xaml.cs
+++ b/Wrecept.Wpf/Views/EditDialogs/UserInfoEditorView.xaml.cs
@@ -1,0 +1,23 @@
+using System.Windows.Controls;
+using System.Windows.Input;
+using Microsoft.Extensions.DependencyInjection;
+using Wrecept.Wpf.Services;
+
+namespace Wrecept.Wpf.Views.EditDialogs;
+
+public partial class UserInfoEditorView : UserControl
+{
+    private readonly KeyboardManager? _keyboard = App.Services != null
+        ? App.Provider.GetRequiredService<KeyboardManager>()
+        : null;
+
+    public UserInfoEditorView()
+    {
+        InitializeComponent();
+    }
+
+    private void OnKeyDown(object sender, KeyEventArgs e)
+    {
+        _keyboard?.Handle(e);
+    }
+}

--- a/Wrecept.Wpf/Views/UserInfoWindow.xaml
+++ b/Wrecept.Wpf/Views/UserInfoWindow.xaml
@@ -1,0 +1,7 @@
+<Window x:Class="Wrecept.Wpf.Views.UserInfoWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:view="clr-namespace:Wrecept.Wpf.Views.EditDialogs"
+        Title="Tulajdonosi adatok" WindowStartupLocation="CenterScreen" SizeToContent="WidthAndHeight">
+    <view:UserInfoEditorView />
+</Window>

--- a/Wrecept.Wpf/Views/UserInfoWindow.xaml.cs
+++ b/Wrecept.Wpf/Views/UserInfoWindow.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows;
+
+namespace Wrecept.Wpf.Views;
+
+public partial class UserInfoWindow : Window
+{
+    public UserInfoWindow()
+    {
+        InitializeComponent();
+    }
+}

--- a/docs/BUILD_RUNTIME_NOTES.md
+++ b/docs/BUILD_RUNTIME_NOTES.md
@@ -37,5 +37,9 @@ Ez a jegyzet a fejlesztés során tapasztalt fordítási és futásidejű probl�
 10. A `SetupWindow` bezárása után az alkalmazás alapértelmezett `OnLastWindowClose` módja miatt azonnal leállt,
     ezért a `ShutdownMode` beállítása a `OnStartup` végén `InvalidOperationException`-t dobott.
     A megoldás: `OnStartup` elején állítsuk `ShutdownMode = OnExplicitShutdown` értékre.
+11. Amennyiben sem adatbázis, sem konfigurációs fájl nem létezik, indításkor rákérdezünk:
+    "Biztos, hogy elölről kezded?". Elfogadás után a `SetupWindow` és a
+    tulajdonosi adatok szerkesztője jelenik meg, ezek mentik a beállított
+    elérési utakat és cégadatokat.
 
 ---

--- a/docs/progress/2025-07-03_22-18-59_code_agent.md
+++ b/docs/progress/2025-07-03_22-18-59_code_agent.md
@@ -1,0 +1,3 @@
+- Első indításkor megerősítő kérdés került a LoadSettingsAsync elejére.
+- Setup után új UserInfoWindow gyűjti be a kötelező cégadatokat.
+- UserInfoEditorViewModel és kapcsolódó XAML dialógus hozzáadva.

--- a/docs/progress/2025-07-03_22-18-59_docs_agent.md
+++ b/docs/progress/2025-07-03_22-18-59_docs_agent.md
@@ -1,0 +1,1 @@
+- BUILD_RUNTIME_NOTES frissítve az első indítási folyamat részleteivel.


### PR DESCRIPTION
## Summary
- ask for confirmation when no settings file exists
- prompt for owner data during initial setup
- add `UserInfoEditorViewModel` with dialog
- document new startup behaviour

## Testing
- `dotnet build Wrecept.sln -v q` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*
- `dotnet test Wrecept.sln -v q` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867004ea7388322870852106c6ae9cb