### PR TITLE
Owner setup validation

### DIFF
--- a/Wrecept.Core.Tests/Services/UserInfoServiceTests.cs
+++ b/Wrecept.Core.Tests/Services/UserInfoServiceTests.cs
@@ -31,6 +31,8 @@ public class UserInfoServiceTests : IDisposable
         Assert.Equal(string.Empty, info.Address);
         Assert.Equal(string.Empty, info.Phone);
         Assert.Equal(string.Empty, info.Email);
+        Assert.Equal(string.Empty, info.TaxNumber);
+        Assert.Equal(string.Empty, info.BankAccount);
     }
 
     [Fact]
@@ -38,7 +40,15 @@ public class UserInfoServiceTests : IDisposable
     {
         var path = Path.Combine(_tempDir, "Wrecept", "wrecept.json");
         var svc = new UserInfoService(path);
-        var info = new UserInfo { CompanyName = "ACME" };
+        var info = new UserInfo
+        {
+            CompanyName = "ACME",
+            Address = "Addr",
+            Phone = "123",
+            Email = "a@b.c",
+            TaxNumber = "12345678-1-42",
+            BankAccount = "11100000-11111111-11111111"
+        };
         await svc.SaveAsync(info);
 
         Assert.True(File.Exists(path));
@@ -49,7 +59,15 @@ public class UserInfoServiceTests : IDisposable
     {
         var path = Path.Combine(_tempDir, "Wrecept", "wrecept.json");
         var svc = new UserInfoService(path);
-        var info = new UserInfo { CompanyName = "ACME", Address = "Addr", Phone = "123", Email = "a@b.c" };
+        var info = new UserInfo
+        {
+            CompanyName = "ACME",
+            Address = "Addr",
+            Phone = "123",
+            Email = "a@b.c",
+            TaxNumber = "12345678-1-42",
+            BankAccount = "11100000-11111111-11111111"
+        };
         await svc.SaveAsync(info);
 
         var loaded = await svc.LoadAsync();
@@ -57,6 +75,8 @@ public class UserInfoServiceTests : IDisposable
         Assert.Equal(info.Address, loaded.Address);
         Assert.Equal(info.Phone, loaded.Phone);
         Assert.Equal(info.Email, loaded.Email);
+        Assert.Equal(info.TaxNumber, loaded.TaxNumber);
+        Assert.Equal(info.BankAccount, loaded.BankAccount);
     }
 
     public void Dispose()

--- a/Wrecept.Core/Entities/UserInfo.cs
+++ b/Wrecept.Core/Entities/UserInfo.cs
@@ -6,4 +6,6 @@ public class UserInfo
     public string Address { get; set; } = string.Empty;
     public string Phone { get; set; } = string.Empty;
     public string Email { get; set; } = string.Empty;
+    public string TaxNumber { get; set; } = string.Empty;
+    public string BankAccount { get; set; } = string.Empty;
 }

--- a/Wrecept.Wpf/App.xaml.cs
+++ b/Wrecept.Wpf/App.xaml.cs
@@ -97,7 +97,9 @@ public static IServiceProvider Provider => Services ?? throw new InvalidOperatio
             CompanyName = infoVm.CompanyName,
             Address = infoVm.Address,
             Phone = infoVm.Phone,
-            Email = infoVm.Email
+            Email = infoVm.Email,
+            TaxNumber = infoVm.TaxNumber,
+            BankAccount = infoVm.BankAccount
         });
 
         var settings = new AppSettings

--- a/Wrecept.Wpf/ViewModels/UserInfoEditorViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/UserInfoEditorViewModel.cs
@@ -6,21 +6,73 @@ namespace Wrecept.Wpf.ViewModels;
 
 public partial class UserInfoEditorViewModel : ObservableObject
 {
-    [ObservableProperty] private string companyName = string.Empty;
-    [ObservableProperty] private string address = string.Empty;
-    [ObservableProperty] private string phone = string.Empty;
-    [ObservableProperty] private string email = string.Empty;
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(OkCommand))]
+    private string companyName = string.Empty;
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(OkCommand))]
+    private string address = string.Empty;
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(OkCommand))]
+    private string phone = string.Empty;
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(OkCommand))]
+    private string email = string.Empty;
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(OkCommand))]
+    private string taxNumber = string.Empty;
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(OkCommand))]
+    private string bankAccount = string.Empty;
+
+    [ObservableProperty] private bool companyNameError;
+    [ObservableProperty] private bool addressError;
+    [ObservableProperty] private bool phoneError;
+    [ObservableProperty] private bool emailError;
+    [ObservableProperty] private bool taxNumberError;
+    [ObservableProperty] private bool bankAccountError;
+
+    private readonly INotificationService _notifications;
 
     public IRelayCommand OkCommand { get; }
     public IRelayCommand CancelCommand { get; }
 
-    public UserInfoEditorViewModel()
+    public UserInfoEditorViewModel(INotificationService? notifications = null)
     {
-        OkCommand = new RelayCommand(() => OnOk?.Invoke(this), () => IsValid);
+        _notifications = notifications ?? (App.Services != null
+            ? App.Provider.GetRequiredService<INotificationService>()
+            : new MessageBoxNotificationService());
+        OkCommand = new RelayCommand(ExecuteOk, () => IsValid);
         CancelCommand = new RelayCommand(() => OnCancel?.Invoke());
     }
 
-    public bool IsValid => !string.IsNullOrWhiteSpace(CompanyName);
+    private void ExecuteOk()
+    {
+        Validate();
+        if (!IsValid) return;
+
+        var summary = $"Cégnév: {CompanyName}\nCím: {Address}\nTelefonszám: {Phone}\nE-mail: {Email}\nAdószám: {TaxNumber}\nBankszámla: {BankAccount}";
+        if (_notifications.Confirm($"Helyesek az adatok?\n\n{summary}"))
+            OnOk?.Invoke(this);
+    }
+
+    public bool IsValid =>
+        !string.IsNullOrWhiteSpace(CompanyName) &&
+        !string.IsNullOrWhiteSpace(Address) &&
+        !string.IsNullOrWhiteSpace(Phone) &&
+        !string.IsNullOrWhiteSpace(Email) &&
+        !string.IsNullOrWhiteSpace(TaxNumber) &&
+        !string.IsNullOrWhiteSpace(BankAccount);
+
+    private void Validate()
+    {
+        CompanyNameError = string.IsNullOrWhiteSpace(CompanyName);
+        AddressError = string.IsNullOrWhiteSpace(Address);
+        PhoneError = string.IsNullOrWhiteSpace(Phone);
+        EmailError = string.IsNullOrWhiteSpace(Email);
+        TaxNumberError = string.IsNullOrWhiteSpace(TaxNumber);
+        BankAccountError = string.IsNullOrWhiteSpace(BankAccount);
+    }
 
     public Action<UserInfoEditorViewModel>? OnOk;
     public Action? OnCancel;

--- a/Wrecept.Wpf/ViewModels/UserInfoViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/UserInfoViewModel.cs
@@ -14,6 +14,8 @@ public partial class UserInfoViewModel : ObservableObject
     [ObservableProperty] private string address = string.Empty;
     [ObservableProperty] private string phone = string.Empty;
     [ObservableProperty] private string email = string.Empty;
+    [ObservableProperty] private string taxNumber = string.Empty;
+    [ObservableProperty] private string bankAccount = string.Empty;
 
     public UserInfoViewModel(IUserInfoService service)
     {
@@ -27,6 +29,8 @@ public partial class UserInfoViewModel : ObservableObject
         Address = info.Address;
         Phone = info.Phone;
         Email = info.Email;
+        TaxNumber = info.TaxNumber;
+        BankAccount = info.BankAccount;
     }
 
     [RelayCommand]
@@ -37,7 +41,9 @@ public partial class UserInfoViewModel : ObservableObject
             CompanyName = CompanyName,
             Address = Address,
             Phone = Phone,
-            Email = Email
+            Email = Email,
+            TaxNumber = TaxNumber,
+            BankAccount = BankAccount
         });
     }
 }

--- a/Wrecept.Wpf/Views/EditDialogs/UserInfoEditorView.xaml
+++ b/Wrecept.Wpf/Views/EditDialogs/UserInfoEditorView.xaml
@@ -4,13 +4,77 @@
              KeyDown="OnKeyDown">
     <StackPanel Margin="10">
         <TextBlock Text="Cégnév" />
-        <TextBox x:Name="InitialFocus" Text="{Binding CompanyName}" Width="280" />
+        <TextBox x:Name="InitialFocus" Text="{Binding CompanyName}" Width="280">
+            <TextBox.Style>
+                <Style TargetType="TextBox" BasedOn="{StaticResource {x:Type TextBox}}">
+                    <Style.Triggers>
+                        <DataTrigger Binding="{Binding CompanyNameError}" Value="True">
+                            <Setter Property="BorderBrush" Value="Red" />
+                        </DataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </TextBox.Style>
+        </TextBox>
         <TextBlock Text="Cím" Margin="0,5,0,0" />
-        <TextBox Text="{Binding Address}" Width="280" />
+        <TextBox Text="{Binding Address}" Width="280">
+            <TextBox.Style>
+                <Style TargetType="TextBox" BasedOn="{StaticResource {x:Type TextBox}}">
+                    <Style.Triggers>
+                        <DataTrigger Binding="{Binding AddressError}" Value="True">
+                            <Setter Property="BorderBrush" Value="Red" />
+                        </DataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </TextBox.Style>
+        </TextBox>
         <TextBlock Text="Telefonszám" Margin="0,5,0,0" />
-        <TextBox Text="{Binding Phone}" Width="280" />
+        <TextBox Text="{Binding Phone}" Width="280">
+            <TextBox.Style>
+                <Style TargetType="TextBox" BasedOn="{StaticResource {x:Type TextBox}}">
+                    <Style.Triggers>
+                        <DataTrigger Binding="{Binding PhoneError}" Value="True">
+                            <Setter Property="BorderBrush" Value="Red" />
+                        </DataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </TextBox.Style>
+        </TextBox>
         <TextBlock Text="E-mail" Margin="0,5,0,0" />
-        <TextBox Text="{Binding Email}" Width="280" />
+        <TextBox Text="{Binding Email}" Width="280">
+            <TextBox.Style>
+                <Style TargetType="TextBox" BasedOn="{StaticResource {x:Type TextBox}}">
+                    <Style.Triggers>
+                        <DataTrigger Binding="{Binding EmailError}" Value="True">
+                            <Setter Property="BorderBrush" Value="Red" />
+                        </DataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </TextBox.Style>
+        </TextBox>
+        <TextBlock Text="Adószám" Margin="0,5,0,0" />
+        <TextBox Text="{Binding TaxNumber}" Width="280">
+            <TextBox.Style>
+                <Style TargetType="TextBox" BasedOn="{StaticResource {x:Type TextBox}}">
+                    <Style.Triggers>
+                        <DataTrigger Binding="{Binding TaxNumberError}" Value="True">
+                            <Setter Property="BorderBrush" Value="Red" />
+                        </DataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </TextBox.Style>
+        </TextBox>
+        <TextBlock Text="Bankszámla" Margin="0,5,0,0" />
+        <TextBox x:Name="LastField" Text="{Binding BankAccount}" Width="280">
+            <TextBox.Style>
+                <Style TargetType="TextBox" BasedOn="{StaticResource {x:Type TextBox}}">
+                    <Style.Triggers>
+                        <DataTrigger Binding="{Binding BankAccountError}" Value="True">
+                            <Setter Property="BorderBrush" Value="Red" />
+                        </DataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </TextBox.Style>
+        </TextBox>
         <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
             <Button Content="OK" Width="80" Margin="0,0,8,0" Command="{Binding OkCommand}" />
             <Button Content="Mégse" Width="80" Command="{Binding CancelCommand}" />

--- a/Wrecept.Wpf/Views/EditDialogs/UserInfoEditorView.xaml.cs
+++ b/Wrecept.Wpf/Views/EditDialogs/UserInfoEditorView.xaml.cs
@@ -1,3 +1,4 @@
+using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using Microsoft.Extensions.DependencyInjection;
@@ -18,6 +19,13 @@ public partial class UserInfoEditorView : UserControl
 
     private void OnKeyDown(object sender, KeyEventArgs e)
     {
+        if (e.Key == Key.Escape)
+        {
+            e.Handled = true;
+            (e.OriginalSource as UIElement)?.MoveFocus(new TraversalRequest(FocusNavigationDirection.Previous));
+            return;
+        }
+
         _keyboard?.Handle(e);
     }
 }

--- a/docs/UI_FLOW.md
+++ b/docs/UI_FLOW.md
@@ -176,3 +176,11 @@ Induláskor a `ScreenModeManager.ApplySavedAsync` kiolvassa a `%AppData%/Wrecept
 2. Az `OnOk` delegáltban frissíti a kiválasztott entitást, majd meghívja a szolgáltatást a mentésre.
 3. A `DialogService.EditEntity<TView, TViewModel>` hívás elkészíti az `EditEntityDialog` példányt, és átadja az `Ok`/`Mégse` parancsokat.
 4. A `NavigationService.ShowCenteredDialog` megjeleníti a dialógust a főablak közepén. A `DialogHelper` gondoskodik a billentyűk leképezéséről.
+
+### Tulajdonosi adatok felvétele
+
+Első indításkor a `UserInfoWindow` kéri be a cég adatait. A mezők kötelezőek, a
+`KeyboardManager` biztosítja, hogy `Enter` a következő mezőre lépjen. Az utolsó
+mező után az `OK` gombra kerül a fókusz, majd megerősítő üzenet jelenik meg:
+"Helyesek az adatok?". `Enter` elfogadja, `Escape` az előző mezőre visz
+vissza. Minden üres mező piros keretet kap, amíg ki nem töltik.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -11,6 +11,8 @@ A program a felhasználó cégadatait JSON formátumban tárolja a `%AppData%/Wr
 - `Address` – székhely vagy telephely címe
 - `Phone` – kapcsolattartó telefonszáma
 - `Email` – általános elérhetőség
+- `TaxNumber` – hivatalos adószám
+- `BankAccount` – bankszámlaszám a kiállított számlákhoz
 
 ## Billentyűzetprofil
 

--- a/docs/progress/2025-07-03_23-05-46_code_agent.md
+++ b/docs/progress/2025-07-03_23-05-46_code_agent.md
@@ -1,0 +1,3 @@
+- UserInfo bővítve adószám és bankszámla mezőkkel.
+- UserInfoEditorView megerősítést kér, hibás mezők piros szegélyt kapnak.
+- Minden mező kitöltése kötelező, Enter/Escape navigáció frissítve.

--- a/tests/viewmodels/UserInfoEditorViewModelTests.cs
+++ b/tests/viewmodels/UserInfoEditorViewModelTests.cs
@@ -1,0 +1,29 @@
+using Wrecept.Wpf.ViewModels;
+using Xunit;
+
+namespace Wrecept.Tests.ViewModels;
+
+public class UserInfoEditorViewModelTests
+{
+    [Fact]
+    public void OkCommand_CanExecute_False_WhenFieldsMissing()
+    {
+        var vm = new UserInfoEditorViewModel();
+        Assert.False(vm.OkCommand.CanExecute(null));
+    }
+
+    [Fact]
+    public void OkCommand_CanExecute_True_WhenAllFieldsFilled()
+    {
+        var vm = new UserInfoEditorViewModel
+        {
+            CompanyName = "ACME",
+            Address = "Addr",
+            Phone = "1",
+            Email = "a@b.c",
+            TaxNumber = "123",
+            BankAccount = "111"
+        };
+        Assert.True(vm.OkCommand.CanExecute(null));
+    }
+}


### PR DESCRIPTION
## Summary
- require tax number and bank account for owner info
- validate all fields in UserInfoEditor with red borders
- ask confirmation before saving owner info
- document updated setup and keyboard flow
- add regression tests for UserInfo

## Testing
- `dotnet test Wrecept.Core.Tests/Wrecept.Core.Tests.csproj -v m`
- `dotnet test tests/Wrecept.Tests/Wrecept.Tests.csproj -v m` *(fails: Project Wrecept.Wpf is not compatible)*

------
https://chatgpt.com/codex/tasks/task_e_68670806acf88322917c95a7c42a21b0