### PR TITLE
Add menu navigation UI tests

### DIFF
--- a/docs/progress/2025-07-04_00-07-30_test_agent.md
+++ b/docs/progress/2025-07-04_00-07-30_test_agent.md
@@ -1,0 +1,1 @@
+- Added MenuNavigationTests for About and Exit menu flows.

--- a/tests/Wrecept.UiTests/MenuNavigationTests.cs
+++ b/tests/Wrecept.UiTests/MenuNavigationTests.cs
@@ -1,0 +1,45 @@
+using System;
+using System.IO;
+using System.Threading;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OpenQA.Selenium;
+using OpenQA.Selenium.Appium;
+using OpenQA.Selenium.Appium.Windows;
+
+namespace Wrecept.UiTests;
+
+[TestClass]
+public class MenuNavigationTests
+{
+    private static WindowsDriver<WindowsElement> LaunchApp()
+    {
+        var exePath = Path.GetFullPath(Path.Combine("..", "..", "..", "..", "Wrecept.Wpf", "bin", "Debug", "net8.0-windows", "Wrecept.Wpf.exe"));
+        var options = new AppiumOptions();
+        options.AddAdditionalCapability("app", exePath);
+        return new WindowsDriver<WindowsElement>(new Uri("http://127.0.0.1:4723"), options);
+    }
+
+    [TestMethod]
+    public void AboutMenu_DisplaysAboutView()
+    {
+        using var driver = LaunchApp();
+
+        driver.FindElementByName("Névjegy").Click();
+        driver.FindElementByName("A program felhasználójának adatai").Click();
+
+        Assert.IsTrue(driver.PageSource.Contains("Program neve"));
+        driver.Close();
+    }
+
+    [TestMethod]
+    public void ExitMenu_ClosesApplication()
+    {
+        using var driver = LaunchApp();
+
+        driver.FindElementByName("Vége").Click();
+        driver.FindElementByName("Kilépés").Click();
+        Thread.Sleep(1000);
+
+        Assert.ThrowsException<WebDriverException>(() => _ = driver.Title);
+    }
+}


### PR DESCRIPTION
## Summary
- add `MenuNavigationTests` to verify About and Exit menu interactions
- log progress for the new test cases

## Testing
- `dotnet test tests/Wrecept.UiTests/Wrecept.UiTests.csproj --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_68671a65ad848322ba0e967dc3bfadc5