### PR TITLE
Fix Appium wait lambdas

### DIFF
--- a/docs/progress/2025-07-04_02-18-14_test_agent.md
+++ b/docs/progress/2025-07-04_02-18-14_test_agent.md
@@ -1,0 +1,2 @@
+- UI tesztekben WindowsDriver castinggal javítottam a `FindElementBy*` hívásokat.
+- Az elavult `Keyboard.PressKey` metódusokat `Actions.SendKeys` váltotta fel.

--- a/tests/Wrecept.UiTests/InvoiceEditorTests.cs
+++ b/tests/Wrecept.UiTests/InvoiceEditorTests.cs
@@ -47,7 +47,8 @@ public class InvoiceEditorTests
         using var driver = LaunchApp();
 
         var wait = new WebDriverWait(driver, TimeSpan.FromSeconds(5));
-        var list = wait.Until(d => d.FindElementByAccessibilityId("InvoiceList"));
+        var list = wait.Until(d => ((WindowsDriver<WindowsElement>)d)
+            .FindElementByAccessibilityId("InvoiceList"));
         Assert.IsNotNull(list);
         var entry = driver.FindElementByAccessibilityId("EntryProduct");
         Assert.IsNotNull(entry);

--- a/tests/Wrecept.UiTests/MasterDataNavigationTests.cs
+++ b/tests/Wrecept.UiTests/MasterDataNavigationTests.cs
@@ -4,6 +4,7 @@ using OpenQA.Selenium.Appium;
 using OpenQA.Selenium.Appium.Windows;
 using OpenQA.Selenium.Support.UI;
 using OpenQA.Selenium;
+using OpenQA.Selenium.Interactions;
 
 namespace Wrecept.UiTests;
 
@@ -54,10 +55,11 @@ public class MasterDataNavigationTests
         driver.FindElementByName(item).Click();
 
         var wait = new WebDriverWait(driver, TimeSpan.FromSeconds(5));
-        var grid = wait.Until(d => d.FindElementByAccessibilityId("Grid"));
+        var grid = wait.Until(d => ((WindowsDriver<WindowsElement>)d)
+            .FindElementByAccessibilityId("Grid"));
         Assert.IsNotNull(grid);
 
-        driver.Keyboard.PressKey(Keys.Escape);
+        new Actions(driver).SendKeys(Keys.Escape).Perform();
         driver.Close();
     }
 }

--- a/tests/Wrecept.UiTests/ScreenModeTests.cs
+++ b/tests/Wrecept.UiTests/ScreenModeTests.cs
@@ -50,7 +50,8 @@ public class ScreenModeTests
         driver.FindElementByName("Képernyő beállítása").Click();
 
         var wait = new WebDriverWait(driver, TimeSpan.FromSeconds(5));
-        var window = wait.Until(d => d.FindElementByName("Képernyőbeállítás"));
+        var window = wait.Until(d => ((WindowsDriver<WindowsElement>)d)
+            .FindElementByName("Képernyőbeállítás"));
         window.FindElementByName("Mégse").Click();
 
         Assert.ThrowsException<OpenQA.Selenium.WebDriverException>(() => driver.FindElementByName("Képernyőbeállítás"));

--- a/tests/Wrecept.UiTests/StageViewFocusUITests.cs
+++ b/tests/Wrecept.UiTests/StageViewFocusUITests.cs
@@ -4,6 +4,7 @@ using OpenQA.Selenium.Appium;
 using OpenQA.Selenium.Appium.Windows;
 using OpenQA.Selenium.Support.UI;
 using OpenQA.Selenium;
+using OpenQA.Selenium.Interactions;
 
 namespace Wrecept.UiTests;
 
@@ -50,7 +51,7 @@ public class StageViewFocusUITests
         driver.FindElementByName("Törzsek").Click();
         driver.FindElementByName("Termékek").Click();
 
-        driver.Keyboard.PressKey(Keys.Escape);
+        new Actions(driver).SendKeys(Keys.Escape).Perform();
         var active = driver.SwitchTo().ActiveElement();
         Assert.AreEqual("Termékek", active.Text);
 

--- a/tests/Wrecept.UiTests/StartupWindowTests.cs
+++ b/tests/Wrecept.UiTests/StartupWindowTests.cs
@@ -7,6 +7,7 @@ using OpenQA.Selenium.Appium;
 using OpenQA.Selenium.Appium.Windows;
 using OpenQA.Selenium.Support.UI;
 using OpenQA.Selenium;
+using OpenQA.Selenium.Interactions;
 
 namespace Wrecept.UiTests;
 
@@ -84,10 +85,12 @@ public class StartupWindowTests
         using var driver = LaunchApp();
 
         var wait = new OpenQA.Selenium.Support.UI.WebDriverWait(driver, TimeSpan.FromSeconds(5));
-        var optionsWindow = wait.Until(d => d.FindElementByName("Mintaszámok"));
+        var optionsWindow = wait.Until(d => ((WindowsDriver<WindowsElement>)d)
+            .FindElementByName("Mintaszámok"));
         optionsWindow.FindElementByName("Mégse").Click();
 
-        var mainWindow = wait.Until(d => d.FindElementByName("Wrecept"));
+        var mainWindow = wait.Until(d => ((WindowsDriver<WindowsElement>)d)
+            .FindElementByName("Wrecept"));
         Assert.IsNotNull(mainWindow);
         driver.Close();
     }
@@ -99,10 +102,12 @@ public class StartupWindowTests
         using var driver = LaunchApp();
 
         var wait = new OpenQA.Selenium.Support.UI.WebDriverWait(driver, TimeSpan.FromSeconds(5));
-        var optionsWindow = wait.Until(d => d.FindElementByName("Mintaszámok"));
+        var optionsWindow = wait.Until(d => ((WindowsDriver<WindowsElement>)d)
+            .FindElementByName("Mintaszámok"));
         optionsWindow.FindElementByName("OK").Click();
 
-        var startupWindow = wait.Until(d => d.FindElementByName("Indulás"));
+        var startupWindow = wait.Until(d => ((WindowsDriver<WindowsElement>)d)
+            .FindElementByName("Indulás"));
         Assert.IsNotNull(startupWindow);
 
         driver.Close();
@@ -115,19 +120,23 @@ public class StartupWindowTests
         using var driver = LaunchApp();
 
         var wait = new WebDriverWait(driver, TimeSpan.FromSeconds(5));
-        var setupWindow = wait.Until(d => d.FindElementByName("Első indítás"));
+        var setupWindow = wait.Until(d => ((WindowsDriver<WindowsElement>)d)
+            .FindElementByName("Első indítás"));
         setupWindow.FindElementByName("OK").Click();
 
-        var editorWindow = wait.Until(d => d.FindElementByName("Tulajdonosi adatok"));
-        wait.Until(d => d.FindElementByAccessibilityId("CompanyNameBox")).SendKeys("Teszt Kft.");
+        var editorWindow = wait.Until(d => ((WindowsDriver<WindowsElement>)d)
+            .FindElementByName("Tulajdonosi adatok"));
+        wait.Until(d => ((WindowsDriver<WindowsElement>)d)
+            .FindElementByAccessibilityId("CompanyNameBox")).SendKeys("Teszt Kft.");
         driver.FindElementByAccessibilityId("AddressBox").SendKeys("Siklós, Fő utca 1.");
         driver.FindElementByAccessibilityId("PhoneBox").SendKeys("1111");
         driver.FindElementByAccessibilityId("EmailBox").SendKeys("teszt@example.hu");
         driver.FindElementByAccessibilityId("TaxNumberBox").SendKeys("123");
         driver.FindElementByAccessibilityId("BankAccountBox").SendKeys("111");
-        driver.Keyboard.PressKey(OpenQA.Selenium.Keys.Enter);
+        new Actions(driver).SendKeys(OpenQA.Selenium.Keys.Enter).Perform();
 
-        wait.Until(d => d.FindElementByName("Wrecept"));
+        wait.Until(d => ((WindowsDriver<WindowsElement>)d)
+            .FindElementByName("Wrecept"));
         driver.Close();
     }
 }


### PR DESCRIPTION
## Summary
- fix `FindElementBy*` calls in web driver waits via casting
- replace obsolete `Keyboard.PressKey` with `Actions.SendKeys`
- log progress

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets missing)*

------
https://chatgpt.com/codex/tasks/task_e_68673910170883229782227c9fc55a94