### PR TITLE
Fix UI test exe path

### DIFF
--- a/docs/progress/2025-07-04_12-38-42_test_agent.md
+++ b/docs/progress/2025-07-04_12-38-42_test_agent.md
@@ -1,0 +1,1 @@
+- UI tesztfájlokban a futtatható elérési útja rögzített abszolút Windows útvonalra lett cserélve.

--- a/tests/Wrecept.UiTests/InvoiceEditorTests.cs
+++ b/tests/Wrecept.UiTests/InvoiceEditorTests.cs
@@ -9,8 +9,7 @@ namespace Wrecept.UiTests;
 [TestClass]
 public class InvoiceEditorTests
 {
-    private static string ExePath =>
-        Path.GetFullPath(Path.Combine("..", "..", "..", "..", "Wrecept.Wpf", "bin", "Debug", "net8.0-windows", "Wrecept.Wpf.exe"));
+    private const string ExePath = @"C:\Users\tankoferenc\source\repos\luckydizzier\wrecept\Wrecept.Wpf\bin\Debug\net8.0-windows\Wrecept.Wpf.exe";
     private const string WinAppDriverUrl = "http://127.0.0.1:4723";
 
     private static WindowsDriver<WindowsElement> LaunchApp()

--- a/tests/Wrecept.UiTests/MasterDataNavigationTests.cs
+++ b/tests/Wrecept.UiTests/MasterDataNavigationTests.cs
@@ -11,8 +11,7 @@ namespace Wrecept.UiTests;
 [TestClass]
 public class MasterDataNavigationTests
 {
-    private static string ExePath =>
-        Path.GetFullPath(Path.Combine("..", "..", "..", "..", "Wrecept.Wpf", "bin", "Debug", "net8.0-windows", "Wrecept.Wpf.exe"));
+    private const string ExePath = @"C:\Users\tankoferenc\source\repos\luckydizzier\wrecept\Wrecept.Wpf\bin\Debug\net8.0-windows\Wrecept.Wpf.exe";
     private const string WinAppDriverUrl = "http://127.0.0.1:4723";
 
     private static WindowsDriver<WindowsElement> LaunchApp()

--- a/tests/Wrecept.UiTests/MenuNavigationTests.cs
+++ b/tests/Wrecept.UiTests/MenuNavigationTests.cs
@@ -13,7 +13,7 @@ public class MenuNavigationTests
 {
     private static WindowsDriver<WindowsElement> LaunchApp()
     {
-        var exePath = Path.GetFullPath(Path.Combine("..", "..", "..", "..", "Wrecept.Wpf", "bin", "Debug", "net8.0-windows", "Wrecept.Wpf.exe"));
+        const string exePath = @"C:\Users\tankoferenc\source\repos\luckydizzier\wrecept\Wrecept.Wpf\bin\Debug\net8.0-windows\Wrecept.Wpf.exe";
         var options = new AppiumOptions();
         options.AddAdditionalCapability("app", exePath);
         var driver = new WindowsDriver<WindowsElement>(new Uri("http://127.0.0.1:4723"), options);

--- a/tests/Wrecept.UiTests/ScreenModeTests.cs
+++ b/tests/Wrecept.UiTests/ScreenModeTests.cs
@@ -9,8 +9,7 @@ namespace Wrecept.UiTests;
 [TestClass]
 public class ScreenModeTests
 {
-    private static string ExePath =>
-        Path.GetFullPath(Path.Combine("..", "..", "..", "..", "Wrecept.Wpf", "bin", "Debug", "net8.0-windows", "Wrecept.Wpf.exe"));
+    private const string ExePath = @"C:\Users\tankoferenc\source\repos\luckydizzier\wrecept\Wrecept.Wpf\bin\Debug\net8.0-windows\Wrecept.Wpf.exe";
     private const string WinAppDriverUrl = "http://127.0.0.1:4723";
 
     private static WindowsDriver<WindowsElement> LaunchApp()

--- a/tests/Wrecept.UiTests/StageViewFocusUITests.cs
+++ b/tests/Wrecept.UiTests/StageViewFocusUITests.cs
@@ -11,8 +11,7 @@ namespace Wrecept.UiTests;
 [TestClass]
 public class StageViewFocusUITests
 {
-    private static string ExePath =>
-        Path.GetFullPath(Path.Combine("..", "..", "..", "..", "Wrecept.Wpf", "bin", "Debug", "net8.0-windows", "Wrecept.Wpf.exe"));
+    private const string ExePath = @"C:\Users\tankoferenc\source\repos\luckydizzier\wrecept\Wrecept.Wpf\bin\Debug\net8.0-windows\Wrecept.Wpf.exe";
     private const string WinAppDriverUrl = "http://127.0.0.1:4723";
 
     private static WindowsDriver<WindowsElement> LaunchApp()

--- a/tests/Wrecept.UiTests/StartupWindowTests.cs
+++ b/tests/Wrecept.UiTests/StartupWindowTests.cs
@@ -14,8 +14,7 @@ namespace Wrecept.UiTests;
 [TestClass]
 public class StartupWindowTests
 {
-    private static string ExePath =>
-        Path.GetFullPath(Path.Combine("..", "..", "..", "..", "Wrecept.Wpf", "bin", "Debug", "net8.0-windows", "Wrecept.Wpf.exe"));
+    private const string ExePath = @"C:\Users\tankoferenc\source\repos\luckydizzier\wrecept\Wrecept.Wpf\bin\Debug\net8.0-windows\Wrecept.Wpf.exe";
     private const string WinAppDriverUrl = "http://127.0.0.1:4723";
 
     private static void PrepareSettings(bool firstRun)


### PR DESCRIPTION
## Summary
- set WPF executable path in UI tests to an absolute Windows location
- log progress update about test path change

## Testing
- `dotnet test --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867ca8aaa9883228f8b468600d1de9a