### PR TITLE
Fix UI startup tests

### DIFF
--- a/docs/progress/2025-07-04_13-05-55_test_agent.md
+++ b/docs/progress/2025-07-04_13-05-55_test_agent.md
@@ -1,0 +1,2 @@
+- TestHelper absolute exe path restored for consistent WinAppDriver launch.
+- Added TestInitialize in UI tests to prepare settings for each case.

--- a/tests/Wrecept.UiTests/InvoiceEditorTests.cs
+++ b/tests/Wrecept.UiTests/InvoiceEditorTests.cs
@@ -11,6 +11,9 @@ public class InvoiceEditorTests
 {
     private static WindowsDriver<WindowsElement> LaunchApp() => TestHelper.LaunchApp();
 
+    [TestInitialize]
+    public void Setup() => TestHelper.PrepareSettings(false);
+
     [TestMethod]
     public void InvoiceEditor_Loads_DefaultView()
     {

--- a/tests/Wrecept.UiTests/MasterDataNavigationTests.cs
+++ b/tests/Wrecept.UiTests/MasterDataNavigationTests.cs
@@ -13,6 +13,9 @@ public class MasterDataNavigationTests
 {
     private static WindowsDriver<WindowsElement> LaunchApp() => TestHelper.LaunchApp();
 
+    [TestInitialize]
+    public void Setup() => TestHelper.PrepareSettings(false);
+
     [DataTestMethod]
     [DataRow("Termékek")]
     [DataRow("Szállítók")]

--- a/tests/Wrecept.UiTests/MenuNavigationTests.cs
+++ b/tests/Wrecept.UiTests/MenuNavigationTests.cs
@@ -13,6 +13,9 @@ public class MenuNavigationTests
 {
     private static WindowsDriver<WindowsElement> LaunchApp() => TestHelper.LaunchApp();
 
+    [TestInitialize]
+    public void Setup() => TestHelper.PrepareSettings(false);
+
     [TestMethod]
     public void AboutMenu_DisplaysAboutView()
     {

--- a/tests/Wrecept.UiTests/ScreenModeTests.cs
+++ b/tests/Wrecept.UiTests/ScreenModeTests.cs
@@ -11,6 +11,9 @@ public class ScreenModeTests
 {
     private static WindowsDriver<WindowsElement> LaunchApp() => TestHelper.LaunchApp();
 
+    [TestInitialize]
+    public void Setup() => TestHelper.PrepareSettings(false);
+
     [TestMethod]
     public void ScreenSettings_OpensAndCancels()
     {

--- a/tests/Wrecept.UiTests/StageViewFocusUITests.cs
+++ b/tests/Wrecept.UiTests/StageViewFocusUITests.cs
@@ -13,6 +13,9 @@ public class StageViewFocusUITests
 {
     private static WindowsDriver<WindowsElement> LaunchApp() => TestHelper.LaunchApp();
 
+    [TestInitialize]
+    public void Setup() => TestHelper.PrepareSettings(false);
+
     [TestMethod]
     public void EscapeRestoresMenuFocus()
     {

--- a/tests/Wrecept.UiTests/TestHelper.cs
+++ b/tests/Wrecept.UiTests/TestHelper.cs
@@ -14,8 +14,7 @@ internal static class TestHelper
     private const string WinAppDriverUrl = "http://127.0.0.1:4723";
 
     internal static string ExePath =>
-        Path.GetFullPath(Path.Combine(AppContext.BaseDirectory,
-            "../../../../Wrecept.Wpf/bin/Debug/net8.0-windows/Wrecept.Wpf.exe"));
+        @"C:\\Users\\tankoferenc\\source\\repos\\luckydizzier\\wrecept\\Wrecept.Wpf\\bin\\Debug\\net8.0-windows\\Wrecept.Wpf.exe";
 
     internal static void PrepareSettings(bool firstRun)
     {


### PR DESCRIPTION
## Summary
- restore absolute path for WinAppDriver
- prepare settings before each UI test

## Testing
- `dotnet test tests/Wrecept.UiTests/Wrecept.UiTests.csproj --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*
- `dotnet restore tests/Wrecept.Tests/Wrecept.Tests.csproj` *(fails: project Wrecept.Wpf not compatible)*

------
https://chatgpt.com/codex/tasks/task_e_6867d09254288322a86b61b1e9ac79a5