### PR TITLE
Improve view focus handling

### DIFF
--- a/Wrecept.Wpf/NavigationHelper.cs
+++ b/Wrecept.Wpf/NavigationHelper.cs
@@ -47,7 +47,6 @@ public static class NavigationHelper
                 if (Window.GetWindow(element) == Application.Current.MainWindow)
                 {
                     e.Handled = true;
-                    Application.Current.MainWindow?.Focus();
                 }
                 break;
         }

--- a/Wrecept.Wpf/Views/InvoiceLookupView.xaml
+++ b/Wrecept.Wpf/Views/InvoiceLookupView.xaml
@@ -17,7 +17,8 @@
         <ListBox x:Name="InvoiceList"
                  ItemsSource="{Binding Invoices}"
                  SelectedItem="{Binding SelectedInvoice}"
-                 Margin="4">
+                 Margin="4"
+                 TabIndex="0">
             <ListBox.ItemTemplate>
                 <DataTemplate>
                     <StackPanel Orientation="Horizontal">

--- a/Wrecept.Wpf/Views/InvoiceLookupView.xaml.cs
+++ b/Wrecept.Wpf/Views/InvoiceLookupView.xaml.cs
@@ -29,6 +29,7 @@ public partial class InvoiceLookupView : UserControl
         {
             if (DataContext is InvoiceLookupViewModel vm)
                 await vm.LoadAsync();
+            FormNavigator.RequestFocus("InvoiceList", typeof(InvoiceLookupView));
         }
         catch (Exception ex)
         {

--- a/Wrecept.Wpf/Views/StageView.xaml
+++ b/Wrecept.Wpf/Views/StageView.xaml
@@ -19,7 +19,7 @@
                 <EventSetter Event="Click" Handler="MenuItem_Click"/>
             </Style>
         </Grid.Resources>
-        <Menu Background="{DynamicResource HeaderFooterBrush}">
+        <Menu x:Name="Menu" Background="{DynamicResource HeaderFooterBrush}">
             <MenuItem Header="Számlák">
                 <MenuItem Header="Bejövő szállítólevelek"
                           Command="{Binding HandleMenuCommand}"

--- a/Wrecept.Wpf/Views/StageView.xaml.cs
+++ b/Wrecept.Wpf/Views/StageView.xaml.cs
@@ -32,13 +32,14 @@ public partial class StageView : UserControl
             if (_lastMenuItem is not null)
             {
                 _lastMenuItem.Focus();
-                e.Handled = true;
             }
-            else
+            else if (Menu.Items.Count > 0)
             {
-                _keyboard.Handle(e);
+                if (Menu.Items[0] is MenuItem first)
+                    first.Focus();
             }
 
+            e.Handled = true;
             return;
         }
 

--- a/docs/KeyboardFlow.md
+++ b/docs/KeyboardFlow.md
@@ -56,11 +56,9 @@ Ezt a `FocusManager` végzi, amely nézetenként rögzíti az utoljára fókuszb
 
 ## 📋 Focus Reset Rules
 
-Globálisan az `Escape` csak a főablakból indítva helyezi a fókuszt vissza a főablakra:
-```csharp
-Application.Current.MainWindow?.Focus();
-```
-Más ablakokban a billentyűt a saját logikájuk kezeli.
+Az `Escape` billentyűt a `StageView` kezeli, és a legutóbb aktivált menüelemre
+állítja a fókuszt. Más nézeteknél a billentyű az adott nézet logikájára van
+bízva.
 Az `Enter` alapértelmezésben a következő vezérlőre ugrik, ha az aktuális kezelő nem nyeli el.
 
 ### Fókuszkövető szolgáltatás

--- a/docs/UI_FLOW.md
+++ b/docs/UI_FLOW.md
@@ -24,6 +24,9 @@ Escape: Returns to menu with last selected item focused
   - **InvoiceEditorView** – bal oldali `InvoiceList`
   - **ProductMasterView** – a táblázat (Grid)
   - **SupplierMasterView** – a táblázat (Grid)
+  
+Az adott nézetek betöltésekor a `FormNavigator.RequestFocus` hívása állítja be
+a kezdő fókuszt a felsorolt vezérlőkre.
 
 🧾 Invoice Editor Flow (Bejövő szállítólevelek)
 

--- a/docs/progress/2025-07-04_19-42-39_code_agent.md
+++ b/docs/progress/2025-07-04_19-42-39_code_agent.md
@@ -1,0 +1,5 @@
+- InvoiceLookupView betöltéskor a fókusz az InvoiceList-re kerül FormNavigator segítségével.
+- StageView Escape logika a legutóbbi menüelemre vagy az elsőre állítja a fókuszt.
+- NavigationHelper Escape ág nem állítja a fókuszt a főablakra.
+- TabIndex attribútum került az InvoiceList ListBoxra.
+- KeyboardFlow és UI_FLOW dokumentáció frissítve.


### PR DESCRIPTION
## Summary
- ensure InvoiceLookupView focuses the invoice list on load
- refine StageView Escape handling and add Menu name
- keep focus in view on Escape
- document new focus rules
- log progress

## Testing
- `dotnet test --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_68682c92bd7c832289aca958302b96ba