### PR TITLE
Fix UserInfo window closing logic

### DIFF
--- a/Wrecept.Wpf/App.xaml.cs
+++ b/Wrecept.Wpf/App.xaml.cs
@@ -86,6 +86,8 @@ public static IServiceProvider Provider => Services ?? throw new InvalidOperatio
 
         var infoVm = new UserInfoEditorViewModel();
         var infoWin = new UserInfoWindow { DataContext = infoVm };
+        infoVm.OnOk = _ => { infoWin.DialogResult = true; infoWin.Close(); };
+        infoVm.OnCancel = () => { infoWin.DialogResult = false; infoWin.Close(); };
         if (infoWin.ShowDialog() != true)
         {
             Current.Shutdown();

--- a/docs/progress/2025-07-04_19-55-44_code_agent.md
+++ b/docs/progress/2025-07-04_19-55-44_code_agent.md
@@ -1,0 +1,1 @@
+- UserInfoWindow bezárása most az Ok/Cancel parancsoknál a DialogResult beállításával történik.


### PR DESCRIPTION
## Summary
- close `UserInfoWindow` from `UserInfoEditorViewModel` OK/Cancel actions
- log progress

## Testing
- `dotnet test --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*
- `dotnet build --no-restore Wrecept.sln` *(fails: missing project.assets.json and WindowsDesktop SDK)*

------
https://chatgpt.com/codex/tasks/task_e_68682ffe38d883229c8299f28289440f