### PR TITLE
Implement AccessKey support

### DIFF
--- a/Wrecept.Wpf/Views/InvoiceEditorView.xaml
+++ b/Wrecept.Wpf/Views/InvoiceEditorView.xaml
@@ -86,8 +86,8 @@
                                 <ColumnDefinition Width="220" />
                             </Grid.ColumnDefinitions>
 
-                            <TextBlock Grid.Row="0" Grid.Column="0" Text="Szállító" Style="{StaticResource LabelTextStyle}" />
-                            <c:SmartLookup Grid.Row="0" Grid.Column="1" Width="220"
+                            <Label Grid.Row="0" Grid.Column="0" Content="_Szállító" Style="{StaticResource LabelTextStyle}" Target="{Binding ElementName=SupplierLookup}" />
+                            <c:SmartLookup x:Name="SupplierLookup" Grid.Row="0" Grid.Column="1" Width="220"
                                            ItemsSource="{Binding Suppliers}"
                                            DisplayMemberPath="Name"
                                            SelectedValuePath="Id"
@@ -97,8 +97,8 @@
                                            Watermark="Kezdjen el gépelni..."
                                            IsEnabled="{Binding IsEditable}" />
 
-                            <TextBlock Grid.Row="1" Grid.Column="0" Text="Fizetési mód" Margin="0,4,0,0" Style="{StaticResource LabelTextStyle}" />
-                            <c:EditLookup Grid.Row="1" Grid.Column="1" Width="220" Margin="0,4,0,0"
+                            <Label Grid.Row="1" Grid.Column="0" Content="_Fizetési mód" Margin="0,4,0,0" Style="{StaticResource LabelTextStyle}" Target="{Binding ElementName=PaymentLookup}" />
+                            <c:EditLookup x:Name="PaymentLookup" Grid.Row="1" Grid.Column="1" Width="220" Margin="0,4,0,0"
                                           ItemsSource="{Binding PaymentMethods}"
                                           DisplayMemberPath="Name"
                                           SelectedValuePath="Id"
@@ -121,11 +121,11 @@
                                 <ColumnDefinition Width="220" />
                             </Grid.ColumnDefinitions>
 
-                            <TextBlock Grid.Row="0" Grid.Column="0" Text="Dátum" Style="{StaticResource LabelTextStyle}" />
-                            <DatePicker Grid.Row="0" Grid.Column="1" Width="220" SelectedDate="{Binding InvoiceDate}" IsEnabled="{Binding IsEditable}" />
+                            <Label Grid.Row="0" Grid.Column="0" Content="_Dátum" Style="{StaticResource LabelTextStyle}" Target="{Binding ElementName=DatePicker}" />
+                            <DatePicker x:Name="DatePicker" Grid.Row="0" Grid.Column="1" Width="220" SelectedDate="{Binding InvoiceDate}" IsEnabled="{Binding IsEditable}" />
 
-                            <TextBlock Grid.Row="1" Grid.Column="0" Margin="0,4,0,0" Text="Számlaszám" Style="{StaticResource LabelTextStyle}" />
-                            <TextBox Grid.Row="1" Grid.Column="1" Width="220" Margin="0,4,0,0"
+                            <Label Grid.Row="1" Grid.Column="0" Margin="0,4,0,0" Content="_Számlaszám" Style="{StaticResource LabelTextStyle}" Target="{Binding ElementName=NumberBox}" />
+                            <TextBox x:Name="NumberBox" Grid.Row="1" Grid.Column="1" Width="220" Margin="0,4,0,0"
                                      Text="{Binding Number}"
                                      IsEnabled="{Binding IsNew}"
                                      Style="{StaticResource HeaderTextBoxBold}" />

--- a/Wrecept.Wpf/Views/StageView.xaml
+++ b/Wrecept.Wpf/Views/StageView.xaml
@@ -20,72 +20,72 @@
             </Style>
         </Grid.Resources>
         <Menu x:Name="Menu" Background="{DynamicResource HeaderFooterBrush}">
-            <MenuItem Header="Számlák">
-                <MenuItem Header="Bejövő szállítólevelek"
+            <MenuItem Header="_Számlák">
+                <MenuItem Header="_Bejövő szállítólevelek"
                           Command="{Binding HandleMenuCommand}"
                           CommandParameter="{x:Static vm:StageMenuAction.InboundDeliveryNotes}" />
-                <MenuItem Header="Bejövő számlák aktualizálása"
+                <MenuItem Header="Bejövő számlák _aktualizálása"
                           Command="{Binding HandleMenuCommand}"
                           CommandParameter="{x:Static vm:StageMenuAction.UpdateInboundInvoices}" />
             </MenuItem>
-            <MenuItem Header="Törzsek">
-                <MenuItem Header="Termékek"
+            <MenuItem Header="_Törzsek">
+                <MenuItem Header="_Termékek"
                           Command="{Binding HandleMenuCommand}"
                           CommandParameter="{x:Static vm:StageMenuAction.EditProducts}" />
-                <MenuItem Header="Termékcsoportok"
+                <MenuItem Header="T_ermékcsoportok"
                           Command="{Binding HandleMenuCommand}"
                           CommandParameter="{x:Static vm:StageMenuAction.EditProductGroups}" />
-                <MenuItem Header="Szállítók"
+                <MenuItem Header="Szá_llítók"
                           Command="{Binding HandleMenuCommand}"
                           CommandParameter="{x:Static vm:StageMenuAction.EditSuppliers}" />
-                <MenuItem Header="ÁFA-kulcsok"
+                <MenuItem Header="Á_FA-kulcsok"
                           Command="{Binding HandleMenuCommand}"
                           CommandParameter="{x:Static vm:StageMenuAction.EditVatKeys}" />
-                <MenuItem Header="Fizetési módok"
+                <MenuItem Header="F_izetési módok"
                           Command="{Binding HandleMenuCommand}"
                           CommandParameter="{x:Static vm:StageMenuAction.EditPaymentMethods}" />
-                <MenuItem Header="Mértékegységek"
+                <MenuItem Header="M_értékegységek"
                           Command="{Binding HandleMenuCommand}"
                           CommandParameter="{x:Static vm:StageMenuAction.EditUnits}" />
             </MenuItem>
-            <MenuItem Header="Listák">
-                <MenuItem Header="Terméklista"
+            <MenuItem Header="_Listák">
+                <MenuItem Header="T_erméklista"
                           Command="{Binding HandleMenuCommand}"
                           CommandParameter="{x:Static vm:StageMenuAction.ListProducts}" />
-                <MenuItem Header="Szállítók listája"
+                <MenuItem Header="Szállí_tók listája"
                           Command="{Binding HandleMenuCommand}"
                           CommandParameter="{x:Static vm:StageMenuAction.ListSuppliers}" />
-                <MenuItem Header="Számlák listája"
+                <MenuItem Header="Számlák l_istája"
                           Command="{Binding HandleMenuCommand}"
                           CommandParameter="{x:Static vm:StageMenuAction.ListInvoices}" />
-                <MenuItem Header="Készletkarton"
+                <MenuItem Header="K_észletkarton"
                           Command="{Binding HandleMenuCommand}"
                           CommandParameter="{x:Static vm:StageMenuAction.InventoryCard}" />
             </MenuItem>
-            <MenuItem Header="Szerviz">
-                <MenuItem Header="Állományok ellenőrzése"
+            <MenuItem Header="Sz_erviz">
+                <MenuItem Header="Á_llományok ellenőrzése"
                           Command="{Binding HandleMenuCommand}"
                           CommandParameter="{x:Static vm:StageMenuAction.CheckFiles}" />
-                <MenuItem Header="Áramszünet után"
+                <MenuItem Header="Áramszünet _után"
                           Command="{Binding HandleMenuCommand}"
                           CommandParameter="{x:Static vm:StageMenuAction.AfterPowerOutage}" />
-                <MenuItem Header="Képernyő beállítása"
+                <MenuItem Header="K_épernyő beállítása"
                           Command="{Binding HandleMenuCommand}"
                           CommandParameter="{x:Static vm:StageMenuAction.ScreenSettings}" />
-                <MenuItem Header="Nyomtató beállítás"
+                <MenuItem Header="N_yomtató beállítás"
                           Command="{Binding HandleMenuCommand}"
                           CommandParameter="{x:Static vm:StageMenuAction.PrinterSettings}" />
-                <MenuItem Header="Tulajdonos szerkesztése..."
+                <MenuItem Header="Tu_lajdonos szerkesztése..."
                           Command="{Binding HandleMenuCommand}"
                           CommandParameter="{x:Static vm:StageMenuAction.EditUserInfo}" />
             </MenuItem>
-            <MenuItem Header="Névjegy">
-                <MenuItem Header="A program felhasználójának adatai"
+            <MenuItem Header="N_évjegy">
+                <MenuItem Header="A program f_elhasználójának adatai"
                           Command="{Binding HandleMenuCommand}"
                           CommandParameter="{x:Static vm:StageMenuAction.UserInfo}" />
             </MenuItem>
-            <MenuItem Header="Vége">
-                <MenuItem Header="Kilépés"
+            <MenuItem Header="V_ége">
+                <MenuItem Header="_Kilépés"
                           Command="{Binding HandleMenuCommand}"
                           CommandParameter="{x:Static vm:StageMenuAction.ExitApplication}" />
             </MenuItem>

--- a/docs/KeyboardFlow.md
+++ b/docs/KeyboardFlow.md
@@ -76,7 +76,7 @@ A billentyűzetes navigációt a sebesség és az időtálló megszokhatóság j
 
 ## 🔧 Future Enhancements
 
-- [ ] AccessKey-k hozzárendelése a címkékhez
+- [x] AccessKey-k hozzárendelése a címkékhez
 - [x] Testreszabható billentyűzetprofil `wrecept.json`-on keresztül
 - [ ] `Ctrl+Z` visszavonás a sor szerkesztésben
 - [ ] Tesztesetek bővítése a `TEST_MATRIX.md`-ben

--- a/docs/UI_FLOW.md
+++ b/docs/UI_FLOW.md
@@ -18,6 +18,9 @@ Enter: Activates the selected submenu view and focuses the first control
 
 Escape: Returns to menu with last selected item focused
 
+AccessKey jelek (aláhúzás) segítik az Alt+betű kombinációkat a főmenüben és a
+számlafejléc mezőknél.
+
 - Fókuszkezdő pontok nézetenként:
   - **StageView** – a főmenüsor első eleme
   - **InvoiceLookupView** – `InvoiceList` `ListBox`

--- a/docs/progress/2025-07-04_20-55-30_docs_agent.md
+++ b/docs/progress/2025-07-04_20-55-30_docs_agent.md
@@ -1,0 +1,1 @@
+- KeyboardFlow.md és UI_FLOW.md frissítve az AccessKey támogatással.

--- a/docs/progress/2025-07-04_20-55-30_ui_agent.md
+++ b/docs/progress/2025-07-04_20-55-30_ui_agent.md
@@ -1,0 +1,1 @@
+- AccessKey jelek kerültek a StageView főmenü pontjaira és az InvoiceEditorView fejlécmezőire.


### PR DESCRIPTION
## Summary
- add AccessKey mnemonics to StageView menu
- convert InvoiceEditor labels to `Label` with AccessKey Target
- mark AccessKey task done in KeyboardFlow
- document AccessKey usage in UI_FLOW
- log progress for ui_agent and docs_agent

## Testing
- `dotnet test --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_68683eb0105483228ef43e331b500814