### PR TITLE
Fix label style mismatch in InvoiceEditorView

### DIFF
--- a/Wrecept.Wpf/Themes/RetroTheme.Dark.xaml
+++ b/Wrecept.Wpf/Themes/RetroTheme.Dark.xaml
@@ -39,6 +39,12 @@
         <Setter Property="FontWeight" Value="SemiBold" />
     </Style>
 
+    <Style TargetType="Label" x:Key="FormLabelStyle">
+        <Setter Property="FontFamily" Value="{StaticResource MonospacedFont}" />
+        <Setter Property="FontSize" Value="14" />
+        <Setter Property="FontWeight" Value="SemiBold" />
+    </Style>
+
     <Style TargetType="TextBlock" x:Key="ValueTextStyle">
         <Setter Property="FontFamily" Value="{StaticResource MonospacedFont}" />
         <Setter Property="FontSize" Value="14" />

--- a/Wrecept.Wpf/Themes/RetroTheme.xaml
+++ b/Wrecept.Wpf/Themes/RetroTheme.xaml
@@ -40,6 +40,12 @@
         <Setter Property="FontWeight" Value="SemiBold" />
     </Style>
 
+    <Style TargetType="Label" x:Key="FormLabelStyle">
+        <Setter Property="FontFamily" Value="{StaticResource MonospacedFont}" />
+        <Setter Property="FontSize" Value="14" />
+        <Setter Property="FontWeight" Value="SemiBold" />
+    </Style>
+
     <Style TargetType="TextBlock" x:Key="ValueTextStyle">
         <Setter Property="FontFamily" Value="{StaticResource MonospacedFont}" />
         <Setter Property="FontSize" Value="14" />

--- a/Wrecept.Wpf/Views/InvoiceEditorView.xaml
+++ b/Wrecept.Wpf/Views/InvoiceEditorView.xaml
@@ -86,7 +86,7 @@
                                 <ColumnDefinition Width="220" />
                             </Grid.ColumnDefinitions>
 
-                            <Label Grid.Row="0" Grid.Column="0" Content="_Szállító" Style="{StaticResource LabelTextStyle}" Target="{Binding ElementName=SupplierLookup}" />
+                            <Label Grid.Row="0" Grid.Column="0" Content="_Szállító" Style="{StaticResource FormLabelStyle}" Target="{Binding ElementName=SupplierLookup}" />
                             <c:SmartLookup x:Name="SupplierLookup" Grid.Row="0" Grid.Column="1" Width="220"
                                            ItemsSource="{Binding Suppliers}"
                                            DisplayMemberPath="Name"
@@ -97,7 +97,7 @@
                                            Watermark="Kezdjen el gépelni..."
                                            IsEnabled="{Binding IsEditable}" />
 
-                            <Label Grid.Row="1" Grid.Column="0" Content="_Fizetési mód" Margin="0,4,0,0" Style="{StaticResource LabelTextStyle}" Target="{Binding ElementName=PaymentLookup}" />
+                            <Label Grid.Row="1" Grid.Column="0" Content="_Fizetési mód" Margin="0,4,0,0" Style="{StaticResource FormLabelStyle}" Target="{Binding ElementName=PaymentLookup}" />
                             <c:EditLookup x:Name="PaymentLookup" Grid.Row="1" Grid.Column="1" Width="220" Margin="0,4,0,0"
                                           ItemsSource="{Binding PaymentMethods}"
                                           DisplayMemberPath="Name"
@@ -121,10 +121,10 @@
                                 <ColumnDefinition Width="220" />
                             </Grid.ColumnDefinitions>
 
-                            <Label Grid.Row="0" Grid.Column="0" Content="_Dátum" Style="{StaticResource LabelTextStyle}" Target="{Binding ElementName=DatePicker}" />
+                            <Label Grid.Row="0" Grid.Column="0" Content="_Dátum" Style="{StaticResource FormLabelStyle}" Target="{Binding ElementName=DatePicker}" />
                             <DatePicker x:Name="DatePicker" Grid.Row="0" Grid.Column="1" Width="220" SelectedDate="{Binding InvoiceDate}" IsEnabled="{Binding IsEditable}" />
 
-                            <Label Grid.Row="1" Grid.Column="0" Margin="0,4,0,0" Content="_Számlaszám" Style="{StaticResource LabelTextStyle}" Target="{Binding ElementName=NumberBox}" />
+                            <Label Grid.Row="1" Grid.Column="0" Margin="0,4,0,0" Content="_Számlaszám" Style="{StaticResource FormLabelStyle}" Target="{Binding ElementName=NumberBox}" />
                             <TextBox x:Name="NumberBox" Grid.Row="1" Grid.Column="1" Width="220" Margin="0,4,0,0"
                                      Text="{Binding Number}"
                                      IsEnabled="{Binding IsNew}"

--- a/docs/progress/2025-07-04_21-06-28_docs_agent.md
+++ b/docs/progress/2025-07-04_21-06-28_docs_agent.md
@@ -1,0 +1,1 @@
+- themes.md bővült az új FormLabelStyle stílus említésével.

--- a/docs/progress/2025-07-04_21-06-28_ui_agent.md
+++ b/docs/progress/2025-07-04_21-06-28_ui_agent.md
@@ -1,0 +1,1 @@
+- FormLabelStyle definiálva mindkét témában, InvoiceEditorView a címke stílusát erre frissíti.

--- a/docs/themes.md
+++ b/docs/themes.md
@@ -20,7 +20,7 @@ A Retro UI hangs on a 16 színű DOS-palettán. A XAML erőforrás szótár egys
 Stílusok:
 - **HeaderText**, **HeaderTextBold**: IBM Plex Mono betűcsalád feliratokhoz.
 - **HeaderTextBoxBold**: ugyanez a megjelenés szövegmezőknél.
-- **LabelTextStyle**, **ValueTextStyle**, **BoldTotalStyle**: számlamezők és összesítések tipográfiája mindkét témában.
+- **FormLabelStyle**, **LabelTextStyle**, **ValueTextStyle**, **BoldTotalStyle**: számlamezők és összesítések tipográfiája mindkét témában.
 
 Betűméretek:
 - **FontSizeNormal:** 16 px, általános szövegekhez és űrlapmezőkhöz.


### PR DESCRIPTION
## Summary
- add `FormLabelStyle` for Label controls
- update InvoiceEditorView to use new style
- document style in `themes.md`
- log progress

## Testing
- `dotnet test --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868415edec08322a0a7b258722ddea7