### PR TITLE
Extend startup UI tests

### DIFF
--- a/docs/progress/2025-07-04_21-37-01_test_agent.md
+++ b/docs/progress/2025-07-04_21-37-01_test_agent.md
@@ -1,0 +1,1 @@
+- Startup UI tesztek bővítve: Kilépés gombra kattintva a SetupWindow és a UserInfoWindow bezárásakor az alkalmazás leállását ellenőrizzük.

--- a/tests/Wrecept.UiTests/StartupWindowTests.cs
+++ b/tests/Wrecept.UiTests/StartupWindowTests.cs
@@ -89,4 +89,36 @@ public class StartupWindowTests
             .FindElementByName("Wrecept"));
         driver.Close();
     }
+
+    [TestMethod]
+    public void SetupWindow_Cancel_ClosesApplication()
+    {
+        PrepareSettings(firstRun: true);
+        using var driver = TestHelper.LaunchAppRaw();
+
+        var wait = new WebDriverWait(driver, TimeSpan.FromSeconds(5));
+        var setupWindow = wait.Until(d => ((WindowsDriver<WindowsElement>)d)
+            .FindElementByName("Első indítás"));
+        setupWindow.FindElementByName("Mégse").Click();
+
+        Assert.ThrowsException<WebDriverException>(() => _ = driver.Title);
+    }
+
+    [TestMethod]
+    public void UserInfoEditor_Cancel_ClosesApplication()
+    {
+        PrepareSettings(firstRun: true);
+        using var driver = TestHelper.LaunchAppRaw();
+
+        var wait = new WebDriverWait(driver, TimeSpan.FromSeconds(5));
+        var setupWindow = wait.Until(d => ((WindowsDriver<WindowsElement>)d)
+            .FindElementByName("Első indítás"));
+        setupWindow.FindElementByName("OK").Click();
+
+        var editorWindow = wait.Until(d => ((WindowsDriver<WindowsElement>)d)
+            .FindElementByName("Tulajdonosi adatok"));
+        editorWindow.FindElementByName("Mégse").Click();
+
+        Assert.ThrowsException<WebDriverException>(() => _ = driver.Title);
+    }
 }

--- a/tests/Wrecept.UiTests/TestHelper.cs
+++ b/tests/Wrecept.UiTests/TestHelper.cs
@@ -75,6 +75,26 @@ internal static class TestHelper
         }
     }
 
+    internal static WindowsDriver<WindowsElement> LaunchAppRaw()
+    {
+        var options = new AppiumOptions();
+        options.AddAdditionalCapability("app", ExePath);
+
+        var driver = new WindowsDriver<WindowsElement>(new Uri(WinAppDriverUrl), options);
+
+        try
+        {
+            WaitForUiReady(driver);
+            return driver;
+        }
+        catch
+        {
+            SaveScreenshot(driver);
+            driver.Close();
+            throw;
+        }
+    }
+
     internal static void DismissFirstLaunchDialogs(WindowsDriver<WindowsElement> driver)
     {
         foreach (var title in new[] { "Első indítás", "Megerősítés" })


### PR DESCRIPTION
## Summary
- add `LaunchAppRaw` to avoid automatic first-run handling
- test cancelling at SetupWindow and UserInfoWindow
- log progress for new test cases

## Testing
- `dotnet test --no-build tests/Wrecept.UiTests/Wrecept.UiTests.csproj` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*
- `dotnet test tests/Wrecept.Tests/Wrecept.Tests.csproj --no-build` *(no tests executed)*

------
https://chatgpt.com/codex/tasks/task_e_686846b12e288322a7794c08e231c46a