### PR TITLE
Alapértelmezett számla kijelölés javítása

### DIFF
--- a/Wrecept.Wpf/ViewModels/InvoiceLookupViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/InvoiceLookupViewModel.cs
@@ -55,6 +55,9 @@ public partial class InvoiceLookupViewModel : ObservableObject
                 Supplier = inv.Supplier?.Name ?? string.Empty
             });
         }
+
+        if (Invoices.Count > 0)
+            SelectedInvoice = Invoices[0];
     }
 
     public Task<int> CreateInvoiceAsync(string number)

--- a/docs/progress/2025-07-04_23-07-11_code_agent.md
+++ b/docs/progress/2025-07-04_23-07-11_code_agent.md
@@ -1,0 +1,2 @@
+- InvoiceLookupViewModel.LoadAsync kijelöli a legfrissebb számlát.
+- Új teszt ellenőrzi a kiválasztást.

--- a/tests/viewmodels/InvoiceLookupViewModelTests.cs
+++ b/tests/viewmodels/InvoiceLookupViewModelTests.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+using Wrecept.Wpf.ViewModels;
+using Wrecept.Core.Models;
+using Wrecept.Core.Services;
+
+namespace Wrecept.Tests.ViewModels;
+
+public class InvoiceLookupViewModelTests
+{
+    private class FakeInvoiceService : IInvoiceService
+    {
+        public List<Invoice> Invoices { get; } = new();
+        public Task<List<Invoice>> GetRecentAsync(int count, System.Threading.CancellationToken ct = default)
+            => Task.FromResult(Invoices);
+
+        public Task<bool> CreateAsync(Invoice invoice, System.Threading.CancellationToken ct = default)
+            => throw new NotImplementedException();
+        public Task<int> CreateHeaderAsync(Invoice invoice, System.Threading.CancellationToken ct = default)
+            => throw new NotImplementedException();
+        public Task<int> AddItemAsync(InvoiceItem item, System.Threading.CancellationToken ct = default)
+            => throw new NotImplementedException();
+        public Task UpdateInvoiceHeaderAsync(int id, DateOnly date, int supplierId, Guid paymentMethodId, bool isGross, System.Threading.CancellationToken ct = default)
+            => throw new NotImplementedException();
+        public Task ArchiveAsync(int id, System.Threading.CancellationToken ct = default)
+            => throw new NotImplementedException();
+        public Task<Invoice?> GetAsync(int id, System.Threading.CancellationToken ct = default)
+            => throw new NotImplementedException();
+        public Task<LastUsageData?> GetLastUsageDataAsync(int supplierId, int productId, System.Threading.CancellationToken ct = default)
+            => throw new NotImplementedException();
+        public InvoiceCalculationResult RecalculateTotals(Invoice invoice)
+            => throw new NotImplementedException();
+    }
+
+    [Fact]
+    public async Task LoadAsync_SelectsFirstInvoice()
+    {
+        var service = new FakeInvoiceService();
+        service.Invoices.Add(new Invoice { Id = 1, Number = "A1", Date = DateOnly.FromDateTime(DateTime.Today) });
+        service.Invoices.Add(new Invoice { Id = 2, Number = "A2", Date = DateOnly.FromDateTime(DateTime.Today.AddDays(-1)) });
+
+        var vm = new InvoiceLookupViewModel(service);
+        await vm.LoadAsync();
+
+        Assert.Equal(1, vm.SelectedInvoice?.Id);
+    }
+}


### PR DESCRIPTION
## Összefoglaló
- InvoiceLookupViewModel betöltéskor automatikusan kiválasztja az első (legújabb) számlát
- új egységteszt ellenőrzi a viselkedést
- naplófrissítés a haladás mappában

## Tesztelés
- `dotnet test --no-build` *(hibás a WindowsDesktop SDK hiánya miatt)*

------
https://chatgpt.com/codex/tasks/task_e_68685dd0be8483228d98938473f38455