### PR TITLE
Fix InvoiceLookup focus timing

### DIFF
--- a/Wrecept.Wpf/Views/InvoiceLookupView.xaml.cs
+++ b/Wrecept.Wpf/Views/InvoiceLookupView.xaml.cs
@@ -31,8 +31,11 @@ public partial class InvoiceLookupView : UserControl
         try
         {
             if (DataContext is InvoiceLookupViewModel vm)
+            {
                 await vm.LoadAsync();
-            _focus.RequestFocus("InvoiceList", typeof(InvoiceLookupView));
+                if (vm.Invoices.Count > 0)
+                    _focus.RequestFocus("InvoiceList", typeof(InvoiceLookupView));
+            }
         }
         catch (Exception ex)
         {

--- a/docs/progress/2025-07-04_23-28-37_code_agent.md
+++ b/docs/progress/2025-07-04_23-28-37_code_agent.md
@@ -1,0 +1,1 @@
+- OnLoaded-ben a fókusz csak adatbetöltés után aktiválódik, és csak ha van számla.


### PR DESCRIPTION
## Summary
- focus requested only after data load, if invoices exist
- log progress for focus timing fix

## Testing
- `dotnet test --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_686863180b44832295413eff21cc7c54