### PR TITLE
Refactor focus management

### DIFF
--- a/Wrecept.Wpf/Services/FocusManager.cs
+++ b/Wrecept.Wpf/Services/FocusManager.cs
@@ -3,12 +3,21 @@ using System.Collections.Generic;
 using System.Windows;
 using System.Windows.Threading;
 using System.Windows.Media;
+using Wrecept.Core.Enums;
 
 namespace Wrecept.Wpf.Services;
 
 public class FocusManager
 {
     private readonly Dictionary<string, WeakReference<IInputElement>> _map = new();
+    private readonly AppStateService _state;
+
+    public FocusManager() : this(new AppStateService()) { }
+
+    public FocusManager(AppStateService state)
+    {
+        _state = state;
+    }
 
     public void Update(string viewKey, IInputElement element)
     {
@@ -24,11 +33,17 @@ public class FocusManager
 
     public void RequestFocus(IInputElement? element)
     {
+        if (_state.Current is AppState.Saving or AppState.DialogOpen or AppState.Error or AppState.PromptActive)
+            return;
+
         Application.Current.Dispatcher.BeginInvoke(() => element?.Focus(), DispatcherPriority.Background);
     }
 
     public void RequestFocus(string elementName, Type? viewType = null)
     {
+        if (_state.Current is AppState.Saving or AppState.DialogOpen or AppState.Error or AppState.PromptActive)
+            return;
+
         Application.Current.Dispatcher.BeginInvoke(() =>
         {
             if (Application.Current.MainWindow is null)

--- a/Wrecept.Wpf/Views/Controls/BaseMasterView.cs
+++ b/Wrecept.Wpf/Views/Controls/BaseMasterView.cs
@@ -68,7 +68,7 @@ public abstract class BaseMasterView : UserControl
         Loaded += async (_, _) =>
         {
             await viewModel.LoadAsync();
-            Grid.Focus();
+            _focus.RequestFocus(Grid);
         };
 
         BindingOperations.SetBinding(Grid, ItemsControl.ItemsSourceProperty, new Binding("Items"));
@@ -123,8 +123,8 @@ public abstract class BaseMasterView : UserControl
     {
         if (e.DetailsElement.FindName("InitialFocus") is Control box &&
             e.Row.DetailsVisibility == Visibility.Visible)
-            box.Focus();
+            _focus.RequestFocus(box);
         else if (e.Row.DetailsVisibility != Visibility.Visible)
-            Grid.Focus();
+            _focus.RequestFocus(Grid);
     }
 }

--- a/Wrecept.Wpf/Views/InlineCreators/PaymentMethodCreatorView.xaml
+++ b/Wrecept.Wpf/Views/InlineCreators/PaymentMethodCreatorView.xaml
@@ -1,8 +1,7 @@
 <UserControl x:Class="Wrecept.Wpf.Views.InlineCreators.PaymentMethodCreatorView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             KeyDown="OnKeyDown"
-             FocusManager.FocusedElement="{Binding ElementName=NameBox}">
+             KeyDown="OnKeyDown">
     <Border Background="#F5F5DC" Padding="4" Margin="0,4,0,0">
         <StackPanel>
             <TextBlock Text="Új fizetési mód" FontWeight="Bold" />

--- a/Wrecept.Wpf/Views/InlineCreators/ProductCreatorView.xaml
+++ b/Wrecept.Wpf/Views/InlineCreators/ProductCreatorView.xaml
@@ -2,8 +2,7 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="clr-namespace:Wrecept.Wpf.ViewModels"
-             KeyDown="OnKeyDown"
-             FocusManager.FocusedElement="{Binding ElementName=NameBox}">
+             KeyDown="OnKeyDown">
     <Border Background="#F5F5DC" Padding="4" Margin="0,4,0,0">
         <StackPanel>
             <TextBlock Text="Új termék" FontWeight="Bold" />

--- a/Wrecept.Wpf/Views/InlineCreators/SupplierCreatorView.xaml
+++ b/Wrecept.Wpf/Views/InlineCreators/SupplierCreatorView.xaml
@@ -1,8 +1,7 @@
 <UserControl x:Class="Wrecept.Wpf.Views.InlineCreators.SupplierCreatorView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             KeyDown="OnKeyDown"
-             FocusManager.FocusedElement="{Binding ElementName=NameBox}">
+             KeyDown="OnKeyDown">
     <Border Background="#F5F5DC" Padding="4" Margin="0,4,0,0">
         <StackPanel>
             <TextBlock Text="Új szállító" FontWeight="Bold" />

--- a/Wrecept.Wpf/Views/InlineCreators/TaxRateCreatorView.xaml
+++ b/Wrecept.Wpf/Views/InlineCreators/TaxRateCreatorView.xaml
@@ -1,8 +1,7 @@
 <UserControl x:Class="Wrecept.Wpf.Views.InlineCreators.TaxRateCreatorView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             KeyDown="OnKeyDown"
-             FocusManager.FocusedElement="{Binding ElementName=NameBox}">
+             KeyDown="OnKeyDown">
     <Border Background="#F5F5DC" Padding="4" Margin="0,4,0,0">
         <StackPanel>
             <TextBlock Text="Új ÁFA kulcs" FontWeight="Bold" />

--- a/Wrecept.Wpf/Views/InlineCreators/UnitCreatorView.xaml
+++ b/Wrecept.Wpf/Views/InlineCreators/UnitCreatorView.xaml
@@ -1,8 +1,7 @@
 <UserControl x:Class="Wrecept.Wpf.Views.InlineCreators.UnitCreatorView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             KeyDown="OnKeyDown"
-             FocusManager.FocusedElement="{Binding ElementName=NameBox}">
+             KeyDown="OnKeyDown">
     <Border Background="#F5F5DC" Padding="4" Margin="0,4,0,0">
         <StackPanel>
             <TextBlock Text="Új mértékegység" FontWeight="Bold" />

--- a/Wrecept.Wpf/Views/InvoiceEditorView.xaml
+++ b/Wrecept.Wpf/Views/InvoiceEditorView.xaml
@@ -7,8 +7,7 @@
             xmlns:views="clr-namespace:Wrecept.Wpf.Views.InlineCreators"
             xmlns:prompt="clr-namespace:Wrecept.Wpf.Views.InlinePrompts"
             xmlns:c="clr-namespace:Wrecept.Wpf.Views.Controls"
-            KeyDown="OnKeyDown"
-             FocusManager.FocusedElement="{Binding ElementName=InvoiceList}">
+            KeyDown="OnKeyDown">
     <UserControl.Resources>
         <local:NegativeValueForegroundConverter x:Key="NegativeForegroundConverter" />
         <local:IsReadOnlyBindingConverter x:Key="IsReadOnlyConverter" />

--- a/Wrecept.Wpf/Views/InvoiceEditorView.xaml.cs
+++ b/Wrecept.Wpf/Views/InvoiceEditorView.xaml.cs
@@ -49,7 +49,7 @@ public partial class InvoiceEditorView : UserControl
     {
         if (e.Key == Key.Escape)
         {
-            LookupView.InvoiceList.Focus();
+            _focus.RequestFocus(LookupView.InvoiceList);
             e.Handled = true;
             return;
         }
@@ -106,9 +106,9 @@ public partial class InvoiceEditorView : UserControl
             if (InlineCreatorHost.Content is FrameworkElement fe)
             {
                 if (fe.FindName("NameBox") is IInputElement box)
-                    Keyboard.Focus(box);
+                    _focus.RequestFocus(box);
                 else
-                    fe.MoveFocus(new TraversalRequest(FocusNavigationDirection.First));
+                    _focus.RequestFocus(fe);
             }
         }, DispatcherPriority.Background);
     }

--- a/Wrecept.Wpf/Views/StageView.xaml.cs
+++ b/Wrecept.Wpf/Views/StageView.xaml.cs
@@ -39,12 +39,12 @@ public partial class StageView : UserControl
         {
             if (_lastMenuItem is not null)
             {
-                _lastMenuItem.Focus();
+                _focus.RequestFocus(_lastMenuItem);
             }
             else if (Menu.Items.Count > 0)
             {
                 if (Menu.Items[0] is MenuItem first)
-                    first.Focus();
+                    _focus.RequestFocus(first);
             }
 
             e.Handled = true;

--- a/docs/progress/2025-07-05_00-55-23_code_agent.md
+++ b/docs/progress/2025-07-05_00-55-23_code_agent.md
@@ -1,0 +1,1 @@
+- Focuskezelés centralizálva, AppState alapú védelemmel.


### PR DESCRIPTION
## Summary
- centralize focus guard with `AppStateService`
- remove direct `Focus()` usage across views
- drop XAML `FocusManager.FocusedElement` attributes
- log progress

## Testing
- `dotnet test --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*
- `dotnet build --no-restore` *(fails: package restore required)*

------
https://chatgpt.com/codex/tasks/task_e_6868769d75248322b932c859aa5f5f18