### PR TITLE
Fix invoice list arrow navigation

### DIFF
--- a/Wrecept.Wpf/Views/InvoiceLookupView.xaml
+++ b/Wrecept.Wpf/Views/InvoiceLookupView.xaml
@@ -18,7 +18,8 @@
                  ItemsSource="{Binding Invoices}"
                  SelectedItem="{Binding SelectedInvoice}"
                  Margin="4"
-                 TabIndex="0">
+                 TabIndex="0"
+                 KeyboardNavigation.DirectionalNavigation="None">
             <ListBox.ItemTemplate>
                 <DataTemplate>
                     <StackPanel Orientation="Horizontal">

--- a/docs/KeyboardFlow.md
+++ b/docs/KeyboardFlow.md
@@ -74,6 +74,7 @@ A billentyűzetes navigációt a sebesség és az időtálló megszokhatóság j
 2. A dialógusok (`DialogHelper`) `Enter`/`Escape` kezeléséhez.
 3. Az `EditLookup` és `SmartLookup` szövegmezőinél a legördülő lista navigációjához.
 - A `ListBox`, `DataGrid`, `ComboBox`, `TreeView`, valamint a `Menu` és `MenuItem` saját nyílkezelése elsőbbséget élvez; a `KeyboardManager` ilyen őst találva nem mozdít fókuszt.
+- Lista vezérlőknél `KeyboardNavigation.DirectionalNavigation` értéke `None`, így a nyilak nem ugranak ki a listából.
 
 ## 🔧 Future Enhancements
 

--- a/docs/progress/2025-07-05_01-08-39_ui_agent.md
+++ b/docs/progress/2025-07-05_01-08-39_ui_agent.md
@@ -1,0 +1,2 @@
+- InvoiceLookupView listához DirectionalNavigation=None beállítás került, így a nyilak nem lépnek ki a listából.
+- KeyboardFlow dokumentum kiegészült a szabállyal.


### PR DESCRIPTION
## Summary
- keep focus inside InvoiceList while pressing up/down
- document DirectionalNavigation rule in KeyboardFlow
- log UI update

## Testing
- `dotnet test --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_68687a3f201c8322acb93ed0358f17c0