### PR TITLE
Replace MoveFocus with FocusManager

### DIFF
--- a/Wrecept.Wpf/Views/Controls/EditLookup.xaml.cs
+++ b/Wrecept.Wpf/Views/Controls/EditLookup.xaml.cs
@@ -3,6 +3,8 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Data;
 using System.Windows.Input;
+using Microsoft.Extensions.DependencyInjection;
+using FocusService = Wrecept.Wpf.Services.FocusManager;
 
 namespace Wrecept.Wpf.Views.Controls;
 
@@ -112,7 +114,9 @@ public partial class EditLookup : UserControl
             }
             else
             {
-                MoveFocus(new TraversalRequest(FocusNavigationDirection.Next));
+                var focus = App.Provider.GetRequiredService<FocusService>();
+                var next = (e.OriginalSource as UIElement)?.PredictFocus(FocusNavigationDirection.Next);
+                focus.RequestFocus(next as IInputElement);
             }
             e.Handled = true;
         }

--- a/Wrecept.Wpf/Views/Controls/SmartLookup.xaml.cs
+++ b/Wrecept.Wpf/Views/Controls/SmartLookup.xaml.cs
@@ -8,6 +8,8 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using System.Windows.Input;
+using Microsoft.Extensions.DependencyInjection;
+using FocusService = Wrecept.Wpf.Services.FocusManager;
 
 namespace Wrecept.Wpf.Views.Controls;
 
@@ -216,7 +218,9 @@ public partial class SmartLookup : UserControl
                 SelectedValue = GetProperty(PART_ListBox.SelectedItem, SelectedValuePath);
                 Text = GetProperty(PART_ListBox.SelectedItem, DisplayMemberPath)?.ToString() ?? string.Empty;
                 PART_Popup.IsOpen = false;
-                MoveFocus(new TraversalRequest(FocusNavigationDirection.Next));
+                var focus = App.Provider.GetRequiredService<FocusService>();
+                var next = (e.OriginalSource as UIElement)?.PredictFocus(FocusNavigationDirection.Next);
+                focus.RequestFocus(next as IInputElement);
             }
             else if (FilteredItems.Count == 0 && !string.IsNullOrWhiteSpace(Text))
             {

--- a/Wrecept.Wpf/Views/EditDialogs/UserInfoEditorView.xaml.cs
+++ b/Wrecept.Wpf/Views/EditDialogs/UserInfoEditorView.xaml.cs
@@ -3,6 +3,7 @@ using System.Windows.Controls;
 using System.Windows.Input;
 using Microsoft.Extensions.DependencyInjection;
 using Wrecept.Wpf.Services;
+using FocusService = Wrecept.Wpf.Services.FocusManager;
 
 namespace Wrecept.Wpf.Views.EditDialogs;
 
@@ -21,8 +22,10 @@ public partial class UserInfoEditorView : UserControl
     {
         if (e.Key == Key.Escape)
         {
+            var focus = App.Provider.GetRequiredService<FocusService>();
+            var next = (e.OriginalSource as UIElement)?.PredictFocus(FocusNavigationDirection.Previous);
+            focus.RequestFocus(next as IInputElement);
             e.Handled = true;
-            (e.OriginalSource as UIElement)?.MoveFocus(new TraversalRequest(FocusNavigationDirection.Previous));
             return;
         }
 

--- a/docs/progress/2025-07-05_01-40-22_code_agent.md
+++ b/docs/progress/2025-07-05_01-40-22_code_agent.md
@@ -1,0 +1,2 @@
+- MoveFocus hívások lecserélve FocusManager.RequestFocus használatára az EditLookup, SmartLookup és UserInfoEditorView kontrollokban.
+- StageViewFocusUITests bővült a fókusz-visszalépést ellenőrző teszttel.

--- a/tests/Wrecept.UiTests/StageViewFocusUITests.cs
+++ b/tests/Wrecept.UiTests/StageViewFocusUITests.cs
@@ -30,4 +30,23 @@ public class StageViewFocusUITests
 
         driver.Close();
     }
+
+    [TestMethod]
+    public void EscapeInUserInfoEditorMovesFocusBack()
+    {
+        using var driver = LaunchApp();
+
+        driver.FindElementByName("Névjegy").Click();
+        driver.FindElementByName("A program felhasználójának adatai").Click();
+
+        var wait = new WebDriverWait(driver, TimeSpan.FromSeconds(5));
+        var address = wait.Until(d => d.FindElementByAccessibilityId("AddressBox"));
+        address.Click();
+
+        new Actions(driver).SendKeys(Keys.Escape).Perform();
+        var active = driver.SwitchTo().ActiveElement();
+        Assert.AreEqual("CompanyNameBox", active.GetAttribute("AutomationId"));
+
+        driver.Close();
+    }
 }


### PR DESCRIPTION
## Summary
- refactor MoveFocus calls in EditLookup, SmartLookup and UserInfoEditorView to use FocusManager.RequestFocus
- extend StageViewFocusUITests with new focus-return scenario
- log progress

## Testing
- `dotnet test --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_686881810a908322bb4182ee45868497