### PR TITLE
Update FocusManager usage docs

### DIFF
--- a/docs/KeyboardFlow.md
+++ b/docs/KeyboardFlow.md
@@ -65,6 +65,7 @@ Az `Enter` alapértelmezésben a következő vezérlőre ugrik, ha az aktuális 
 ### Fókuszkövető szolgáltatás
 
 A `FocusManager` a nézetekhez rendelt kulcs alapján megjegyzi az utoljára fókuszba került vezérlőt. A promptok vagy nézetek bezárásakor ezen keresztül állítjuk vissza a fókuszt az eredeti elemre. A szolgáltatás singletonként regisztrált, így minden View és ViewModel DI-n keresztül éri el.
+Minden programozott fókuszváltáshoz **kötelező** a `FocusManager.RequestFocus` metódust használni; közvetlen `MoveFocus` vagy `Keyboard.Focus` hívás nem megengedett.
 
 ## 💡 Design Philosophy
 

--- a/docs/UI_FLOW.md
+++ b/docs/UI_FLOW.md
@@ -150,6 +150,7 @@ The FocusManager.RequestFocus helper accepts an optional view-type
 parameter to narrow the search scope; dynamic elements therefore need not use
 globally unique identifiers.
 FocusManager jegyzi meg, melyik vezérlő volt aktív a nézetekben, így a promptok bezárásakor visszaállítható a fókusz.
+Every programmatic focus change **must** invoke `FocusManager.RequestFocus`; direct `MoveFocus` calls are disallowed.
 
 📚 Future List Views
 

--- a/docs/progress/2025-07-05_01-45-38_docs_agent.md
+++ b/docs/progress/2025-07-05_01-45-38_docs_agent.md
@@ -1,0 +1,2 @@
+- KeyboardFlow.md frissítve: minden programozott fókuszváltásnál kötelező a FocusManager.RequestFocus használata.
+- UI_FLOW.md kiegészítve ugyanezzel a követelménnyel.


### PR DESCRIPTION
## Summary
- add mandatory use of FocusManager.RequestFocus to `KeyboardFlow.md`
- document same rule in `UI_FLOW.md`
- log progress for docs agent

## Testing
- `dotnet test Wrecept.Core.Tests/Wrecept.Core.Tests.csproj --no-build -v n`

------
https://chatgpt.com/codex/tasks/task_e_686882e087788322ace666ff23dd6ea3