### PR TITLE
Fix WPF design-time init and tests

### DIFF
--- a/Wrecept.Wpf/Views/Controls/BaseMasterView.cs
+++ b/Wrecept.Wpf/Views/Controls/BaseMasterView.cs
@@ -18,14 +18,15 @@ public abstract class BaseMasterView : UserControl
 
     protected DataGrid Grid { get; }
 
-    private readonly FocusManager _focus;
+    private readonly FocusManager? _focus;
 
     protected BaseMasterView()
     {
         Grid = BuildLayout();
         Loaded += OnLoaded;
         KeyDown += OnKeyDown;
-        _focus = App.Provider.GetRequiredService<FocusManager>();
+        if (App.Provider is not null)
+            _focus = App.Provider.GetRequiredService<FocusManager>();
         Keyboard.AddGotKeyboardFocusHandler(this, OnGotKeyboardFocus);
     }
 
@@ -68,7 +69,7 @@ public abstract class BaseMasterView : UserControl
         Loaded += async (_, _) =>
         {
             await viewModel.LoadAsync();
-            _focus.RequestFocus(Grid);
+            _focus?.RequestFocus(Grid);
         };
 
         BindingOperations.SetBinding(Grid, ItemsControl.ItemsSourceProperty, new Binding("Items"));
@@ -86,10 +87,11 @@ public abstract class BaseMasterView : UserControl
             Grid.RowDetailsTemplate = RowDetailsTemplate;
     }
 
-    private readonly KeyboardManager _keyboard = App.Provider.GetRequiredService<KeyboardManager>();
+    private readonly KeyboardManager? _keyboard =
+        App.Provider is not null ? App.Provider.GetRequiredService<KeyboardManager>() : null;
 
     private void OnKeyDown(object? sender, KeyEventArgs e)
-        => _keyboard.Handle(e);
+        => _keyboard?.Handle(e);
 
     private void Grid_PreviewKeyDown(object? sender, KeyEventArgs e)
     {
@@ -117,14 +119,14 @@ public abstract class BaseMasterView : UserControl
     }
 
     private void OnGotKeyboardFocus(object sender, KeyboardFocusChangedEventArgs e)
-        => _focus.Update(GetType().Name, e.NewFocus);
+        => _focus?.Update(GetType().Name, e.NewFocus);
 
     private void Grid_RowDetailsVisibilityChanged(object? sender, DataGridRowDetailsEventArgs e)
     {
         if (e.DetailsElement.FindName("InitialFocus") is Control box &&
             e.Row.DetailsVisibility == Visibility.Visible)
-            _focus.RequestFocus(box);
+            _focus?.RequestFocus(box);
         else if (e.Row.DetailsVisibility != Visibility.Visible)
-            _focus.RequestFocus(Grid);
+            _focus?.RequestFocus(Grid);
     }
 }

--- a/Wrecept.Wpf/Views/EditDialogs/ProductEditorView.xaml.cs
+++ b/Wrecept.Wpf/Views/EditDialogs/ProductEditorView.xaml.cs
@@ -7,12 +7,15 @@ namespace Wrecept.Wpf.Views.EditDialogs;
 
 public partial class ProductEditorView : UserControl
 {
-    private readonly KeyboardManager _keyboard = App.Provider.GetRequiredService<KeyboardManager>();
+    private readonly KeyboardManager? _keyboard;
+
     public ProductEditorView()
     {
+        if (App.Provider is not null)
+            _keyboard = App.Provider.GetRequiredService<KeyboardManager>();
         InitializeComponent();
     }
 
     private void OnKeyDown(object sender, KeyEventArgs e)
-        => _keyboard.Handle(e);
+        => _keyboard?.Handle(e);
 }

--- a/Wrecept.Wpf/Views/InlineCreators/PaymentMethodCreatorView.xaml.cs
+++ b/Wrecept.Wpf/Views/InlineCreators/PaymentMethodCreatorView.xaml.cs
@@ -7,12 +7,15 @@ namespace Wrecept.Wpf.Views.InlineCreators;
 
 public partial class PaymentMethodCreatorView : UserControl
 {
-    private readonly KeyboardManager _keyboard = App.Provider.GetRequiredService<KeyboardManager>();
+    private readonly KeyboardManager? _keyboard;
+
     public PaymentMethodCreatorView()
     {
+        if (App.Provider is not null)
+            _keyboard = App.Provider.GetRequiredService<KeyboardManager>();
         InitializeComponent();
     }
 
     private void OnKeyDown(object sender, KeyEventArgs e)
-        => _keyboard.Handle(e);
+        => _keyboard?.Handle(e);
 }

--- a/Wrecept.Wpf/Views/InlineCreators/ProductCreatorView.xaml.cs
+++ b/Wrecept.Wpf/Views/InlineCreators/ProductCreatorView.xaml.cs
@@ -7,9 +7,12 @@ namespace Wrecept.Wpf.Views.InlineCreators;
 
 public partial class ProductCreatorView : UserControl
 {
-    private readonly KeyboardManager _keyboard = App.Provider.GetRequiredService<KeyboardManager>();
+    private readonly KeyboardManager? _keyboard;
+
     public ProductCreatorView()
     {
+        if (App.Provider is not null)
+            _keyboard = App.Provider.GetRequiredService<KeyboardManager>();
         InitializeComponent();
     }
 
@@ -21,6 +24,6 @@ public partial class ProductCreatorView : UserControl
             e.Handled = true;
             return;
         }
-        _keyboard.Handle(e);
+        _keyboard?.Handle(e);
     }
 }

--- a/Wrecept.Wpf/Views/InlineCreators/SupplierCreatorView.xaml.cs
+++ b/Wrecept.Wpf/Views/InlineCreators/SupplierCreatorView.xaml.cs
@@ -7,12 +7,15 @@ namespace Wrecept.Wpf.Views.InlineCreators;
 
 public partial class SupplierCreatorView : UserControl
 {
-    private readonly KeyboardManager _keyboard = App.Provider.GetRequiredService<KeyboardManager>();
+    private readonly KeyboardManager? _keyboard;
+
     public SupplierCreatorView()
     {
+        if (App.Provider is not null)
+            _keyboard = App.Provider.GetRequiredService<KeyboardManager>();
         InitializeComponent();
     }
 
     private void OnKeyDown(object sender, KeyEventArgs e)
-        => _keyboard.Handle(e);
+        => _keyboard?.Handle(e);
 }

--- a/Wrecept.Wpf/Views/InlineCreators/TaxRateCreatorView.xaml.cs
+++ b/Wrecept.Wpf/Views/InlineCreators/TaxRateCreatorView.xaml.cs
@@ -7,12 +7,15 @@ namespace Wrecept.Wpf.Views.InlineCreators;
 
 public partial class TaxRateCreatorView : UserControl
 {
-    private readonly KeyboardManager _keyboard = App.Provider.GetRequiredService<KeyboardManager>();
+    private readonly KeyboardManager? _keyboard;
+
     public TaxRateCreatorView()
     {
+        if (App.Provider is not null)
+            _keyboard = App.Provider.GetRequiredService<KeyboardManager>();
         InitializeComponent();
     }
 
     private void OnKeyDown(object sender, KeyEventArgs e)
-        => _keyboard.Handle(e);
+        => _keyboard?.Handle(e);
 }

--- a/Wrecept.Wpf/Views/InlineCreators/UnitCreatorView.xaml.cs
+++ b/Wrecept.Wpf/Views/InlineCreators/UnitCreatorView.xaml.cs
@@ -7,12 +7,15 @@ namespace Wrecept.Wpf.Views.InlineCreators;
 
 public partial class UnitCreatorView : UserControl
 {
-    private readonly KeyboardManager _keyboard = App.Provider.GetRequiredService<KeyboardManager>();
+    private readonly KeyboardManager? _keyboard;
+
     public UnitCreatorView()
     {
+        if (App.Provider is not null)
+            _keyboard = App.Provider.GetRequiredService<KeyboardManager>();
         InitializeComponent();
     }
 
     private void OnKeyDown(object sender, KeyEventArgs e)
-        => _keyboard.Handle(e);
+        => _keyboard?.Handle(e);
 }

--- a/Wrecept.Wpf/Views/InvoiceEditorView.xaml.cs
+++ b/Wrecept.Wpf/Views/InvoiceEditorView.xaml.cs
@@ -15,18 +15,30 @@ namespace Wrecept.Wpf.Views;
 
 public partial class InvoiceEditorView : UserControl
 {
-    private readonly KeyboardManager _keyboard;
-    private readonly FocusManager _focus;
-    public InvoiceEditorView() : this(App.Provider.GetRequiredService<InvoiceEditorViewModel>())
+    private readonly KeyboardManager? _keyboard;
+    private readonly FocusManager? _focus;
+
+    public InvoiceEditorView()
     {
+        if (App.Provider is null)
+        {
+            InitializeComponent();
+            return;
+        }
+        Initialize(App.Provider.GetRequiredService<InvoiceEditorViewModel>());
     }
 
     public InvoiceEditorView(InvoiceEditorViewModel viewModel)
     {
+        Initialize(viewModel);
+    }
+
+    private void Initialize(InvoiceEditorViewModel viewModel)
+    {
         InitializeComponent();
         DataContext = viewModel;
-        _keyboard = App.Provider.GetRequiredService<KeyboardManager>();
-        _focus = App.Provider.GetRequiredService<FocusManager>();
+        _keyboard = App.Provider?.GetRequiredService<KeyboardManager>();
+        _focus = App.Provider?.GetRequiredService<FocusManager>();
         Keyboard.AddGotKeyboardFocusHandler(this, OnGotKeyboardFocus);
         Loaded += async (_, _) =>
         {
@@ -41,8 +53,8 @@ public partial class InvoiceEditorView : UserControl
             });
             await viewModel.LoadAsync(progress);
             progressWindow.Close();
-            Dispatcher.InvokeAsync(() =>
-                _focus.RequestFocus("InvoiceList", typeof(InvoiceEditorView)),
+            _ = Dispatcher.InvokeAsync(() =>
+                _focus?.RequestFocus("InvoiceList", typeof(InvoiceEditorView)),
                 DispatcherPriority.ContextIdle);
         };
     }
@@ -51,11 +63,11 @@ public partial class InvoiceEditorView : UserControl
     {
         if (e.Key == Key.Escape)
         {
-            _focus.RequestFocus(LookupView.InvoiceList);
+            _focus?.RequestFocus(LookupView.InvoiceList);
             e.Handled = true;
             return;
         }
-        _keyboard.Handle(e);
+        _keyboard?.Handle(e);
     }
 
     private async void OnEntryKeyDown(object sender, KeyEventArgs e)
@@ -89,7 +101,7 @@ public partial class InvoiceEditorView : UserControl
                 return;
             }
 
-            _keyboard.Handle(e);
+            _keyboard?.Handle(e);
         }
         catch (Exception ex)
         {
@@ -99,7 +111,7 @@ public partial class InvoiceEditorView : UserControl
     }
 
     private void OnGotKeyboardFocus(object sender, KeyboardFocusChangedEventArgs e)
-        => _focus.Update("InvoiceEditorView", e.NewFocus);
+        => _focus?.Update("InvoiceEditorView", e.NewFocus);
 
     private void OnInlineCreatorOpened(object sender, EventArgs e)
     {
@@ -111,9 +123,9 @@ public partial class InvoiceEditorView : UserControl
             if (InlineCreatorHost.Content is FrameworkElement fe)
             {
                 if (fe.FindName("NameBox") is IInputElement box)
-                    _focus.RequestFocus(box);
+                    _focus?.RequestFocus(box);
                 else
-                    _focus.RequestFocus(fe);
+                    _focus?.RequestFocus(fe);
             }
         }, DispatcherPriority.Background);
     }

--- a/docs/progress/2025-07-05_02-09-15_code_agent.md
+++ b/docs/progress/2025-07-05_02-09-15_code_agent.md
@@ -1,0 +1,4 @@
+- Fixed design-time service initialization in inline creator views
+- Guarded InvoiceEditorView constructors and focus handling
+- Suppressed CS4014 via Dispatcher.InvokeAsync discard
+- Corrected UI test element lookups with explicit WindowsDriver cast

--- a/tests/Wrecept.UiTests/LookupFocusTests.cs
+++ b/tests/Wrecept.UiTests/LookupFocusTests.cs
@@ -21,7 +21,7 @@ public class LookupFocusTests
         using var driver = LaunchApp();
 
         var wait = new WebDriverWait(driver, TimeSpan.FromSeconds(5));
-        var product = wait.Until(d => d.FindElementByAccessibilityId("EntryProduct"));
+        var product = wait.Until(d => ((WindowsDriver<WindowsElement>)d).FindElementByAccessibilityId("EntryProduct"));
         product.Click();
 
         new Actions(driver).SendKeys(Keys.Enter).Perform();

--- a/tests/Wrecept.UiTests/StageViewFocusUITests.cs
+++ b/tests/Wrecept.UiTests/StageViewFocusUITests.cs
@@ -40,7 +40,7 @@ public class StageViewFocusUITests
         driver.FindElementByName("A program felhasználójának adatai").Click();
 
         var wait = new WebDriverWait(driver, TimeSpan.FromSeconds(5));
-        var address = wait.Until(d => d.FindElementByAccessibilityId("AddressBox"));
+        var address = wait.Until(d => ((WindowsDriver<WindowsElement>)d).FindElementByAccessibilityId("AddressBox"));
         address.Click();
 
         new Actions(driver).SendKeys(Keys.Escape).Perform();


### PR DESCRIPTION
## Summary
- guard inline creator constructors against missing DI
- fix InvoiceEditorView initialization
- cast to WindowsDriver in UI tests
- update progress log

## Testing
- `dotnet test --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_686887e0534483229513c0bd545b479f