### PR TITLE
Fix MC3061 parse error

### DIFF
--- a/Wrecept.Wpf/Views/InvoiceEditorView.xaml
+++ b/Wrecept.Wpf/Views/InvoiceEditorView.xaml
@@ -21,7 +21,7 @@
             <views:TaxRateCreatorView/>
         </DataTemplate>
         <DataTemplate DataType="{x:Type vm:UnitCreatorViewModel}">
-            z<views:UnitCreatorView/>
+            <views:UnitCreatorView />
         </DataTemplate>
         <DataTemplate DataType="{x:Type vm:PaymentMethodCreatorViewModel}">
             <views:PaymentMethodCreatorView/>

--- a/docs/BUILD_RUNTIME_NOTES.md
+++ b/docs/BUILD_RUNTIME_NOTES.md
@@ -18,6 +18,7 @@ Ez a jegyzet a fejlesztés során tapasztalt fordítási és futásidejű probl�
 - **Elgépelés vagy hiányzó záró tag** – az `InvoiceEditorView.xaml` fájlban egy fölösleges `</StackPanel>` tag miatt a build meghiúsult.
 - **Önzáró `DataGridTemplateColumn` hiánya** – ha a nyitó tag `>` jellel zárul és az attribútumok külön sorban szerepelnek, a parser MC3061 hibát dob.
 - **Teszt futtatásához szükséges csomag** – a `Xunit.StaFact` hiánya tesztfutási hibát eredményezhet Windows környezetben.
+- **Téves karakter a `DataTemplate`-ben** – ha egy véletlen karakter (pl. `z`) marad a sablon nyitó vagy záró tagja előtt, MC3061 hibával leáll a fordítás.
 
 ## Javaslatok
 

--- a/docs/progress/2025-07-05_12-21-10_ui_agent.md
+++ b/docs/progress/2025-07-05_12-21-10_ui_agent.md
@@ -1,0 +1,1 @@
+- InvoiceEditorView DataTemplate szöveghiba ("z") eltávolítva, MC3061 megszűnt.


### PR DESCRIPTION
## Summary
- remove stray character in InvoiceEditorView template
- document DataTemplate parse failure in BUILD_RUNTIME_NOTES
- log ui_agent fix

## Testing
- `dotnet build Wrecept.sln -c Debug`
- `dotnet test tests/Wrecept.UiTests/Wrecept.UiTests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_686918207acc8322bf275ec264c95ffd