### PR TITLE
Fix startup logging when DI fails

### DIFF
--- a/Wrecept.Wpf/App.xaml.cs
+++ b/Wrecept.Wpf/App.xaml.cs
@@ -233,7 +233,9 @@ public static IServiceProvider Provider => Services ?? throw new InvalidOperatio
         }
         catch (Exception ex)
         {
-            var log = Provider.GetRequiredService<ILogService>();
+            ILogService log = Services != null
+                ? Provider.GetRequiredService<ILogService>()
+                : new Wrecept.Storage.Services.LogService();
             await log.LogError("App.OnStartup", ex);
             MessageBox.Show(
                 "Váratlan hiba indításkor. Részletek a logs/startup.log fájlban.",

--- a/docs/progress/2025-07-05_16-23-50_code_agent.md
+++ b/docs/progress/2025-07-05_16-23-50_code_agent.md
@@ -1,0 +1,2 @@
+# Service initialization fail-safe
+- Kiegészítettem az `App.OnStartup` hibakezelését, hogy a naplózás akkor is működjön, ha a DI konténer még nem jött létre.


### PR DESCRIPTION
## Summary
- ensure App.OnStartup can log errors even if service provider is not built
- record progress for code_agent

## Testing
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_686950d3a06c832290271876bb09c64e