### PR TITLE
Add InvoiceEditor layout prototype

### DIFF
--- a/Wrecept.Wpf/Views/InvoiceEditorLayout.xaml
+++ b/Wrecept.Wpf/Views/InvoiceEditorLayout.xaml
@@ -1,0 +1,205 @@
+<UserControl x:Class="Wrecept.Wpf.Views.InvoiceEditorLayout"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="clr-namespace:Wrecept.Wpf.ViewModels"
+             xmlns:view="clr-namespace:Wrecept.Wpf.Views"
+             xmlns:views="clr-namespace:Wrecept.Wpf.Views.InlineCreators"
+             xmlns:prompt="clr-namespace:Wrecept.Wpf.Views.InlinePrompts"
+             xmlns:c="clr-namespace:Wrecept.Wpf.Views.Controls">
+    <!-- Inline creator and prompt templates -->
+    <UserControl.Resources>
+        <DataTemplate DataType="{x:Type vm:ProductCreatorViewModel}">
+            <views:ProductCreatorView/>
+        </DataTemplate>
+        <DataTemplate DataType="{x:Type vm:SupplierCreatorViewModel}">
+            <views:SupplierCreatorView/>
+        </DataTemplate>
+        <DataTemplate DataType="{x:Type vm:TaxRateCreatorViewModel}">
+            <views:TaxRateCreatorView/>
+        </DataTemplate>
+        <DataTemplate DataType="{x:Type vm:UnitCreatorViewModel}">
+            <views:UnitCreatorView />
+        </DataTemplate>
+        <DataTemplate DataType="{x:Type vm:PaymentMethodCreatorViewModel}">
+            <views:PaymentMethodCreatorView/>
+        </DataTemplate>
+        <DataTemplate DataType="{x:Type vm:SaveLinePromptViewModel}">
+            <prompt:SaveLinePromptView/>
+        </DataTemplate>
+        <DataTemplate DataType="{x:Type vm:ArchivePromptViewModel}">
+            <prompt:ArchivePromptView/>
+        </DataTemplate>
+        <DataTemplate DataType="{x:Type vm:DeleteItemPromptViewModel}">
+            <prompt:DeleteItemPromptView/>
+        </DataTemplate>
+    </UserControl.Resources>
+
+    <Grid Margin="6">
+        <Grid.ColumnDefinitions>
+            <!-- Left invoice list -->
+            <ColumnDefinition Width="Auto" MinWidth="220" />
+            <!-- Right panel with editor -->
+            <ColumnDefinition Width="*" />
+        </Grid.ColumnDefinitions>
+
+        <!-- 📄 Invoice list panel -->
+        <view:InvoiceLookupView x:Name="LookupView" DataContext="{Binding Lookup}" />
+
+        <!-- ➡️ Editor section -->
+        <Grid Grid.Column="1">
+            <Grid.RowDefinitions>
+                <!-- Header and summary -->
+                <RowDefinition Height="Auto" />
+                <!-- Line item entry row -->
+                <RowDefinition Height="Auto" />
+                <!-- Product lines grid -->
+                <RowDefinition Height="*" />
+                <!-- Hint text -->
+                <RowDefinition Height="Auto" />
+                <!-- Action buttons -->
+                <RowDefinition Height="Auto" />
+                <!-- Prompts -->
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+
+            <!-- Header + Summary block -->
+            <Grid Grid.Row="0" Margin="0,0,0,6">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="2*" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+
+                <!-- Header fields -->
+                <Border Padding="6" Margin="0,0,6,0" Background="{DynamicResource ControlBackgroundBrush}" BorderBrush="{DynamicResource HighlightBrush}" BorderThickness="1">
+                    <!-- Header section -->
+                    <UniformGrid Columns="2" Margin="4">
+                        <!-- Supplier -->
+                        <StackPanel Margin="0,0,6,0">
+                            <Label Content="_Szállító" Style="{StaticResource FormLabelStyle}" Target="{Binding ElementName=SupplierLookup}" />
+                            <c:SmartLookup x:Name="SupplierLookup" Width="220"
+                                           ItemsSource="{Binding Suppliers}"
+                                           DisplayMemberPath="Name"
+                                           SelectedValuePath="Id"
+                                           SelectedValue="{Binding SupplierId}"
+                                           CreateCommand="{Binding ShowSupplierCreatorCommand}"
+                                           CommandParameter="{Binding RelativeSource={RelativeSource Self}}"
+                                           Watermark="Kezdjen el gépelni..."
+                                           IsEnabled="{Binding IsEditable}" />
+                        </StackPanel>
+
+                        <!-- Date -->
+                        <StackPanel Margin="0,0,6,0">
+                            <Label Content="_Dátum" Style="{StaticResource FormLabelStyle}" Target="{Binding ElementName=DatePicker}" />
+                            <DatePicker x:Name="DatePicker" Width="220" SelectedDate="{Binding InvoiceDate}" IsEnabled="{Binding IsEditable}" />
+                        </StackPanel>
+
+                        <!-- Payment method -->
+                        <StackPanel Margin="0,6,6,0">
+                            <Label Content="_Fizetési mód" Style="{StaticResource FormLabelStyle}" Target="{Binding ElementName=PaymentLookup}" />
+                            <c:EditLookup x:Name="PaymentLookup" Width="220"
+                                          ItemsSource="{Binding PaymentMethods}"
+                                          DisplayMemberPath="Name"
+                                          SelectedValuePath="Id"
+                                          SelectedValue="{Binding PaymentMethodId}"
+                                          CreateCommand="{Binding ShowPaymentMethodCreatorCommand}"
+                                          CreateCommandParameter="{Binding RelativeSource={RelativeSource Self}}"
+                                          IsEnabled="{Binding IsEditable}" />
+                        </StackPanel>
+
+                        <!-- Invoice number -->
+                        <StackPanel Margin="0,6,0,0">
+                            <Label Content="_Számlaszám" Style="{StaticResource FormLabelStyle}" Target="{Binding ElementName=NumberBox}" />
+                            <TextBox x:Name="NumberBox" Width="220" Text="{Binding Number}" IsEnabled="{Binding IsNew}" Style="{StaticResource HeaderTextBoxBold}" />
+                        </StackPanel>
+                    </UniformGrid>
+                </Border>
+
+                <!-- Summary totals -->
+                <Border Grid.Column="1" Padding="6" Background="{DynamicResource ControlBackgroundBrush}" BorderBrush="{DynamicResource HighlightBrush}" BorderThickness="1">
+                    <c:TotalsPanel />
+                </Border>
+            </Grid>
+
+            <!-- Line input editor -->
+            <Border Grid.Row="1" Padding="6" Margin="0,0,0,6" Background="{DynamicResource ControlBackgroundBrush}" BorderBrush="{DynamicResource HighlightBrush}" BorderThickness="1">
+                <Grid DataContext="{Binding EditableItem}">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="200" />
+                        <ColumnDefinition Width="60" />
+                        <ColumnDefinition Width="80" />
+                        <ColumnDefinition Width="80" />
+                        <ColumnDefinition Width="100" />
+                    </Grid.ColumnDefinitions>
+
+                    <c:SmartLookup x:Name="EntryProduct" Grid.Column="0"
+                                   ItemsSource="{Binding DataContext.Products, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                   DisplayMemberPath="Name"
+                                   SelectedValuePath="Name"
+                                   SelectedValue="{Binding Product, Mode=TwoWay}"
+                                   Watermark="Termék neve"
+                                   CreateCommand="{Binding DataContext.ShowProductCreatorCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                   CommandParameter="{Binding RelativeSource={RelativeSource Self}}" />
+                    <TextBox x:Name="EntryQuantity" Grid.Column="1" Margin="4,0" Text="{Binding Quantity, Mode=TwoWay}" />
+                    <c:SmartLookup x:Name="EntryUnit" Grid.Column="2"
+                                   ItemsSource="{Binding DataContext.Units, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                   DisplayMemberPath="Name"
+                                   SelectedValuePath="Id"
+                                   SelectedValue="{Binding UnitId, Mode=TwoWay}"
+                                   Watermark="Me.e."
+                                   CreateCommand="{Binding DataContext.ShowUnitCreatorCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                   CommandParameter="{Binding RelativeSource={RelativeSource Self}}" />
+                    <TextBox x:Name="EntryPrice" Grid.Column="3" Margin="4,0" Text="{Binding UnitPrice, Mode=TwoWay}" />
+                    <c:EditLookup x:Name="EntryTax" Grid.Column="4" Tag="LastEntry"
+                                  ItemsSource="{Binding DataContext.TaxRates, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                  DisplayMemberPath="Name"
+                                  SelectedValuePath="Id"
+                                  SelectedValue="{Binding TaxRateId, Mode=TwoWay}"
+                                  CreateCommand="{Binding DataContext.ShowTaxRateCreatorCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                  CreateCommandParameter="{Binding RelativeSource={RelativeSource Self}}" />
+                </Grid>
+            </Border>
+
+            <!-- Product line list -->
+            <Border Grid.Row="2" Padding="0" Margin="0,0,0,6" BorderBrush="{DynamicResource HighlightBrush}" BorderThickness="1">
+                <view:InvoiceItemsGrid x:Name="ItemsGrid" />
+            </Border>
+
+            <!-- Hint text -->
+            <TextBlock Grid.Row="3" Text="Negatív mennyiség visszárut jelez." FontStyle="{x:Static FontStyles.Italic}" Margin="0,4" />
+
+            <!-- Action buttons -->
+            <StackPanel Grid.Row="4" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0">
+                <Button Content="Mentés" Command="{Binding SaveCommand}" IsEnabled="{Binding IsEditable}" Margin="0,0,4,0" />
+                <Button Content="Nyomtatás" IsEnabled="{Binding IsArchived}" Margin="0,0,4,0" />
+                <Button Content="Bezárás" Command="{Binding CloseCommand}" Margin="0,0,4,0" />
+                <Button Content="📦 Véglegesítés" Command="{Binding ShowArchivePromptCommand}">
+                    <Button.Style>
+                        <Style TargetType="Button">
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding IsArchived}" Value="True">
+                                    <Setter Property="Visibility" Value="Collapsed" />
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </Button.Style>
+                </Button>
+            </StackPanel>
+
+            <!-- Inline prompts -->
+            <ContentControl Grid.Row="5" Content="{Binding SavePrompt}" Visibility="{Binding IsSavePromptVisible, Converter={StaticResource BooleanToVisibilityConverter}}" />
+            <ContentControl Grid.Row="5" Content="{Binding ArchivePrompt}" Visibility="{Binding IsArchivePromptVisible, Converter={StaticResource BooleanToVisibilityConverter}}" Margin="0,4,0,0" />
+            <ContentControl Grid.Row="5" Content="{Binding DeletePrompt}" Visibility="{Binding IsDeletePromptVisible, Converter={StaticResource BooleanToVisibilityConverter}}" Margin="0,8,0,0" />
+        </Grid>
+
+        <!-- Inline creator popup -->
+        <Popup Placement="Bottom"
+               PlacementTarget="{Binding InlineCreatorTarget}"
+               IsOpen="{Binding IsInlineCreatorVisible, Mode=OneWay}"
+               StaysOpen="True"
+               AllowsTransparency="True">
+            <Border Background="{DynamicResource ControlBackgroundBrush}" BorderBrush="{DynamicResource HighlightBrush}" BorderThickness="1">
+                <ContentControl x:Name="InlineCreatorHost" Content="{Binding InlineCreator}" />
+            </Border>
+        </Popup>
+    </Grid>
+</UserControl>

--- a/docs/progress/2025-07-05_17-52-29_ui_agent.md
+++ b/docs/progress/2025-07-05_17-52-29_ui_agent.md
@@ -1,0 +1,3 @@
+# InvoiceEditor layout prototype
+- Új InvoiceEditorLayout.xaml készült modern grid struktúrával.
+- Fejléc, tételbevitel, összegzés és gombok szekciókra bontva.


### PR DESCRIPTION
## Summary
- add InvoiceEditorLayout.xaml showcasing the proposed keyboard-friendly redesign
- log progress for ui_agent

## Testing
- `dotnet test --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869651fc2e483229254d0e1f35bd6b4