### PR TITLE
fix invoice editor visibility

### DIFF
--- a/Wrecept.Wpf/Views/InvoiceEditorLayout.xaml.cs
+++ b/Wrecept.Wpf/Views/InvoiceEditorLayout.xaml.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Windows.Controls;
+using Microsoft.Extensions.DependencyInjection;
+using Wrecept.Core.Services;
+using Wrecept.Core.Utilities;
+using Wrecept.Wpf.Services;
+using Wrecept.Wpf.ViewModels;
+
+namespace Wrecept.Wpf.Views;
+
+public partial class InvoiceEditorLayout : UserControl
+{
+    public InvoiceEditorLayout()
+    {
+        if (App.Provider is null)
+        {
+            InitializeComponent();
+            return;
+        }
+        Initialize(App.Provider.GetRequiredService<InvoiceEditorViewModel>());
+    }
+
+    public InvoiceEditorLayout(InvoiceEditorViewModel viewModel)
+    {
+        Initialize(viewModel);
+    }
+
+    private void Initialize(InvoiceEditorViewModel viewModel)
+    {
+        InitializeComponent();
+        DataContext = viewModel;
+        Loaded += async (_, _) =>
+        {
+            var progressVm = new ProgressViewModel();
+            var progressWindow = new StartupWindow { DataContext = progressVm };
+            progressWindow.Show();
+            var progress = new Progress<ProgressReport>(r =>
+            {
+                progressVm.GlobalProgress = r.SubtaskPercent;
+                progressVm.SubProgress = r.SubtaskPercent;
+                progressVm.StatusMessage = r.Message;
+            });
+            await viewModel.LoadAsync(progress);
+            progressWindow.Close();
+        };
+    }
+}
+


### PR DESCRIPTION
## Summary
- add codebehind for InvoiceEditorLayout to load InvoiceEditorViewModel on demand

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*
- `dotnet test --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_686980adfd308322b935752bebb9111e