### PR TITLE
Improve invoice editor keyboard UX

### DIFF
--- a/Wrecept.Wpf/KeyboardOnlyUXHelper.cs
+++ b/Wrecept.Wpf/KeyboardOnlyUXHelper.cs
@@ -1,0 +1,16 @@
+using System.Windows.Controls;
+
+namespace Wrecept.Wpf;
+
+public static class KeyboardOnlyUXHelper
+{
+    public static void SuppressUnintendedDropDown(ComboBox combo)
+    {
+        combo.PreviewMouseDown += (_, e) => e.Handled = true;
+        combo.DropDownOpened += (_, e) =>
+        {
+            if (!combo.IsKeyboardFocusWithin)
+                combo.IsDropDownOpen = false;
+        };
+    }
+}

--- a/Wrecept.Wpf/ViewModels/InvoiceEditorViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/InvoiceEditorViewModel.cs
@@ -116,6 +116,8 @@ public partial class InvoiceEditorViewModel : ObservableObject
 
     public InvoiceLookupViewModel Lookup { get; }
 
+    public event Action? InvoiceLoaded;
+
     public ObservableCollection<PaymentMethod> PaymentMethods { get; } = new();
     public ObservableCollection<TaxRate> TaxRates { get; } = new();
     public ObservableCollection<Supplier> Suppliers { get; } = new();
@@ -448,6 +450,7 @@ private void UpdateSupplierId(string name)
             RecalculateTotals();
             await Task.Yield();
             IsLoading = false;
+            InvoiceLoaded?.Invoke();
             return;
         }
 
@@ -479,6 +482,7 @@ private void UpdateSupplierId(string name)
         RecalculateTotals();
         await Task.Yield();
         IsLoading = false;
+        InvoiceLoaded?.Invoke();
     }
 
     public void EditLineFromSelection(InvoiceItemRowViewModel selected)

--- a/Wrecept.Wpf/Views/Controls/EditLookup.xaml
+++ b/Wrecept.Wpf/Views/Controls/EditLookup.xaml
@@ -10,7 +10,7 @@
               DisplayMemberPath="{Binding DisplayMemberPath, RelativeSource={RelativeSource AncestorType=UserControl}}"
               SelectedValue="{Binding SelectedValue, RelativeSource={RelativeSource AncestorType=UserControl}, Mode=TwoWay}"
               IsEditable="True"
-              StaysOpenOnEdit="True"
               IsTextSearchEnabled="False"
+              StaysOpenOnEdit="False"
               IsSynchronizedWithCurrentItem="True"/>
 </UserControl>

--- a/Wrecept.Wpf/Views/Controls/EditLookup.xaml.cs
+++ b/Wrecept.Wpf/Views/Controls/EditLookup.xaml.cs
@@ -66,6 +66,8 @@ public partial class EditLookup : UserControl
 
     private TextBox? _textBox;
 
+    public ComboBox ComboBoxControl => Box;
+
     public EditLookup()
     {
         InitializeComponent();

--- a/Wrecept.Wpf/Views/Controls/SmartLookup.xaml.cs
+++ b/Wrecept.Wpf/Views/Controls/SmartLookup.xaml.cs
@@ -167,4 +167,9 @@ public partial class SmartLookup : UserControl
         return prop?.GetValue(item);
     }
 
+    public void ClosePopup()
+    {
+        PART_Popup.IsOpen = false;
+    }
+
 }

--- a/Wrecept.Wpf/Views/InvoiceEditorLayout.xaml
+++ b/Wrecept.Wpf/Views/InvoiceEditorLayout.xaml
@@ -73,47 +73,52 @@
                 <!-- Header fields -->
                 <Border Padding="6" Margin="0,0,6,0" Background="{DynamicResource ControlBackgroundBrush}" BorderBrush="{DynamicResource HighlightBrush}" BorderThickness="1">
                     <!-- Header section -->
-                    <UniformGrid Columns="2" Margin="4">
+                    <Grid Margin="4" Grid.IsSharedSizeScope="True">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" SharedSizeGroup="Labels" />
+                            <ColumnDefinition Width="*" SharedSizeGroup="Inputs" />
+                            <ColumnDefinition Width="Auto" SharedSizeGroup="Labels" />
+                            <ColumnDefinition Width="*" SharedSizeGroup="Inputs" />
+                        </Grid.ColumnDefinitions>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                        </Grid.RowDefinitions>
+
                         <!-- Supplier -->
-                        <StackPanel Margin="0,0,6,0">
-                            <Label Content="_Szállító" Style="{StaticResource FormLabelStyle}" Target="{Binding ElementName=SupplierLookup}" />
-                            <c:SmartLookup x:Name="SupplierLookup" Width="220"
-                                           AutomationProperties.Name="Supplier Lookup"
-                                           ItemsSource="{Binding Suppliers}"
-                                           DisplayMemberPath="Name"
-                                           SelectedValuePath="Id"
-                                           SelectedValue="{Binding SupplierId}"
-                                           CreateCommand="{Binding ShowSupplierCreatorCommand}"
-                                           CommandParameter="{Binding RelativeSource={RelativeSource Self}}"
-                                           Watermark="Kezdjen el gépelni..."
-                                           IsEnabled="{Binding IsEditable}" />
-                        </StackPanel>
+                        <Label Grid.Row="0" Grid.Column="0" Content="_Szállító" Style="{StaticResource FormLabelStyle}" Target="{Binding ElementName=SupplierLookup}" />
+                        <c:SmartLookup Grid.Row="0" Grid.Column="1" x:Name="SupplierLookup"
+                                       MinWidth="150"
+                                       AutomationProperties.Name="Supplier Lookup"
+                                       ItemsSource="{Binding Suppliers}"
+                                       DisplayMemberPath="Name"
+                                       SelectedValuePath="Id"
+                                       SelectedValue="{Binding SupplierId}"
+                                       CreateCommand="{Binding ShowSupplierCreatorCommand}"
+                                       CommandParameter="{Binding RelativeSource={RelativeSource Self}}"
+                                       Watermark="Kezdjen el gépelni..."
+                                       IsEnabled="{Binding IsEditable}" />
 
                         <!-- Date -->
-                        <StackPanel Margin="0,0,6,0">
-                            <Label Content="_Dátum" Style="{StaticResource FormLabelStyle}" Target="{Binding ElementName=DatePicker}" />
-                            <DatePicker x:Name="DatePicker" Width="220" SelectedDate="{Binding InvoiceDate}" IsEnabled="{Binding IsEditable}" />
-                        </StackPanel>
+                        <Label Grid.Row="0" Grid.Column="2" Content="_Dátum" Style="{StaticResource FormLabelStyle}" Target="{Binding ElementName=DatePicker}" />
+                        <DatePicker Grid.Row="0" Grid.Column="3" x:Name="DatePicker" MinWidth="150" SelectedDate="{Binding InvoiceDate}" IsEnabled="{Binding IsEditable}" />
 
                         <!-- Payment method -->
-                        <StackPanel Margin="0,6,6,0">
-                            <Label Content="_Fizetési mód" Style="{StaticResource FormLabelStyle}" Target="{Binding ElementName=PaymentLookup}" />
-                            <c:EditLookup x:Name="PaymentLookup" Width="220"
-                                          ItemsSource="{Binding PaymentMethods}"
-                                          DisplayMemberPath="Name"
-                                          SelectedValuePath="Id"
-                                          SelectedValue="{Binding PaymentMethodId}"
-                                          CreateCommand="{Binding ShowPaymentMethodCreatorCommand}"
-                                          CreateCommandParameter="{Binding RelativeSource={RelativeSource Self}}"
-                                          IsEnabled="{Binding IsEditable}" />
-                        </StackPanel>
+                        <Label Grid.Row="1" Grid.Column="0" Content="_Fizetési mód" Style="{StaticResource FormLabelStyle}" Target="{Binding ElementName=PaymentLookup}" />
+                        <c:EditLookup Grid.Row="1" Grid.Column="1" x:Name="PaymentLookup"
+                                      MinWidth="150"
+                                      ItemsSource="{Binding PaymentMethods}"
+                                      DisplayMemberPath="Name"
+                                      SelectedValuePath="Id"
+                                      SelectedValue="{Binding PaymentMethodId}"
+                                      CreateCommand="{Binding ShowPaymentMethodCreatorCommand}"
+                                      CreateCommandParameter="{Binding RelativeSource={RelativeSource Self}}"
+                                      IsEnabled="{Binding IsEditable}" />
 
                         <!-- Invoice number -->
-                        <StackPanel Margin="0,6,0,0">
-                            <Label Content="_Számlaszám" Style="{StaticResource FormLabelStyle}" Target="{Binding ElementName=NumberBox}" />
-                            <TextBox x:Name="NumberBox" Width="220" Text="{Binding Number}" IsEnabled="{Binding IsNew}" Style="{StaticResource HeaderTextBoxBold}" />
-                        </StackPanel>
-                    </UniformGrid>
+                        <Label Grid.Row="1" Grid.Column="2" Content="_Számlaszám" Style="{StaticResource FormLabelStyle}" Target="{Binding ElementName=NumberBox}" />
+                        <TextBox Grid.Row="1" Grid.Column="3" x:Name="NumberBox" MinWidth="150" Text="{Binding Number}" IsEnabled="{Binding IsNew}" Style="{StaticResource HeaderTextBoxBold}" />
+                    </Grid>
                 </Border>
 
                 <!-- Summary totals -->
@@ -133,7 +138,7 @@
                         <ColumnDefinition Width="100" />
                     </Grid.ColumnDefinitions>
 
-                    <c:SmartLookup x:Name="EntryProduct" Grid.Column="0"
+                    <c:SmartLookup x:Name="EntryProduct" Grid.Column="0" MinWidth="150"
                                    ItemsSource="{Binding DataContext.Products, RelativeSource={RelativeSource AncestorType=UserControl}}"
                                    DisplayMemberPath="Name"
                                    SelectedValuePath="Name"
@@ -141,8 +146,8 @@
                                    Watermark="Termék neve"
                                    CreateCommand="{Binding DataContext.ShowProductCreatorCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
                                    CommandParameter="{Binding RelativeSource={RelativeSource Self}}" />
-                    <TextBox x:Name="EntryQuantity" Grid.Column="1" Margin="4,0" Text="{Binding Quantity, Mode=TwoWay}" />
-                    <c:SmartLookup x:Name="EntryUnit" Grid.Column="2"
+                    <TextBox x:Name="EntryQuantity" Grid.Column="1" Margin="4,0" MinWidth="150" Text="{Binding Quantity, Mode=TwoWay}" />
+                    <c:SmartLookup x:Name="EntryUnit" Grid.Column="2" MinWidth="150"
                                    ItemsSource="{Binding DataContext.Units, RelativeSource={RelativeSource AncestorType=UserControl}}"
                                    DisplayMemberPath="Name"
                                    SelectedValuePath="Id"
@@ -150,8 +155,8 @@
                                    Watermark="Me.e."
                                    CreateCommand="{Binding DataContext.ShowUnitCreatorCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
                                    CommandParameter="{Binding RelativeSource={RelativeSource Self}}" />
-                    <TextBox x:Name="EntryPrice" Grid.Column="3" Margin="4,0" Text="{Binding UnitPrice, Mode=TwoWay}" />
-                    <c:EditLookup x:Name="EntryTax" Grid.Column="4" Tag="LastEntry"
+                    <TextBox x:Name="EntryPrice" Grid.Column="3" Margin="4,0" MinWidth="150" Text="{Binding UnitPrice, Mode=TwoWay}" />
+                    <c:EditLookup x:Name="EntryTax" Grid.Column="4" Tag="LastEntry" MinWidth="150"
                                   ItemsSource="{Binding DataContext.TaxRates, RelativeSource={RelativeSource AncestorType=UserControl}}"
                                   DisplayMemberPath="Name"
                                   SelectedValuePath="Id"

--- a/Wrecept.Wpf/Views/InvoiceEditorLayout.xaml.cs
+++ b/Wrecept.Wpf/Views/InvoiceEditorLayout.xaml.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Linq;
 using System.Windows.Controls;
+using System.Windows.Input;
 using Microsoft.Extensions.DependencyInjection;
 using Wrecept.Core.Services;
 using Wrecept.Core.Utilities;
@@ -29,6 +31,7 @@ public partial class InvoiceEditorLayout : UserControl
     {
         InitializeComponent();
         DataContext = viewModel;
+        KeyboardOnlyUXHelper.SuppressUnintendedDropDown(PaymentLookup.ComboBoxControl);
         Loaded += async (_, _) =>
         {
             var progressVm = new ProgressViewModel();
@@ -42,6 +45,15 @@ public partial class InvoiceEditorLayout : UserControl
             });
             await viewModel.LoadAsync(progress);
             progressWindow.Close();
+        };
+        viewModel.InvoiceLoaded += () =>
+        {
+            SupplierLookup.Text = viewModel.Supplier;
+            SupplierLookup.ClosePopup();
+            PaymentLookup.ComboBoxControl.SelectedItem = viewModel.PaymentMethods.FirstOrDefault(p => p.Id == viewModel.PaymentMethodId);
+            PaymentLookup.ComboBoxControl.IsDropDownOpen = false;
+            LookupView.InvoiceList.Focus();
+            Keyboard.Focus(LookupView.InvoiceList);
         };
     }
 }

--- a/docs/progress/2025-07-05_20-15-05_ui_agent.md
+++ b/docs/progress/2025-07-05_20-15-05_ui_agent.md
@@ -1,0 +1,4 @@
+# Keyboard stability fixes
+- Rögzítettem a fejléc rácselrendezését SharedSizeGroup használatával.
+- Új KeyboardOnlyUXHelper gondoskodik arról, hogy a kombók ne nyíljanak ki maguktól.
+- Invoice betöltésekor a mezők kitöltődnek és a fókusz az InvoiceList-en marad.


### PR DESCRIPTION
## Summary
- add `KeyboardOnlyUXHelper` to keep dropdowns closed unless the keyboard is used
- refactor `InvoiceEditorLayout` header with shared size columns and min widths
- update controls to avoid automatic dropdown opening
- restore focus to invoice list after loading invoices
- log progress

## Testing
- `dotnet test --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_686986089fd08322a8bf8f60d986ea9f