### PR TITLE
Allow negative invoice item quantity

### DIFF
--- a/Wrecept.Wpf/Resources/Strings.resx
+++ b/Wrecept.Wpf/Resources/Strings.resx
@@ -64,7 +64,7 @@
     <value>Betöltés kész.</value>
   </data>
   <data name="InvoiceLine_InvalidQuantity" xml:space="preserve">
-    <value>Mennyiségnek 0-nál nagyobbnak kell lennie</value>
+    <value>Mennyiség nem lehet nulla</value>
   </data>
   <data name="InvoiceLine_InvalidPrice" xml:space="preserve">
     <value>Az ár nem lehet negatív</value>

--- a/Wrecept.Wpf/ViewModels/InvoiceEditorViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/InvoiceEditorViewModel.cs
@@ -512,7 +512,7 @@ private void UpdateSupplierId(string name)
 
     private bool ValidateLineItem(InvoiceItemRowViewModel line, out string error)
     {
-        if (line.Quantity <= 0)
+        if (line.Quantity == 0)
         {
             error = Resources.Strings.InvoiceLine_InvalidQuantity;
             return false;

--- a/docs/BUSINESS_LOGIC.md
+++ b/docs/BUSINESS_LOGIC.md
@@ -125,7 +125,7 @@ Ez a dokumentum definiálja a **Wrecept** rendszer üzleti logikáját. A rendsz
 ## 9. ⚠️ Validációs szabályok
 
 * Számlán legalább egy tételnek szerepelnie kell.
-* Tétel: `Quantity != 0`, `UnitPrice ≥ 0`
+* Tétel: `Quantity != 0` (negatív érték visszárut jelent), `UnitPrice ≥ 0`
 * Termék, beszállító, fizetési mód kiválasztása kötelező.
 * Törzsadatból csak **nem archivált** elemek választhatók.
 

--- a/docs/UI_FLOW.md
+++ b/docs/UI_FLOW.md
@@ -64,6 +64,7 @@ Confirm entry prompt: Save line? (Enter=Yes, Esc=No)
 Insert new line, repeat
 
 Quantity < 0 indicates return (visszáru), highlighted red via converter
+Quantity = 0 is rejected with inline error message
 
 📄 Invoice Finalization
 

--- a/docs/progress/2025-07-05_21-50-40_code_agent.md
+++ b/docs/progress/2025-07-05_21-50-40_code_agent.md
@@ -1,0 +1,4 @@
+- Quantity rule updated: zero disallowed, negatives allowed.
+- Updated resource string and validation logic.
+- Added unit test for negative quantity.
+- Documentation reflects validation change.

--- a/tests/viewmodels/InvoiceEditorViewModelTests.cs
+++ b/tests/viewmodels/InvoiceEditorViewModelTests.cs
@@ -152,6 +152,36 @@ public class InvoiceEditorViewModelTests
     }
 
     [Fact]
+    public async Task AddLineItem_NegativeQuantity_Accepted()
+    {
+        var invoiceSvc = new FakeInvoiceService();
+        var productSvc = new FakeProductService();
+        var taxId = Guid.NewGuid();
+        productSvc.Products.Add(new Product { Id = 1, Name = "Test", TaxRateId = taxId });
+        var payment = new DummyService<object>();
+        var tax = new DummyService<object>();
+        var supplier = new DummyService<object>();
+        var unit = new DummyService<object>();
+        var log = new DummyLogService();
+        var notify = new DummyNotificationService();
+        var lookup = new InvoiceLookupViewModel(invoiceSvc);
+        var vm = new InvoiceEditorViewModel(payment, tax, supplier, productSvc, unit, invoiceSvc, log, notify, lookup);
+
+        var row = vm.Items[0];
+        row.Product = "Test";
+        row.Quantity = -2;
+        row.UnitPrice = 100;
+        row.TaxRateId = taxId;
+
+        await vm.AddLineItemAsync();
+
+        Assert.Equal(0, invoiceSvc.Items.Count);
+        Assert.False(row.HasError);
+        Assert.Equal(2, vm.Items.Count);
+        Assert.Equal(-2, vm.Items[1].Quantity);
+    }
+
+    [Fact]
     public async Task Commands_Ignored_When_ReadOnly()
     {
         var invoiceSvc = new FakeInvoiceService();


### PR DESCRIPTION
## Summary
- allow negative quantity in InvoiceEditorViewModel validation
- update error text to state that zero is disallowed
- document changed rule in BUSINESS_LOGIC and UI_FLOW
- add a unit test for negative quantity

## Testing
- `dotnet test --no-build --verbosity minimal` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_68699d5201048322bd1cff24613f6b64