### PR TITLE
Enable SQLite WAL mode

### DIFF
--- a/Wrecept.Storage/Data/AppDbContextFactory.cs
+++ b/Wrecept.Storage/Data/AppDbContextFactory.cs
@@ -10,6 +10,7 @@ public class AppDbContextFactory : IDesignTimeDbContextFactory<AppDbContext>
         var dbPath = args.Length > 0 ? args[0] : "app.db";
         var options = new DbContextOptionsBuilder<AppDbContext>()
             .UseSqlite($"Data Source={dbPath}")
+            .AddInterceptors(new WalPragmaInterceptor())
             .Options;
         return new AppDbContext(options);
     }

--- a/Wrecept.Storage/Data/WalPragmaInterceptor.cs
+++ b/Wrecept.Storage/Data/WalPragmaInterceptor.cs
@@ -1,0 +1,30 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using System.Data.Common;
+
+namespace Wrecept.Storage.Data;
+
+public class WalPragmaInterceptor : DbConnectionInterceptor
+{
+    private const string Sql = "PRAGMA journal_mode=WAL";
+
+    public override async Task ConnectionOpenedAsync(DbConnection connection, ConnectionEndEventData eventData, CancellationToken cancellationToken = default)
+    {
+        if (connection is SqliteConnection)
+        {
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = Sql;
+            await cmd.ExecuteScalarAsync(cancellationToken);
+        }
+    }
+
+    public override void ConnectionOpened(DbConnection connection, ConnectionEndEventData eventData)
+    {
+        if (connection is SqliteConnection)
+        {
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = Sql;
+            cmd.ExecuteScalar();
+        }
+    }
+}

--- a/docs/DEV_SPECS.md
+++ b/docs/DEV_SPECS.md
@@ -39,6 +39,8 @@ The design must be:
 | Backups     | Manual + optional autosave-based copy            |
 | Permissions | No admin required. Writes to `%AppData%\Wrecept` |
 
+Az alkalmazás minden adatbázis-kapcsolat nyitásakor lefuttatja a `PRAGMA journal_mode=WAL` parancsot, így a naplózási mód mindig visszaáll WAL értékre.
+
 ---
 
 ## 🧱 Architectural Principles

--- a/docs/progress/2025-07-05_21-57-32_root_agent.md
+++ b/docs/progress/2025-07-05_21-57-32_root_agent.md
@@ -1,0 +1,4 @@
+# WAL mode enabled
+- Added WalPragmaInterceptor and registered it during storage setup.
+- Updated context factory and initialization to enforce `PRAGMA journal_mode=WAL`.
+- Documented WAL requirement in DEV_SPECS and added unit test for journal mode.

--- a/tests/Wrecept.Tests/WalPragmaTests.cs
+++ b/tests/Wrecept.Tests/WalPragmaTests.cs
@@ -1,0 +1,33 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Wrecept.Storage;
+using Wrecept.Storage.Data;
+using Xunit;
+using System;
+using System.IO;
+
+namespace Wrecept.Tests;
+
+public class WalPragmaTests
+{
+    [Fact]
+    public async Task JournalMode_Is_Wal()
+    {
+        var dbPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".db");
+        var userPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".json");
+        var settingsPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".json");
+
+        var services = new ServiceCollection();
+        await services.AddStorageAsync(dbPath, userPath, settingsPath);
+        using var provider = services.BuildServiceProvider();
+        var factory = provider.GetRequiredService<IDbContextFactory<AppDbContext>>();
+        await using var ctx = await factory.CreateDbContextAsync();
+        await ctx.Database.OpenConnectionAsync();
+        await using var cmd = ctx.Database.GetDbConnection().CreateCommand();
+        cmd.CommandText = "PRAGMA journal_mode";
+        var mode = (string)await cmd.ExecuteScalarAsync();
+        await ctx.Database.CloseConnectionAsync();
+
+        Assert.Equal("wal", mode.ToLowerInvariant());
+    }
+}

--- a/tests/Wrecept.Tests/Wrecept.Tests.csproj
+++ b/tests/Wrecept.Tests/Wrecept.Tests.csproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\Wrecept.Wpf\Wrecept.Wpf.csproj" />
     <ProjectReference Include="..\..\Wrecept.Core\Wrecept.Core.csproj" />
+    <ProjectReference Include="..\..\Wrecept.Storage\Wrecept.Storage.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\viewmodels\*.cs" />


### PR DESCRIPTION
## Summary
- create `WalPragmaInterceptor` to enforce WAL mode
- register interceptor in storage setup and context factory
- run `PRAGMA journal_mode=WAL` during initialization
- verify WAL mode via unit test
- document journaling in DEV_SPECS
- log progress

## Testing
- `dotnet test --no-build` *(fails: SDK 'Microsoft.NET.Sdk.WindowsDesktop' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68699edc72288322bb043a3767fce91e