### PR TITLE
Implement backup service

### DIFF
--- a/Wrecept.Core/Services/IBackupService.cs
+++ b/Wrecept.Core/Services/IBackupService.cs
@@ -1,0 +1,9 @@
+using System.Threading.Tasks;
+using System.Threading;
+namespace Wrecept.Core.Services;
+
+public interface IBackupService
+{
+    Task BackupAsync(string destinationZipPath, CancellationToken ct = default);
+    Task RestoreAsync(string zipPath, CancellationToken ct = default);
+}

--- a/Wrecept.Storage/ServiceCollectionExtensions.cs
+++ b/Wrecept.Storage/ServiceCollectionExtensions.cs
@@ -44,6 +44,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<ISettingsService>(_ => new SettingsService(settingsPath));
         var sessionPath = Path.Combine(Path.GetDirectoryName(settingsPath)!, "session.json");
         services.AddSingleton<ISessionService>(_ => new SessionService(sessionPath));
+        services.AddScoped<IBackupService>(_ => new FileBackupService(dbPath, userInfoPath, settingsPath));
         services.AddScoped<IDbHealthService, DbHealthService>();
 
         using var provider = services.BuildServiceProvider();

--- a/Wrecept.Storage/Services/FileBackupService.cs
+++ b/Wrecept.Storage/Services/FileBackupService.cs
@@ -1,0 +1,66 @@
+using System.IO;
+using System.IO.Compression;
+using Wrecept.Core.Services;
+
+namespace Wrecept.Storage.Services;
+
+public class FileBackupService : IBackupService
+{
+    private readonly string _dbPath;
+    private readonly string _userInfoPath;
+    private readonly string _settingsPath;
+    private readonly string _sessionPath;
+
+    public FileBackupService(string dbPath, string userInfoPath, string settingsPath)
+    {
+        _dbPath = dbPath;
+        _userInfoPath = userInfoPath;
+        _settingsPath = settingsPath;
+        _sessionPath = Path.Combine(Path.GetDirectoryName(settingsPath)!, "session.json");
+    }
+
+    public Task BackupAsync(string destinationZipPath, CancellationToken ct = default)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(destinationZipPath)!);
+        if (File.Exists(destinationZipPath))
+            File.Delete(destinationZipPath);
+
+        using var zip = ZipFile.Open(destinationZipPath, ZipArchiveMode.Create);
+        AddFile(zip, _dbPath);
+        AddFile(zip, _userInfoPath);
+        AddFile(zip, _settingsPath);
+        AddFile(zip, _sessionPath);
+        return Task.CompletedTask;
+    }
+
+    public Task RestoreAsync(string zipPath, CancellationToken ct = default)
+    {
+        if (!File.Exists(zipPath))
+            throw new FileNotFoundException(zipPath);
+
+        using var zip = ZipFile.OpenRead(zipPath);
+        foreach (var entry in zip.Entries)
+        {
+            string? dest = entry.Name switch
+            {
+                var n when n == Path.GetFileName(_dbPath) => _dbPath,
+                var n when n == Path.GetFileName(_userInfoPath) => _userInfoPath,
+                var n when n == Path.GetFileName(_settingsPath) => _settingsPath,
+                var n when n == Path.GetFileName(_sessionPath) => _sessionPath,
+                _ => null
+            };
+            if (dest != null)
+            {
+                Directory.CreateDirectory(Path.GetDirectoryName(dest)!);
+                entry.ExtractToFile(dest, true);
+            }
+        }
+        return Task.CompletedTask;
+    }
+
+    private static void AddFile(ZipArchive zip, string path)
+    {
+        if (File.Exists(path))
+            zip.CreateEntryFromFile(path, Path.GetFileName(path));
+    }
+}

--- a/Wrecept.Wpf/Resources/Strings.Designer.cs
+++ b/Wrecept.Wpf/Resources/Strings.Designer.cs
@@ -21,6 +21,8 @@ internal static class Strings
     internal static string Stage_DbCheckFailed => _rm.GetString("Stage_DbCheckFailed") ?? string.Empty;
     internal static string Stage_LastInvoiceRestored => _rm.GetString("Stage_LastInvoiceRestored") ?? string.Empty;
     internal static string Stage_NoInvoiceToRestore => _rm.GetString("Stage_NoInvoiceToRestore") ?? string.Empty;
+    internal static string Stage_BackupSuccess => _rm.GetString("Stage_BackupSuccess") ?? string.Empty;
+    internal static string Stage_RestoreSuccess => _rm.GetString("Stage_RestoreSuccess") ?? string.Empty;
     internal static string StatusBar_DefaultMessage => _rm.GetString("StatusBar_DefaultMessage") ?? string.Empty;
     internal static string Load_PaymentMethods => _rm.GetString("Load_PaymentMethods") ?? string.Empty;
     internal static string Load_Suppliers => _rm.GetString("Load_Suppliers") ?? string.Empty;

--- a/Wrecept.Wpf/Resources/Strings.resx
+++ b/Wrecept.Wpf/Resources/Strings.resx
@@ -54,6 +54,12 @@
   <data name="Stage_NoInvoiceToRestore" xml:space="preserve">
     <value>Nincs visszaállítható számla</value>
   </data>
+  <data name="Stage_BackupSuccess" xml:space="preserve">
+    <value>Mentés elkészült</value>
+  </data>
+  <data name="Stage_RestoreSuccess" xml:space="preserve">
+    <value>Visszaállítás kész</value>
+  </data>
   <data name="StatusBar_DefaultMessage" xml:space="preserve">
     <value>[Esc] Kilépés  [Enter] Jóváhagy</value>
   </data>

--- a/Wrecept.Wpf/Services/NavigationService.cs
+++ b/Wrecept.Wpf/Services/NavigationService.cs
@@ -1,4 +1,5 @@
 using System.Windows;
+using Microsoft.Win32;
 using Wrecept.Wpf.Dialogs;
 
 namespace Wrecept.Wpf.Services;
@@ -10,5 +11,10 @@ public static class NavigationService
         if (Application.Current.MainWindow is { } owner)
             DialogHelper.CenterToOwner(dialog, owner);
         return dialog.ShowDialog() == true;
+    }
+
+    public static bool ShowFileDialog(FileDialog dialog)
+    {
+        return dialog.ShowDialog(Application.Current.MainWindow) == true;
     }
 }

--- a/Wrecept.Wpf/ViewModels/StageViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/StageViewModel.cs
@@ -3,6 +3,8 @@ using CommunityToolkit.Mvvm.Input;
 using Microsoft.Extensions.DependencyInjection;
 using System.Threading.Tasks;
 using System.Windows;
+using Microsoft.Win32;
+using System.IO;
 using Wrecept.Core.Entities;
 using Wrecept.Core.Services;
 using Wrecept.Wpf.Resources;
@@ -27,6 +29,8 @@ public enum StageMenuAction
     InventoryCard,
     CheckFiles,
     AfterPowerOutage,
+    BackupData,
+    RestoreData,
     ScreenSettings,
     PrinterSettings,
     EditUserInfo,
@@ -187,6 +191,33 @@ private async Task HandleMenu(StageMenuAction action)
                 {
                     CurrentViewModel = _placeholder;
                     _statusBar.Message = Resources.Strings.Stage_NoInvoiceToRestore;
+                }
+                break;
+            case StageMenuAction.BackupData:
+                var saveDlg = new SaveFileDialog
+                {
+                    Filter = "ZIP (*.zip)|*.zip|All files|*.*",
+                    FileName = "wrecept-backup.zip",
+                    InitialDirectory = Path.GetDirectoryName(App.DbPath)
+                };
+                if (NavigationService.ShowFileDialog(saveDlg))
+                {
+                    var svc = App.Provider.GetRequiredService<IBackupService>();
+                    await svc.BackupAsync(saveDlg.FileName);
+                    _statusBar.Message = Resources.Strings.Stage_BackupSuccess;
+                }
+                break;
+            case StageMenuAction.RestoreData:
+                var openDlg = new OpenFileDialog
+                {
+                    Filter = "ZIP (*.zip)|*.zip|All files|*.*",
+                    InitialDirectory = Path.GetDirectoryName(App.DbPath)
+                };
+                if (NavigationService.ShowFileDialog(openDlg))
+                {
+                    var svc = App.Provider.GetRequiredService<IBackupService>();
+                    await svc.RestoreAsync(openDlg.FileName);
+                    _statusBar.Message = Resources.Strings.Stage_RestoreSuccess;
                 }
                 break;
             case StageMenuAction.ScreenSettings:

--- a/Wrecept.Wpf/Views/StageView.xaml
+++ b/Wrecept.Wpf/Views/StageView.xaml
@@ -65,6 +65,12 @@
                 <MenuItem Header="Áramszünet _után"
                           Command="{Binding HandleMenuCommand}"
                           CommandParameter="{x:Static vm:StageMenuAction.AfterPowerOutage}" />
+                <MenuItem Header="_Mentés"
+                          Command="{Binding HandleMenuCommand}"
+                          CommandParameter="{x:Static vm:StageMenuAction.BackupData}" />
+                <MenuItem Header="_Visszaállítás"
+                          Command="{Binding HandleMenuCommand}"
+                          CommandParameter="{x:Static vm:StageMenuAction.RestoreData}" />
                 <MenuItem Header="K_épernyő beállítása"
                           Command="{Binding HandleMenuCommand}"
                           CommandParameter="{x:Static vm:StageMenuAction.ScreenSettings}" />

--- a/docs/manuals/user_manual_hu.md
+++ b/docs/manuals/user_manual_hu.md
@@ -38,6 +38,8 @@ A *Szerviz* menü segít az adatállományok karbantartásában:
 
 - **Állományok ellenőrzése** – adatbázis-hiba esetén futtasd.
 - **Áramszünet után** – nem várt leállás után indítsd.
+- **Mentés** – a teljes adatbázist és beállításokat ZIP fájlba menti.
+- **Visszaállítás** – korábbi mentésből tölti vissza az adatokat.
 - **Tulajdonos szerkesztése...** – itt módosíthatod a céges adatokat, amelyek a számlák fejlécében megjelennek.
 
 

--- a/docs/progress/2025-07-05_22-29-04_root_agent.md
+++ b/docs/progress/2025-07-05_22-29-04_root_agent.md
@@ -1,0 +1,4 @@
+- IBackupService introduced with BackupAsync and RestoreAsync methods.
+- FileBackupService implements ZIP-based export/import of DB and configs.
+- StageView adds "Mentés" and "Visszaállítás" items invoking dialogs via NavigationService.
+- User manual updated with backup instructions.

--- a/tests/Wrecept.Tests/FileBackupServiceTests.cs
+++ b/tests/Wrecept.Tests/FileBackupServiceTests.cs
@@ -1,0 +1,43 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Wrecept.Storage.Services;
+using Xunit;
+
+namespace Wrecept.Tests;
+
+public class FileBackupServiceTests
+{
+    [Fact]
+    public async Task BackupAndRestore_RoundTrip()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(dir);
+        var db = Path.Combine(dir, "app.db");
+        var user = Path.Combine(dir, "user.json");
+        var settings = Path.Combine(dir, "settings.json");
+        var session = Path.Combine(dir, "session.json");
+        await File.WriteAllTextAsync(db, "db");
+        await File.WriteAllTextAsync(user, "user");
+        await File.WriteAllTextAsync(settings, "settings");
+        await File.WriteAllTextAsync(session, "session");
+
+        var svc = new FileBackupService(db, user, settings);
+        var zip = Path.Combine(dir, "backup.zip");
+        await svc.BackupAsync(zip);
+
+        File.Delete(db);
+        File.Delete(user);
+        File.Delete(settings);
+        File.Delete(session);
+
+        await svc.RestoreAsync(zip);
+
+        Assert.True(File.Exists(db));
+        Assert.True(File.Exists(user));
+        Assert.True(File.Exists(settings));
+        Assert.True(File.Exists(session));
+
+        Directory.Delete(dir, true);
+    }
+}


### PR DESCRIPTION
## Summary
- define `IBackupService` in Core
- implement `FileBackupService` that zips database and configs
- register new service during storage setup
- extend `NavigationService` with file dialog helper
- add backup & restore menu options with handlers
- document maintenance options in the user manual
- add regression test for `FileBackupService`

## Testing
- `dotnet test --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869a57d9f08832282ee25db99e55bf7