### PR TITLE
Fix startup cancel command disposal

### DIFF
--- a/docs/BUILD_RUNTIME_NOTES.md
+++ b/docs/BUILD_RUNTIME_NOTES.md
@@ -42,5 +42,8 @@ Ez a jegyzet a fejlesztés során tapasztalt fordítási és futásidejű probl�
     "Biztos, hogy elölről kezded?". Elfogadás után a `SetupWindow` és a
     tulajdonosi adatok szerkesztője jelenik meg, ezek mentik a beállított
     elérési utakat és cégadatokat.
+12. A `StartupWindow` `Mégse` gombjára kattintva `ObjectDisposedException` lépett
+    fel, ha a `CancellationTokenSource` már felszabadult. A parancs most
+    biztonságosan kezeli ezt és az indítás végén eltávolítjuk a hivatkozást.
 
 ---

--- a/docs/progress/2025-07-05_23-27-40_code_agent.md
+++ b/docs/progress/2025-07-05_23-27-40_code_agent.md
@@ -1,0 +1,2 @@
+- Megakadályoztam az ObjectDisposedException kivételt a Startup ablak `Mégse` gombjánál.
+- A CancelCommand most try-catch blokkban hívja a tokent és a parancsot indítás végén töröljük.


### PR DESCRIPTION
## Summary
- handle disposed CancellationTokenSource when seeding is cancelled
- record details in runtime notes
- log progress

## Testing
- `dotnet build Wrecept.sln -c Release` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*
- `dotnet test Wrecept.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869b428f8c88322b1a4abf937496527