### PR TITLE
Update SmartLookup docs and export feature

### DIFF
--- a/Wrecept.Wpf/ViewModels/InvoiceEditorViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/InvoiceEditorViewModel.cs
@@ -513,8 +513,6 @@ private void UpdateSupplierId(string name)
     [RelayCommand]
     private async Task SavePdfAsync()
     {
-        if (!IsArchived)
-            return;
         var dlg = new SaveFileDialog
         {
             Filter = "PDF (*.pdf)|*.pdf",
@@ -531,8 +529,6 @@ private void UpdateSupplierId(string name)
     [RelayCommand]
     private async Task PrintAsync()
     {
-        if (!IsArchived)
-            return;
         var invoice = await _invoiceService.GetAsync(InvoiceId);
         if (invoice != null)
             await _exporter.PrintAsync(invoice);

--- a/Wrecept.Wpf/Views/InvoiceEditorLayout.xaml
+++ b/Wrecept.Wpf/Views/InvoiceEditorLayout.xaml
@@ -174,8 +174,8 @@
             <!-- Action buttons -->
             <StackPanel Grid.Row="4" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0">
                 <Button Content="Mentés" Command="{Binding SaveCommand}" IsEnabled="{Binding IsEditable}" Margin="0,0,4,0" />
-                <Button Content="PDF mentés" Command="{Binding SavePdfCommand}" IsEnabled="{Binding IsArchived}" Margin="0,0,4,0" />
-                <Button Content="Nyomtatás" Command="{Binding PrintCommand}" IsEnabled="{Binding IsArchived}" Margin="0,0,4,0" />
+                <Button Content="PDF mentés" Command="{Binding SavePdfCommand}" Margin="0,0,4,0" />
+                <Button Content="Nyomtatás" Command="{Binding PrintCommand}" Margin="0,0,4,0" />
                 <Button Content="Bezárás" Command="{Binding CloseCommand}" Margin="0,0,4,0" />
                 <Button Content="📦 Véglegesítés" Command="{Binding ShowArchivePromptCommand}">
                     <Button.Style>

--- a/docs/InlineEntityCreation.md
+++ b/docs/InlineEntityCreation.md
@@ -7,7 +7,7 @@ date: "2025-07-03"
 
 # Inline Entity Creation
 
-Az InvoiceEditor nézetben lehetőség nyílik a hiányzó törzsadatok azonnali felvételére. Ha a felhasználó olyan terméket, szállítót, ÁFA-kulcsot vagy mértékegységet ír be, amely nem található az adatbázisban, a program egy kibomló űrlapot jelenít meg az aktuális sor alatt.
+Az InvoiceEditor nézetben lehetőség nyílik a hiányzó törzsadatok azonnali felvételére. Ha a felhasználó olyan terméket, szállítót, ÁFA-kulcsot vagy mértékegységet ír be, amely nem található az adatbázisban, a program a beviteli mezőben felugró űrlapot jelenít meg.
 
 Korábban a űrlap a DataGrid `RowDetailsTemplate` elemében jelent meg, ám ez rejtve maradt a sorok összecsukása miatt.  A legutóbbi frissítés óta a nézet egy lebegő `Popup` segítségével közvetlenül a keresőmező alatt jeleníti meg az űrlapot, így a felhasználó fókusza nem vész el.
 

--- a/docs/UI_FLOW.md
+++ b/docs/UI_FLOW.md
@@ -55,7 +55,9 @@ Bruttó checkbox (affects unit price interpretation)
 
 SmartLookup behavior with real-time filtering
 
-If product not found → inline product creator in-row (no modal popup)
+A számlafejadatoknál és a tételsorok felett is SmartLookup segíti a választást.
+Ha nincs találat, a beviteli mezőben egy felugró űrlap jelenik meg, így azonnal
+létrehozható az új entitás.
 
 Pre-fill Quantity, Price, TaxRate based on latest usage
 
@@ -70,7 +72,7 @@ Quantity = 0 is rejected with inline error message
 
 📄 Invoice Finalization
 
-„PDF mentés” és „Nyomtatás” gomb csak archivált számlánál aktív
+„PDF mentés” és „Nyomtatás” gomb minden számlánál elérhető
 
 Archived invoices:
 

--- a/docs/progress/2025-07-05_23-48-45_code_agent.md
+++ b/docs/progress/2025-07-05_23-48-45_code_agent.md
@@ -1,0 +1,1 @@
+- SavePdfAsync and PrintAsync no longer check IsArchived.

--- a/docs/progress/2025-07-05_23-48-45_docs_agent.md
+++ b/docs/progress/2025-07-05_23-48-45_docs_agent.md
@@ -1,0 +1,3 @@
+- Updated UI_FLOW.md to describe SmartLookup popup in header and item entry fields.
+- Revised PDF export note: printing and export available on all invoices.
+- InlineEntityCreation wording updated for popup form in input box.

--- a/docs/progress/2025-07-05_23-48-45_ui_agent.md
+++ b/docs/progress/2025-07-05_23-48-45_ui_agent.md
@@ -1,0 +1,1 @@
+- InvoiceEditorLayout buttons SavePdf and Print always enabled.


### PR DESCRIPTION
## Summary
- clarify SmartLookup popup behavior for header and line items
- allow PDF export and printing before archiving
- update inline creator documentation

## Testing
- `dotnet test --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869b5da5b348322a0090ae858bbb1ee