### PR TITLE
Fix missing DueDate column

### DIFF
--- a/Wrecept.Storage/Data/DbInitializer.cs
+++ b/Wrecept.Storage/Data/DbInitializer.cs
@@ -2,6 +2,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage;
 using Wrecept.Core.Services;
+using System;
 
 namespace Wrecept.Storage.Data;
 
@@ -19,15 +20,49 @@ public static class DbInitializer
             if (!await creator.ExistsAsync(ct))
             {
                 await db.Database.MigrateAsync(ct);
+                await EnsureInvoiceDueDateColumnAsync(db, ct);
                 return;
             }
 
             await db.Database.MigrateAsync(ct);
+            await EnsureInvoiceDueDateColumnAsync(db, ct);
         }
         catch (Exception ex)
         {
             await logService.LogError("Initialization failed", ex);
             throw;
+        }
+    }
+
+    private static async Task EnsureInvoiceDueDateColumnAsync(AppDbContext db, CancellationToken ct)
+    {
+        var conn = db.Database.GetDbConnection();
+        await conn.OpenAsync(ct);
+        try
+        {
+            await using var checkCmd = conn.CreateCommand();
+            checkCmd.CommandText = "PRAGMA table_info('Invoices')";
+            await using var reader = await checkCmd.ExecuteReaderAsync(ct);
+            var hasColumn = false;
+            while (await reader.ReadAsync(ct))
+            {
+                if (reader.GetString(1).Equals("DueDate", StringComparison.OrdinalIgnoreCase))
+                {
+                    hasColumn = true;
+                    break;
+                }
+            }
+
+            if (!hasColumn)
+            {
+                await using var alter = conn.CreateCommand();
+                alter.CommandText = "ALTER TABLE \"Invoices\" ADD COLUMN \"DueDate\" TEXT NOT NULL DEFAULT '2000-01-01'";
+                await alter.ExecuteNonQueryAsync(ct);
+            }
+        }
+        finally
+        {
+            await conn.CloseAsync();
         }
     }
 }

--- a/docs/progress/2025-07-06_00-06-11_storage_agent.md
+++ b/docs/progress/2025-07-06_00-06-11_storage_agent.md
@@ -1,0 +1,2 @@
+- Fixed missing DueDate column by adding schema self-heal logic in DbInitializer.
+- Added runtime check and ALTER TABLE fallback.


### PR DESCRIPTION
## Summary
- fix DB initialization when DueDate column is missing
- log update in progress notes

## Testing
- `dotnet test --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*
- `dotnet build --no-restore` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869bce9e2bc8322bfe255401a2784eb