### PR TITLE
Update inline entity creation forms

### DIFF
--- a/Wrecept.Wpf/Resources/Strings.Designer.cs
+++ b/Wrecept.Wpf/Resources/Strings.Designer.cs
@@ -29,6 +29,7 @@ internal static class Strings
     internal static string Load_TaxRates => _rm.GetString("Load_TaxRates") ?? string.Empty;
     internal static string Load_Products => _rm.GetString("Load_Products") ?? string.Empty;
     internal static string Load_Units => _rm.GetString("Load_Units") ?? string.Empty;
+    internal static string Load_ProductGroups => _rm.GetString("Load_ProductGroups") ?? string.Empty;
     internal static string Load_Complete => _rm.GetString("Load_Complete") ?? string.Empty;
     internal static string InvoiceLine_InvalidQuantity => _rm.GetString("InvoiceLine_InvalidQuantity") ?? string.Empty;
     internal static string InvoiceLine_InvalidPrice => _rm.GetString("InvoiceLine_InvalidPrice") ?? string.Empty;

--- a/Wrecept.Wpf/Resources/Strings.resx
+++ b/Wrecept.Wpf/Resources/Strings.resx
@@ -78,6 +78,9 @@
   <data name="Load_Units" xml:space="preserve">
     <value>Mértékegységek betöltése...</value>
   </data>
+  <data name="Load_ProductGroups" xml:space="preserve">
+    <value>Termékcsoportok betöltése...</value>
+  </data>
   <data name="Load_Complete" xml:space="preserve">
     <value>Betöltés kész.</value>
   </data>

--- a/Wrecept.Wpf/ViewModels/ProductCreatorViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/ProductCreatorViewModel.cs
@@ -5,6 +5,7 @@ using CommunityToolkit.Mvvm.Input;
 using Wrecept.Core.Models;
 using Wrecept.Core.Services;
 using System.Collections.ObjectModel;
+using System.Linq;
 
 namespace Wrecept.Wpf.ViewModels;
 
@@ -19,6 +20,7 @@ public partial class ProductCreatorViewModel : ObservableObject
 
     public ObservableCollection<Unit> Units => _parent.Units;
     public ObservableCollection<TaxRate> TaxRates => _parent.TaxRates;
+    public ObservableCollection<ProductGroup> ProductGroups => _parent.ProductGroups;
 
     [ObservableProperty]
     private string name = string.Empty;
@@ -34,6 +36,9 @@ public partial class ProductCreatorViewModel : ObservableObject
 
     [ObservableProperty]
     private Guid taxRateId;
+
+    [ObservableProperty]
+    private Guid productGroupId;
 
     public ProductCreatorViewModel(InvoiceEditorViewModel parent, InvoiceItemRowViewModel row, IProductService products)
     {
@@ -52,13 +57,19 @@ public partial class ProductCreatorViewModel : ObservableObject
             Net = Net,
             Gross = Gross,
             UnitId = UnitId,
-            TaxRateId = TaxRateId
+            TaxRateId = TaxRateId,
+            ProductGroupId = ProductGroupId
         };
 
         var id = await _products.AddAsync(product);
         product.Id = id;
         _parent.Products.Add(product);
         _row.Product = product.Name;
+        _row.UnitId = product.UnitId;
+        _row.UnitName = _parent.Units.FirstOrDefault(u => u.Id == UnitId)?.Name ?? string.Empty;
+        _row.TaxRateId = product.TaxRateId;
+        _row.TaxRateName = _parent.TaxRates.FirstOrDefault(t => t.Id == TaxRateId)?.Name ?? string.Empty;
+        _row.ProductGroup = _parent.ProductGroups.FirstOrDefault(g => g.Id == ProductGroupId)?.Name ?? string.Empty;
         _parent.InlineCreator = null;
         if (_parent.IsEditable)
             await _parent.AddLineItemCommand.ExecuteAsync(null);

--- a/Wrecept.Wpf/ViewModels/SupplierCreatorViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/SupplierCreatorViewModel.cs
@@ -15,6 +15,9 @@ public partial class SupplierCreatorViewModel : ObservableObject
     [ObservableProperty]
     private string name = string.Empty;
 
+    [ObservableProperty]
+    private string taxId = string.Empty;
+
     public SupplierCreatorViewModel(InvoiceEditorViewModel parent, ISupplierService suppliers)
     {
         _parent = parent;
@@ -24,7 +27,7 @@ public partial class SupplierCreatorViewModel : ObservableObject
     [RelayCommand]
     private async Task ConfirmAsync()
     {
-        var supplier = new Supplier { Name = Name };
+        var supplier = new Supplier { Name = Name, TaxId = TaxId };
         var id = await _suppliers.AddAsync(supplier);
         supplier.Id = id;
         _parent.Suppliers.Add(supplier);

--- a/Wrecept.Wpf/ViewModels/TaxRateCreatorViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/TaxRateCreatorViewModel.cs
@@ -16,6 +16,9 @@ public partial class TaxRateCreatorViewModel : ObservableObject
     private string name = string.Empty;
 
     [ObservableProperty]
+    private string code = string.Empty;
+
+    [ObservableProperty]
     private decimal percentage;
 
     public TaxRateCreatorViewModel(InvoiceEditorViewModel parent, ITaxRateService taxRates)
@@ -27,7 +30,13 @@ public partial class TaxRateCreatorViewModel : ObservableObject
     [RelayCommand]
     private async Task ConfirmAsync()
     {
-        var rate = new TaxRate { Name = Name, Percentage = Percentage, EffectiveFrom = DateTime.UtcNow };
+        var rate = new TaxRate
+        {
+            Name = Name,
+            Percentage = Percentage,
+            Code = Code,
+            EffectiveFrom = DateTime.UtcNow
+        };
         var id = await _taxRates.AddAsync(rate);
         rate.Id = id;
         _parent.TaxRates.Add(rate);

--- a/Wrecept.Wpf/ViewModels/UnitCreatorViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/UnitCreatorViewModel.cs
@@ -15,6 +15,9 @@ public partial class UnitCreatorViewModel : ObservableObject
     [ObservableProperty]
     private string name = string.Empty;
 
+    [ObservableProperty]
+    private string code = string.Empty;
+
     public UnitCreatorViewModel(InvoiceEditorViewModel parent, IUnitService units)
     {
         _parent = parent;
@@ -24,7 +27,7 @@ public partial class UnitCreatorViewModel : ObservableObject
     [RelayCommand]
     private async Task ConfirmAsync()
     {
-        var unit = new Unit { Name = Name };
+        var unit = new Unit { Name = Name, Code = Code };
         var id = await _units.AddAsync(unit);
         unit.Id = id;
         _parent.Units.Add(unit);

--- a/Wrecept.Wpf/Views/InlineCreators/ProductCreatorView.xaml
+++ b/Wrecept.Wpf/Views/InlineCreators/ProductCreatorView.xaml
@@ -23,6 +23,10 @@
                 <ComboBox Width="120" ItemsSource="{Binding Units}" SelectedValuePath="Id" DisplayMemberPath="Name" SelectedValue="{Binding UnitId}" />
             </StackPanel>
             <StackPanel Orientation="Horizontal" Margin="0,4,0,0">
+                <TextBlock Text="Csoport" Width="60" />
+                <ComboBox Width="120" ItemsSource="{Binding ProductGroups}" SelectedValuePath="Id" DisplayMemberPath="Name" SelectedValue="{Binding ProductGroupId}" />
+            </StackPanel>
+            <StackPanel Orientation="Horizontal" Margin="0,4,0,0">
                 <TextBlock Text="ÁFA" Width="60" />
                 <ComboBox Width="120" ItemsSource="{Binding TaxRates}" SelectedValuePath="Id" DisplayMemberPath="Name" SelectedValue="{Binding TaxRateId}" />
             </StackPanel>

--- a/Wrecept.Wpf/Views/InlineCreators/SupplierCreatorView.xaml
+++ b/Wrecept.Wpf/Views/InlineCreators/SupplierCreatorView.xaml
@@ -10,6 +10,10 @@
                 <TextBox x:Name="NameBox" Width="160" Text="{Binding Name}" />
             </StackPanel>
             <StackPanel Orientation="Horizontal" Margin="0,4,0,0">
+                <TextBlock Text="Adószám" Width="60" />
+                <TextBox Width="160" Text="{Binding TaxId}" />
+            </StackPanel>
+            <StackPanel Orientation="Horizontal" Margin="0,4,0,0">
                 <Button Content="OK" Command="{Binding ConfirmCommand}" Width="60" Margin="0,0,4,0" />
                 <Button Content="Mégse" Command="{Binding CancelCommand}" Width="60" />
             </StackPanel>

--- a/Wrecept.Wpf/Views/InlineCreators/TaxRateCreatorView.xaml
+++ b/Wrecept.Wpf/Views/InlineCreators/TaxRateCreatorView.xaml
@@ -10,6 +10,10 @@
                 <TextBox x:Name="NameBox" Width="120" Text="{Binding Name}" />
             </StackPanel>
             <StackPanel Orientation="Horizontal" Margin="0,4,0,0">
+                <TextBlock Text="Kód" Width="60" />
+                <TextBox Width="80" Text="{Binding Code}" />
+            </StackPanel>
+            <StackPanel Orientation="Horizontal" Margin="0,4,0,0">
                 <TextBlock Text="%" Width="60" />
                 <TextBox Width="80" Text="{Binding Percentage}" />
             </StackPanel>

--- a/Wrecept.Wpf/Views/InlineCreators/UnitCreatorView.xaml
+++ b/Wrecept.Wpf/Views/InlineCreators/UnitCreatorView.xaml
@@ -10,6 +10,10 @@
                 <TextBox x:Name="NameBox" Width="120" Text="{Binding Name}" />
             </StackPanel>
             <StackPanel Orientation="Horizontal" Margin="0,4,0,0">
+                <TextBlock Text="Kód" Width="60" />
+                <TextBox Width="80" Text="{Binding Code}" />
+            </StackPanel>
+            <StackPanel Orientation="Horizontal" Margin="0,4,0,0">
                 <Button Content="OK" Command="{Binding ConfirmCommand}" Width="60" Margin="0,0,4,0" />
                 <Button Content="Mégse" Command="{Binding CancelCommand}" Width="60" />
             </StackPanel>

--- a/docs/InlineEntityCreation.md
+++ b/docs/InlineEntityCreation.md
@@ -31,6 +31,7 @@ A kitöltött űrlap mentése azonnal létrehozza az entitást és a szerkesztet
 * Az `InlineCreatorTarget` property az adott vezérlőre mutat, amelyhez a `Popup` igazodik.
 * A háttérszín `#F5F5DC`, ezzel emeljük ki az inline űrlapot.
 * Az entitások validálását a megfelelő szolgáltatások (`IProductService`, stb.) végzik.
+* Az űrlapok már minden fő tulajdonságot bekérnek (pl. terméknél egység, termékcsoport és ÁFA; szállítónál név és adószám).
 
 ## Jövőbeli bővítések
 

--- a/docs/progress/2025-07-06_00-17-49_code_agent.md
+++ b/docs/progress/2025-07-06_00-17-49_code_agent.md
@@ -1,0 +1,5 @@
+- InvoiceEditorViewModel now loads ProductGroups and injects IProductGroupService.
+- Inline creator ViewModels extended with missing fields (TaxId, Code, ProductGroupId).
+- Corresponding XAML views updated with new input controls.
+- Resources updated with Load_ProductGroups string.
+- Tests adjusted for new constructor signature.

--- a/docs/progress/2025-07-06_00-17-49_docs_agent.md
+++ b/docs/progress/2025-07-06_00-17-49_docs_agent.md
@@ -1,0 +1,1 @@
+- InlineEntityCreation.md updated to mention full property support.

--- a/tests/viewmodels/InvoiceEditorViewModelTests.cs
+++ b/tests/viewmodels/InvoiceEditorViewModelTests.cs
@@ -72,7 +72,7 @@ public class InvoiceEditorViewModelTests
         public Task UpdateAsync(Product product, System.Threading.CancellationToken ct = default) => Task.CompletedTask;
     }
 
-    private class DummyService<T> : IPaymentMethodService, ITaxRateService, ISupplierService, IUnitService
+    private class DummyService<T> : IPaymentMethodService, ITaxRateService, ISupplierService, IUnitService, IProductGroupService
         where T : class
     {
         public Task<List<PaymentMethod>> GetActiveAsync(System.Threading.CancellationToken ct = default) => Task.FromResult(new List<PaymentMethod>());
@@ -94,6 +94,11 @@ public class InvoiceEditorViewModelTests
         public Task<List<Unit>> GetActiveAsync(System.Threading.CancellationToken ct = default) => Task.FromResult(new List<Unit>());
         public Task<Guid> AddAsync(Unit unit, System.Threading.CancellationToken ct = default) => Task.FromResult(Guid.NewGuid());
         public Task UpdateAsync(Unit unit, System.Threading.CancellationToken ct = default) => Task.CompletedTask;
+
+        public Task<List<ProductGroup>> GetAllAsync(System.Threading.CancellationToken ct = default) => Task.FromResult(new List<ProductGroup>());
+        public Task<List<ProductGroup>> GetActiveAsync(System.Threading.CancellationToken ct = default) => Task.FromResult(new List<ProductGroup>());
+        public Task<Guid> AddAsync(ProductGroup group, System.Threading.CancellationToken ct = default) => Task.FromResult(Guid.NewGuid());
+        public Task UpdateAsync(ProductGroup group, System.Threading.CancellationToken ct = default) => Task.CompletedTask;
     }
 
     private class DummyLogService : ILogService
@@ -137,11 +142,13 @@ public class InvoiceEditorViewModelTests
         var tax = new DummyService<object>();
         var supplier = new DummyService<object>();
         var unit = new DummyService<object>();
+        var groups = new DummyService<object>();
+        var groups = new DummyService<object>();
         var log = new DummyLogService();
         var notify = new DummyNotificationService();
         var lookup = new InvoiceLookupViewModel(invoiceSvc);
         var state = new AppStateService(Path.GetTempFileName());
-        var vm = new InvoiceEditorViewModel(payment, tax, supplier, productSvc, unit, invoiceSvc, log, notify, state, lookup);
+        var vm = new InvoiceEditorViewModel(payment, tax, supplier, productSvc, unit, groups, invoiceSvc, log, notify, state, lookup);
 
         var row = vm.Items[0];
         row.Product = "Test";
@@ -169,7 +176,7 @@ public class InvoiceEditorViewModelTests
         var notify = new DummyNotificationService();
         var lookup = new InvoiceLookupViewModel(invoiceSvc);
         var state = new AppStateService(Path.GetTempFileName());
-        var vm = new InvoiceEditorViewModel(payment, tax, supplier, productSvc, unit, invoiceSvc, log, notify, state, lookup);
+        var vm = new InvoiceEditorViewModel(payment, tax, supplier, productSvc, unit, groups, invoiceSvc, log, notify, state, lookup);
 
         var row = vm.Items[0];
         row.Product = "Test";
@@ -196,7 +203,7 @@ public class InvoiceEditorViewModelTests
         var notify = new DummyNotificationService();
         var lookup = new InvoiceLookupViewModel(invoiceSvc);
         var state = new AppStateService(Path.GetTempFileName());
-        var vm = new InvoiceEditorViewModel(dummy, dummy, dummy, productSvc, dummy, invoiceSvc, log, notify, state, lookup)
+        var vm = new InvoiceEditorViewModel(dummy, dummy, dummy, productSvc, dummy, dummy, invoiceSvc, log, notify, state, lookup)
         {
             IsArchived = true
         };
@@ -224,7 +231,7 @@ public class InvoiceEditorViewModelTests
         var notify = new DummyNotificationService();
         var lookup = new InvoiceLookupViewModel(invoiceSvc);
         var state = new AppStateService(Path.GetTempFileName());
-        var vm = new InvoiceEditorViewModel(dummy, dummy, dummy, productSvc, dummy, invoiceSvc, log, notify, state, lookup);
+        var vm = new InvoiceEditorViewModel(dummy, dummy, dummy, productSvc, dummy, dummy, invoiceSvc, log, notify, state, lookup);
 
         var row = vm.Items[0];
         var creator = new ProductCreatorViewModel(vm, row, productSvc)
@@ -250,7 +257,7 @@ public class InvoiceEditorViewModelTests
         var notify = new DummyNotificationService();
         var lookup = new InvoiceLookupViewModel(invoiceSvc);
         var state = new AppStateService(Path.GetTempFileName());
-        var vm = new InvoiceEditorViewModel(dummy, dummy, dummy, productSvc, dummy, invoiceSvc, log, notify, state, lookup)
+        var vm = new InvoiceEditorViewModel(dummy, dummy, dummy, productSvc, dummy, dummy, invoiceSvc, log, notify, state, lookup)
         {
             IsNew = false,
             InvoiceId = 1
@@ -283,7 +290,7 @@ public class InvoiceEditorViewModelTests
         var notify = new DummyNotificationService();
         var lookup = new InvoiceLookupViewModel(invoiceSvc);
         var state = new AppStateService(Path.GetTempFileName());
-        var vm = new InvoiceEditorViewModel(dummy, dummy, dummy, productSvc, dummy, invoiceSvc, log, notify, state, lookup)
+        var vm = new InvoiceEditorViewModel(dummy, dummy, dummy, productSvc, dummy, dummy, invoiceSvc, log, notify, state, lookup)
         {
             IsNew = false,
             InvoiceId = 1,
@@ -315,7 +322,7 @@ public class InvoiceEditorViewModelTests
         var notify = new DummyNotificationService();
         var lookup = new InvoiceLookupViewModel(invoiceSvc);
         var state = new AppStateService(Path.GetTempFileName());
-        var vm = new InvoiceEditorViewModel(dummy, dummy, dummy, productSvc, dummy, invoiceSvc, log, notify, state, lookup);
+        var vm = new InvoiceEditorViewModel(dummy, dummy, dummy, productSvc, dummy, dummy, invoiceSvc, log, notify, state, lookup);
 
         lookup.Invoices.Add(new InvoiceLookupItem { Id = 1, Number = "A1", Date = DateOnly.FromDateTime(DateTime.Today) });
         lookup.SelectedInvoice = lookup.Invoices[0];


### PR DESCRIPTION
## Summary
- load product groups in InvoiceEditor
- allow specifying ProductGroup, TaxId, Code in inline creator viewmodels
- update inline creator XAML views with new inputs
- document inline creator enhancements
- adjust unit tests for new constructor

## Testing
- `dotnet test tests/Wrecept.Tests/Wrecept.Tests.csproj` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869be7c23c88322bd861588dcc1a341