### PR TITLE
Fix QuestPDF license initialization

### DIFF
--- a/Wrecept.Wpf/Services/PdfInvoiceExporter.cs
+++ b/Wrecept.Wpf/Services/PdfInvoiceExporter.cs
@@ -9,6 +9,11 @@ namespace Wrecept.Wpf.Services;
 
 public class PdfInvoiceExporter : IInvoiceExportService
 {
+    static PdfInvoiceExporter()
+    {
+        QuestPDF.Settings.License = LicenseType.Community;
+    }
+
     public Task SavePdfAsync(Invoice invoice, string filePath, CancellationToken ct = default)
     {
         ArgumentNullException.ThrowIfNull(invoice);

--- a/docs/progress/2025-07-06_08-23-43_code_agent.md
+++ b/docs/progress/2025-07-06_08-23-43_code_agent.md
@@ -1,0 +1,1 @@
+- PdfInvoiceExporter sets QuestPDF community license in static constructor to avoid runtime check.


### PR DESCRIPTION
## Summary
- set QuestPDF community license in `PdfInvoiceExporter`
- log progress

## Testing
- `dotnet test tests/Wrecept.Tests/Wrecept.Tests.csproj -v n` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a31b8628c8322954da2c2f70cf066