### PR TITLE
Add gross checkbox to invoice editor header

### DIFF
--- a/Wrecept.Wpf/Views/InvoiceEditorLayout.xaml
+++ b/Wrecept.Wpf/Views/InvoiceEditorLayout.xaml
@@ -108,10 +108,15 @@
                                           IsEnabled="{Binding IsEditable}" />
                         </StackPanel>
 
-                        <!-- Invoice number -->
+                        <!-- Invoice number and gross mode -->
                         <StackPanel Margin="0,6,0,0">
                             <Label Content="_Számlaszám" Style="{StaticResource FormLabelStyle}" Target="{Binding ElementName=NumberBox}" />
-                            <TextBox x:Name="NumberBox" Width="220" Text="{Binding Number}" IsEnabled="{Binding IsNew}" Style="{StaticResource HeaderTextBoxBold}" />
+                            <StackPanel Orientation="Horizontal">
+                                <TextBox x:Name="NumberBox" Width="220" Text="{Binding Number}" IsEnabled="{Binding IsNew}" Style="{StaticResource HeaderTextBoxBold}" />
+                                <CheckBox Content="Bruttó" Margin="8,0,0,0"
+                                          IsChecked="{Binding IsGross}"
+                                          IsEnabled="{Binding IsEditable}" />
+                            </StackPanel>
                         </StackPanel>
                     </UniformGrid>
                 </Border>

--- a/docs/UI_FLOW.md
+++ b/docs/UI_FLOW.md
@@ -49,7 +49,7 @@ Date selection (default = today, arrow or numpad)
 
 Payment method (SmartLookup)
 
-Bruttó checkbox (affects unit price interpretation)
+Bruttó jelölőnégyzet a számlaszám mező mellett. Csak szerkeszthető számlánál aktív, az egységár értelmezését szabályozza.
 
 3. Invoice Line Items Entry
 

--- a/docs/progress/2025-07-06_09-05-06_ui_agent.md
+++ b/docs/progress/2025-07-06_09-05-06_ui_agent.md
@@ -1,0 +1,2 @@
+- InvoiceEditorLayout header expanded with Bruttó checkbox bound to IsGross.
+- UI_FLOW.md bullet refined to mention checkbox placement and editability.


### PR DESCRIPTION
## Summary
- add Bruttó checkbox next to invoice number in `InvoiceEditorLayout`
- checkbox enabled only when invoice editable
- clarify checkbox placement in `UI_FLOW.md`
- log progress for ui_agent

## Testing
- `dotnet test Wrecept.Core.Tests/Wrecept.Core.Tests.csproj -v minimal` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a3b30732c8322bdeefc6458a36a83