### PR TITLE
Handle ESC finalization prompt

### DIFF
--- a/Wrecept.Wpf/Views/InvoiceEditorLayout.xaml
+++ b/Wrecept.Wpf/Views/InvoiceEditorLayout.xaml
@@ -157,7 +157,7 @@
                                    CreateCommand="{Binding DataContext.ShowUnitCreatorCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
                                    CommandParameter="{Binding RelativeSource={RelativeSource Self}}" />
                     <TextBox x:Name="EntryPrice" Grid.Column="3" Margin="4,0" Text="{Binding UnitPrice, Mode=TwoWay}" />
-                    <c:EditLookup x:Name="EntryTax" Grid.Column="4" Tag="LastEntry"
+                    <c:EditLookup x:Name="EntryTax" Grid.Column="4" Tag="LastEntry" PreviewKeyDown="LastEntry_PreviewKeyDown"
                                   ItemsSource="{Binding DataContext.TaxRates, RelativeSource={RelativeSource AncestorType=UserControl}}"
                                   DisplayMemberPath="Name"
                                   SelectedValuePath="Id"

--- a/Wrecept.Wpf/Views/InvoiceEditorLayout.xaml.cs
+++ b/Wrecept.Wpf/Views/InvoiceEditorLayout.xaml.cs
@@ -44,5 +44,19 @@ public partial class InvoiceEditorLayout : UserControl
             progressWindow.Close();
         };
     }
+
+    private void LastEntry_PreviewKeyDown(object sender, System.Windows.Input.KeyEventArgs e)
+    {
+        if (e.Key == System.Windows.Input.Key.Escape && DataContext is InvoiceEditorViewModel vm)
+        {
+            if (vm.IsInLineFinalizationPrompt)
+                return;
+
+            vm.IsInLineFinalizationPrompt = true;
+            vm.SavePrompt = new SaveLinePromptViewModel(vm,
+                "Végeztél a szerkesztéssel? (Enter=Igen, Esc=Nem)", finalize: true);
+            e.Handled = true;
+        }
+    }
 }
 

--- a/docs/progress/2025-07-06_09-19-38_logic_agent.md
+++ b/docs/progress/2025-07-06_09-19-38_logic_agent.md
@@ -1,0 +1,2 @@
+- Escape handler added to EntryTax (Tag=LastEntry) in InvoiceEditorLayout.
+- Handler sets IsInLineFinalizationPrompt and shows SaveLinePromptViewModel with finalize=true.


### PR DESCRIPTION
## Summary
- trigger finalization prompt when pressing ESC in the last invoice line field
- surface new handler in logic progress log

## Testing
- `dotnet test --no-build` *(fails: WindowsDesktop SDK not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a3e9b28588322a08de9227dd384a5