### PR TITLE
Implement Enter handler in InvoiceEditor

### DIFF
--- a/Wrecept.Wpf/Views/InvoiceEditorLayout.xaml
+++ b/Wrecept.Wpf/Views/InvoiceEditorLayout.xaml
@@ -164,7 +164,8 @@
                                   SelectedValue="{Binding TaxRateId, Mode=TwoWay}"
                                   CreateCommand="{Binding DataContext.ShowTaxRateCreatorCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
                                   CreateCommandParameter="{Binding RelativeSource={RelativeSource Self}}" />
-                    <TextBox x:Name="EntryDesc" Grid.Column="5" Text="{Binding Description, Mode=TwoWay}" Margin="4,0" />
+                    <TextBox x:Name="EntryDesc" Grid.Column="5" Text="{Binding Description, Mode=TwoWay}" Margin="4,0"
+                             PreviewKeyDown="EntryDesc_PreviewKeyDown" />
                 </Grid>
             </Border>
 

--- a/Wrecept.Wpf/Views/InvoiceEditorLayout.xaml.cs
+++ b/Wrecept.Wpf/Views/InvoiceEditorLayout.xaml.cs
@@ -58,5 +58,16 @@ public partial class InvoiceEditorLayout : UserControl
             e.Handled = true;
         }
     }
+
+    private async void EntryDesc_PreviewKeyDown(object sender, System.Windows.Input.KeyEventArgs e)
+    {
+        if (e.Key == System.Windows.Input.Key.Enter && DataContext is InvoiceEditorViewModel vm)
+        {
+            vm.ShowSavePromptCommand.Execute(null);
+            await vm.AddLineItemCommand.ExecuteAsync(null);
+            EntryProduct.Focus();
+            e.Handled = true;
+        }
+    }
 }
 

--- a/docs/progress/2025-07-06_11-53-16_logic_agent.md
+++ b/docs/progress/2025-07-06_11-53-16_logic_agent.md
@@ -1,0 +1,2 @@
+- EntryDesc mező PreviewKeyDown eseményt kapott, amely Enterre menti a sort.
+- EntryDesc_PreviewKeyDown meghívja ShowSavePromptCommand és AddLineItemCommand parancsokat, majd visszaadja a fókuszt a termék mezőre.


### PR DESCRIPTION
## Summary
- handle Enter on EntryDesc in InvoiceEditor
- save invoice line via command and refocus product field
- log progress

## Testing
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a62ac3e7c83228f5b5d04f800b499