### PR TITLE
Focus InvoiceLookup list after loading

### DIFF
--- a/Wrecept.Wpf/Views/InvoiceLookupView.xaml.cs
+++ b/Wrecept.Wpf/Views/InvoiceLookupView.xaml.cs
@@ -29,6 +29,7 @@ public partial class InvoiceLookupView : UserControl
             if (DataContext is InvoiceLookupViewModel vm)
             {
                 await vm.LoadAsync();
+                InvoiceList.Focus();
             }
         }
         catch (Exception ex)

--- a/docs/UI_FLOW.md
+++ b/docs/UI_FLOW.md
@@ -24,6 +24,7 @@ számlafejléc mezőknél.
 - Fókuszkezdő pontok nézetenként:
   - **StageView** – a főmenüsor első eleme
   - **InvoiceLookupView** – `InvoiceList` `ListBox`
+    - A lista betöltése után az `OnLoaded` esemény hívja meg az `InvoiceList.Focus()` metódust, így a kurzor rögtön a listára kerül.
   - **InvoiceEditorLayout** – bal oldali `InvoiceList`
   - **ProductMasterView** – a táblázat (Grid)
   - **SupplierMasterView** – a táblázat (Grid)

--- a/docs/progress/2025-07-06_12-27-05_code_agent.md
+++ b/docs/progress/2025-07-06_12-27-05_code_agent.md
@@ -1,0 +1,1 @@
+- InvoiceLookupView OnLoaded most az adatok betöltése után meghívja az InvoiceList.Focus()-t.

--- a/docs/progress/2025-07-06_12-27-05_docs_agent.md
+++ b/docs/progress/2025-07-06_12-27-05_docs_agent.md
@@ -1,0 +1,1 @@
+- UI_FLOW.md bővült: jelezzük, hogy az InvoiceLookupView betöltéskor a lista kap fókuszt.


### PR DESCRIPTION
## Summary
- ensure InvoiceLookup list receives focus when loaded
- document automatic focus in UI flow
- log progress for docs and code agents

## Testing
- `dotnet test --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a6ad0591883229a5599831bd66ce7