### PR TITLE
Handle Up arrow invoice creation

### DIFF
--- a/Wrecept.Wpf/Views/InvoiceLookupView.xaml.cs
+++ b/Wrecept.Wpf/Views/InvoiceLookupView.xaml.cs
@@ -41,7 +41,15 @@ public partial class InvoiceLookupView : UserControl
 
     private async void InvoiceList_PreviewKeyDown(object sender, System.Windows.Input.KeyEventArgs e)
     {
-        if (e.Key == System.Windows.Input.Key.Insert && DataContext is InvoiceLookupViewModel vm)
+        if (DataContext is not InvoiceLookupViewModel vm)
+            return;
+
+        if (e.Key == System.Windows.Input.Key.Insert)
+        {
+            await vm.PromptNewInvoiceAsync();
+            e.Handled = true;
+        }
+        else if (e.Key == System.Windows.Input.Key.Up && InvoiceList.SelectedIndex == 0)
         {
             await vm.PromptNewInvoiceAsync();
             e.Handled = true;

--- a/docs/progress/2025-07-06_13-17-07_logic_agent.md
+++ b/docs/progress/2025-07-06_13-17-07_logic_agent.md
@@ -1,0 +1,1 @@
+- InvoiceList_PreviewKeyDown now also triggers invoice creation when Up is pressed on the first item.

--- a/docs/progress/2025-07-06_13-17-07_test_agent.md
+++ b/docs/progress/2025-07-06_13-17-07_test_agent.md
@@ -1,0 +1,1 @@
+- Added InvoiceList_UpOnFirstItem_OpensPrompt UI test ensuring Up arrow at top opens new invoice dialog.

--- a/tests/Wrecept.UiTests/InvoiceEditorTests.cs
+++ b/tests/Wrecept.UiTests/InvoiceEditorTests.cs
@@ -28,4 +28,42 @@ public class InvoiceEditorTests
 
         driver.Close();
     }
+
+    [TestMethod]
+    public void InvoiceList_UpOnFirstItem_OpensPrompt()
+    {
+        using var driver = LaunchApp();
+
+        var wait = new WebDriverWait(driver, TimeSpan.FromSeconds(5));
+
+        var options = driver.FindElementsByName("Mintaszámok");
+        if (options.Count > 0)
+            options[0].FindElementByName("Mégse").Click();
+
+        var list = wait.Until(d => ((WindowsDriver<WindowsElement>)d)
+            .FindElementByAccessibilityId("InvoiceList"));
+        list.Click();
+
+        new OpenQA.Selenium.Interactions.Actions(driver)
+            .SendKeys(OpenQA.Selenium.Keys.Insert)
+            .Perform();
+
+        var box = wait.Until(d => ((WindowsDriver<WindowsElement>)d)
+            .FindElementByAccessibilityId("NumberBox"));
+        new OpenQA.Selenium.Interactions.Actions(driver)
+            .SendKeys(OpenQA.Selenium.Keys.Enter)
+            .Perform();
+        wait.Until(d => d.FindElementsByAccessibilityId("NumberBox").Count == 0);
+
+        list.Click();
+        new OpenQA.Selenium.Interactions.Actions(driver)
+            .SendKeys(OpenQA.Selenium.Keys.ArrowUp)
+            .Perform();
+
+        box = wait.Until(d => ((WindowsDriver<WindowsElement>)d)
+            .FindElementByAccessibilityId("NumberBox"));
+        Assert.IsNotNull(box);
+
+        driver.Close();
+    }
 }


### PR DESCRIPTION
## Summary
- allow Up arrow to trigger new invoice prompt when first item is selected
- extend UI tests to verify prompt on Up key
- log progress for logic and test agents

## Testing
- `dotnet test tests/Wrecept.UiTests/Wrecept.UiTests.csproj -c Release --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*
- `dotnet test tests/Wrecept.Tests/Wrecept.Tests.csproj -c Release --no-build` *(no output)*

------
https://chatgpt.com/codex/tasks/task_e_686a75c565448322b2157a8bbe2eadda