### PR TITLE
Fix build errors

### DIFF
--- a/Wrecept.Core/Wrecept.Core.csproj
+++ b/Wrecept.Core/Wrecept.Core.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>

--- a/Wrecept.Storage/Wrecept.Storage.csproj
+++ b/Wrecept.Storage/Wrecept.Storage.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>

--- a/Wrecept.Wpf/Services/AppStateService.cs
+++ b/Wrecept.Wpf/Services/AppStateService.cs
@@ -5,6 +5,7 @@ namespace Wrecept.Wpf.Services;
 
 using System.Text.Json;
 using Wrecept.Wpf.ViewModels;
+using System.Threading.Tasks;
 
 public partial class AppStateService : ObservableObject
 {

--- a/Wrecept.Wpf/Services/PdfInvoiceExporter.cs
+++ b/Wrecept.Wpf/Services/PdfInvoiceExporter.cs
@@ -4,6 +4,8 @@ using QuestPDF.Helpers;
 using QuestPDF.Infrastructure;
 using Wrecept.Core.Models;
 using Wrecept.Core.Services;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Wrecept.Wpf.Services;
 

--- a/Wrecept.Wpf/Wrecept.Wpf.csproj
+++ b/Wrecept.Wpf/Wrecept.Wpf.csproj
@@ -1,8 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <TargetFramework>net8.0-windows</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <UseWPF>true</UseWPF>
   </PropertyGroup>
@@ -13,7 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.0" />
-    <PackageReference Include="QuestPDF" Version="2024.2.0" />
+    <PackageReference Include="QuestPDF" Version="2024.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/docs/progress/2025-07-06_13-24-45_code_agent.md
+++ b/docs/progress/2025-07-06_13-24-45_code_agent.md
@@ -1,0 +1,4 @@
+- Csere a WindowsDesktop SDK-ről Microsoft.NET.Sdk-ra.
+- Engedélyeztem az implicit usingeket a WPF projektben.
+- Frissítettem a QuestPDF csomagot.
+- Hozzáadtam hiányzó usingokat a Task és CancellationToken típusokhoz.

--- a/tests/Wrecept.UiTests/Wrecept.UiTests.csproj
+++ b/tests/Wrecept.UiTests/Wrecept.UiTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net8.0-windows</TargetFramework>


### PR DESCRIPTION
## Summary
- fix csproj SDK references and enable implicit usings
- update QuestPDF version
- add missing `Task` and `CancellationToken` usings
- log progress

## Testing
- `dotnet build --no-restore` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*
- `dotnet test --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a7836b3cc83228d9f91716c783b83