### PR TITLE
Refresh lookup after save

### DIFF
--- a/Wrecept.Wpf/ViewModels/InvoiceEditorViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/InvoiceEditorViewModel.cs
@@ -829,6 +829,7 @@ private void UpdateSupplierId(string name)
         _state.CurrentInvoiceId = null;
         await _state.SaveAsync();
         await Lookup.LoadAsync();
+        Lookup.SelectedInvoice = null;
     }
 
     private async void LookupLoadSelected()

--- a/Wrecept.Wpf/ViewModels/InvoiceEditorViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/InvoiceEditorViewModel.cs
@@ -761,9 +761,12 @@ private void UpdateSupplierId(string name)
                 var ok = await _invoiceService.CreateAsync(_draft);
                 if (ok)
                 {
-                    InvoiceId = _draft.Id;
+                    var newId = _draft.Id;
+                    InvoiceId = newId;
                     IsNew = false;
                     _draft = new Invoice();
+                    await Lookup.LoadAsync();
+                    Lookup.SelectedInvoice = Lookup.Invoices.FirstOrDefault(i => i.Id == newId);
                 }
             }
             else
@@ -825,6 +828,7 @@ private void UpdateSupplierId(string name)
         await _session.SaveLastInvoiceIdAsync(null);
         _state.CurrentInvoiceId = null;
         await _state.SaveAsync();
+        await Lookup.LoadAsync();
     }
 
     private async void LookupLoadSelected()

--- a/docs/progress/2025-07-06_13-35-40_code_agent.md
+++ b/docs/progress/2025-07-06_13-35-40_code_agent.md
@@ -1,0 +1,2 @@
+- SaveAsync hívás után frissíti az InvoiceLookup listát és kiválasztja az új számlát.
+- Archiválás után szintén frissül a lista.


### PR DESCRIPTION
## Summary
- refresh InvoiceLookup list after saving new invoice and after archive
- log progress

## Testing
- `dotnet test tests/Wrecept.Tests/Wrecept.Tests.csproj -nologo` *(fails: Project Wrecept.Wpf is not compatible with net8.0)*

------
https://chatgpt.com/codex/tasks/task_e_686a7ace02148322a5d1abe62d8d0896