### PR TITLE
Fix InvoiceEditorTests compile error

### DIFF
--- a/docs/progress/2025-07-06_14-35-29_code_agent.md
+++ b/docs/progress/2025-07-06_14-35-29_code_agent.md
@@ -1,0 +1,1 @@
+- Fixed compile error in InvoiceEditorTests by casting IWebDriver to WindowsDriver before using FindElementsByAccessibilityId.

--- a/tests/Wrecept.UiTests/InvoiceEditorTests.cs
+++ b/tests/Wrecept.UiTests/InvoiceEditorTests.cs
@@ -50,7 +50,8 @@ public class InvoiceEditorTests
         var box = wait.Until(d => ((WindowsDriver<WindowsElement>)d)
             .FindElementByAccessibilityId("NumberBox"));
         actions.SendKeys(OpenQA.Selenium.Keys.Enter).Perform();
-        wait.Until(d => d.FindElementsByAccessibilityId("NumberBox").Count == 0);
+        wait.Until(d => ((WindowsDriver<WindowsElement>)d)
+            .FindElementsByAccessibilityId("NumberBox").Count == 0);
 
         list.Click();
         actions.SendKeys(OpenQA.Selenium.Keys.ArrowUp).Perform();


### PR DESCRIPTION
## Summary
- fix WindowsDriver cast for `FindElementsByAccessibilityId`
- log progress for code_agent

## Testing
- `dotnet test --no-build tests/Wrecept.UiTests/Wrecept.UiTests.csproj` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a892d24188322ac4b0793305c92e2