### PR TITLE
Fix invoice finalization behavior

### DIFF
--- a/Wrecept.Wpf/ViewModels/InvoiceEditorViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/InvoiceEditorViewModel.cs
@@ -813,7 +813,7 @@ private void UpdateSupplierId(string name)
     [RelayCommand]
     internal async Task FinalizeInvoiceAsync()
     {
-        await ArchiveAsync();
+        await SaveAsync();
         IsInLineFinalizationPrompt = false;
     }
 

--- a/docs/progress/2025-07-06_14-53-00_code_agent.md
+++ b/docs/progress/2025-07-06_14-53-00_code_agent.md
@@ -1,0 +1,1 @@
+- FinalizeInvoiceAsync now saves the invoice instead of archiving it.


### PR DESCRIPTION
## Summary
- FinalizeInvoiceAsync saves the invoice instead of archiving
- log progress for code_agent

## Testing
- `dotnet test --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets missing)*

------
https://chatgpt.com/codex/tasks/task_e_686a8b12568c8322bd7e015d9f6fef19