### PR TITLE
Add unit tests for WPF service classes

### DIFF
--- a/docs/progress/2025-07-06_18-07-59_code_agent.md
+++ b/docs/progress/2025-07-06_18-07-59_code_agent.md
@@ -1,0 +1,2 @@
+- Added unit tests for WPF services: ThemeManager, ScreenModeManager, NavigationService, DialogService and MessageBoxNotificationService.
+- Updated Wrecept.Tests project to include Xunit.StaFact for STA-based test execution.

--- a/tests/Wrecept.Tests/DialogServiceTests.cs
+++ b/tests/Wrecept.Tests/DialogServiceTests.cs
@@ -1,0 +1,40 @@
+using System.Windows;
+using CommunityToolkit.Mvvm.Input;
+using Wrecept.Wpf.Services;
+using Xunit;
+
+namespace Wrecept.Tests;
+
+public class DialogServiceTests
+{
+    private class AutoCloseView : FrameworkElement
+    {
+        public AutoCloseView()
+        {
+            Loaded += (_, _) =>
+            {
+                if (Window.GetWindow(this) is Window w)
+                {
+                    w.DialogResult = true;
+                    w.Close();
+                }
+            };
+        }
+    }
+
+    private static void EnsureApp()
+    {
+        if (Application.Current == null)
+            new Application();
+    }
+
+    [StaFact]
+    public void EditEntity_ShowsDialogAndReturnsTrue()
+    {
+        EnsureApp();
+        Application.Current.MainWindow = new Window();
+        var vm = new object();
+        var result = DialogService.EditEntity<AutoCloseView, object>(vm, new RelayCommand(() => { }), new RelayCommand(() => { }));
+        Assert.True(result);
+    }
+}

--- a/tests/Wrecept.Tests/MessageBoxNotificationServiceTests.cs
+++ b/tests/Wrecept.Tests/MessageBoxNotificationServiceTests.cs
@@ -1,0 +1,22 @@
+using Wrecept.Wpf.Services;
+using Xunit;
+
+namespace Wrecept.Tests;
+
+public class MessageBoxNotificationServiceTests
+{
+    [Fact]
+    public void Confirm_ReturnsTrue()
+    {
+        var svc = new MessageBoxNotificationService();
+        Assert.True(svc.Confirm("?"));
+    }
+
+    [Fact]
+    public void ShowMethods_DoNotThrow()
+    {
+        var svc = new MessageBoxNotificationService();
+        svc.ShowError("err");
+        svc.ShowInfo("info");
+    }
+}

--- a/tests/Wrecept.Tests/NavigationServiceTests.cs
+++ b/tests/Wrecept.Tests/NavigationServiceTests.cs
@@ -1,0 +1,42 @@
+using System.Windows;
+using Wrecept.Wpf.Services;
+using Xunit;
+
+namespace Wrecept.Tests;
+
+public class NavigationServiceTests
+{
+    private class AutoCloseWindow : Window
+    {
+        public AutoCloseWindow()
+        {
+            Loaded += (_, _) => { DialogResult = true; Close(); };
+        }
+    }
+
+    private static void EnsureApp()
+    {
+        if (Application.Current == null)
+            new Application();
+    }
+
+    [StaFact]
+    public void ShowCenteredDialog_CentersAndReturnsTrue()
+    {
+        EnsureApp();
+        Application.Current.MainWindow = new Window { Left = 10, Top = 20, Width = 200, Height = 200 };
+        var dlg = new AutoCloseWindow { Width = 100, Height = 100 };
+
+        var result = NavigationService.ShowCenteredDialog(dlg);
+
+        Assert.True(result);
+        Assert.Equal(Application.Current.MainWindow, dlg.Owner);
+        Assert.Equal(WindowStartupLocation.Manual, dlg.WindowStartupLocation);
+        var expectedLeft = Application.Current.MainWindow.Left +
+            (Application.Current.MainWindow.Width - dlg.Width) / 2;
+        var expectedTop = Application.Current.MainWindow.Top +
+            (Application.Current.MainWindow.Height - dlg.Height) / 2;
+        Assert.Equal(expectedLeft, dlg.Left);
+        Assert.Equal(expectedTop, dlg.Top);
+    }
+}

--- a/tests/Wrecept.Tests/ScreenModeManagerTests.cs
+++ b/tests/Wrecept.Tests/ScreenModeManagerTests.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Runtime.Serialization;
+using System.Threading.Tasks;
+using System.Windows;
+using Wrecept.Core;
+using Wrecept.Core.Entities;
+using Wrecept.Core.Services;
+using Wrecept.Wpf;
+using Wrecept.Wpf.Services;
+using Xunit;
+
+namespace Wrecept.Tests;
+
+public class ScreenModeManagerTests
+{
+    private class FakeSettingsService : ISettingsService
+    {
+        public AppSettings Saved = new();
+        public AppSettings LoadValue = new();
+        public Task<AppSettings> LoadAsync() => Task.FromResult(LoadValue);
+        public Task SaveAsync(AppSettings settings)
+        {
+            Saved = settings;
+            return Task.CompletedTask;
+        }
+    }
+
+    private static void EnsureApp()
+    {
+        if (Application.Current == null)
+            new Application();
+    }
+
+    private static MainWindow CreateWindow() =>
+        (MainWindow)FormatterServices.GetUninitializedObject(typeof(MainWindow));
+
+    [StaFact]
+    public async Task ApplySavedAsync_LoadsAndApplies()
+    {
+        EnsureApp();
+        var settings = new FakeSettingsService { LoadValue = new AppSettings { ScreenMode = ScreenMode.Small } };
+        var manager = new ScreenModeManager(settings);
+        var window = CreateWindow();
+
+        await manager.ApplySavedAsync(window);
+
+        Assert.Equal(ScreenMode.Small, manager.CurrentMode);
+        Assert.Equal(800d, window.Width);
+        Assert.Equal(600d, window.Height);
+    }
+
+    [StaFact]
+    public async Task ChangeModeAsync_ResizesAndSaves()
+    {
+        EnsureApp();
+        var settings = new FakeSettingsService();
+        var manager = new ScreenModeManager(settings);
+        var window = CreateWindow();
+
+        await manager.ChangeModeAsync(window, ScreenMode.ExtraLarge);
+
+        Assert.Equal(ScreenMode.ExtraLarge, manager.CurrentMode);
+        Assert.Equal(1920d, window.Width);
+        Assert.Equal(1080d, window.Height);
+        Assert.Equal(ScreenMode.ExtraLarge, settings.Saved.ScreenMode);
+    }
+}

--- a/tests/Wrecept.Tests/ThemeManagerTests.cs
+++ b/tests/Wrecept.Tests/ThemeManagerTests.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Linq;
+using System.Windows;
+using Wrecept.Wpf.Services;
+using Xunit;
+
+namespace Wrecept.Tests;
+
+public class ThemeManagerTests
+{
+    private static void EnsureApp()
+    {
+        if (Application.Current == null)
+            new Application();
+        Application.Current.Resources.MergedDictionaries.Clear();
+    }
+
+    [StaFact]
+    public void ApplyDarkTheme_UpdatesDictionary()
+    {
+        EnsureApp();
+
+        ThemeManager.ApplyDarkTheme(false);
+        var dict = Application.Current.Resources.MergedDictionaries.First();
+        Assert.EndsWith("RetroTheme.xaml", dict.Source!.OriginalString);
+
+        ThemeManager.ApplyDarkTheme(true);
+        dict = Application.Current.Resources.MergedDictionaries.First();
+        Assert.EndsWith("RetroTheme.Dark.xaml", dict.Source!.OriginalString);
+    }
+}

--- a/tests/Wrecept.Tests/Wrecept.Tests.csproj
+++ b/tests/Wrecept.Tests/Wrecept.Tests.csproj
@@ -9,6 +9,7 @@
     <PackageReference Include="xunit" Version="2.5.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="Xunit.StaFact" Version="2.1.7" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Wrecept.Wpf\Wrecept.Wpf.csproj" />


### PR DESCRIPTION
## Summary
- extend test project with Xunit.StaFact
- add unit tests for WPF services
- log progress

## Testing
- `dotnet test tests/Wrecept.Tests/Wrecept.Tests.csproj -c Release` *(fails: Project Wrecept.Wpf is not compatible with net8.0)*

------
https://chatgpt.com/codex/tasks/task_e_686ab836b4148322aadceecb4c6fc7a8