### PR TITLE
Add ViewModel unit tests

### DIFF
--- a/docs/progress/2025-07-06_18-21-58_test_agent.md
+++ b/docs/progress/2025-07-06_18-21-58_test_agent.md
@@ -1,0 +1,2 @@
+- Added unit tests for master data viewmodels and Stage/ScreenMode viewmodels.
+- `dotnet test` failed locally due to missing WindowsDesktop SDK.

--- a/tests/viewmodels/PaymentMethodMasterViewModelTests.cs
+++ b/tests/viewmodels/PaymentMethodMasterViewModelTests.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+using Wrecept.Wpf.ViewModels;
+using Wrecept.Core.Models;
+using Wrecept.Core.Services;
+
+namespace Wrecept.Tests.ViewModels;
+
+public class PaymentMethodMasterViewModelTests
+{
+    private class FakePaymentMethodService : IPaymentMethodService
+    {
+        public List<PaymentMethod> Methods { get; } = new();
+        public PaymentMethod? Updated;
+        public Task<List<PaymentMethod>> GetAllAsync(System.Threading.CancellationToken ct = default)
+            => Task.FromResult(Methods);
+        public Task<List<PaymentMethod>> GetActiveAsync(System.Threading.CancellationToken ct = default)
+            => Task.FromResult(Methods);
+        public Task<Guid> AddAsync(PaymentMethod method, System.Threading.CancellationToken ct = default)
+        {
+            method.Id = Guid.NewGuid();
+            Methods.Add(method);
+            return Task.FromResult(method.Id);
+        }
+        public Task UpdateAsync(PaymentMethod method, System.Threading.CancellationToken ct = default)
+        {
+            Updated = method;
+            return Task.CompletedTask;
+        }
+    }
+
+    [Fact]
+    public async Task LoadAsync_FillsCollection()
+    {
+        var service = new FakePaymentMethodService();
+        service.Methods.Add(new PaymentMethod { Id = Guid.NewGuid(), Name = "Cash" });
+        var vm = new PaymentMethodMasterViewModel(service);
+
+        await vm.LoadAsync();
+
+        Assert.Single(vm.PaymentMethods);
+    }
+
+    [Fact]
+    public async Task DeleteSelectedCommand_ArchivesItem()
+    {
+        var service = new FakePaymentMethodService();
+        var method = new PaymentMethod { Id = Guid.NewGuid(), Name = "X" };
+        service.Methods.Add(method);
+        var vm = new PaymentMethodMasterViewModel(service);
+        await vm.LoadAsync();
+
+        vm.SelectedItem = vm.PaymentMethods[0];
+        vm.DeleteSelectedCommand.Execute(null);
+        await Task.Delay(10);
+
+        Assert.True(method.IsArchived);
+        Assert.Equal(method, service.Updated);
+    }
+}

--- a/tests/viewmodels/ProductGroupMasterViewModelTests.cs
+++ b/tests/viewmodels/ProductGroupMasterViewModelTests.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+using Wrecept.Wpf.ViewModels;
+using Wrecept.Core.Models;
+using Wrecept.Core.Services;
+
+namespace Wrecept.Tests.ViewModels;
+
+public class ProductGroupMasterViewModelTests
+{
+    private class FakeService : IProductGroupService
+    {
+        public List<ProductGroup> Groups { get; } = new();
+        public ProductGroup? Updated;
+        public Task<List<ProductGroup>> GetAllAsync(System.Threading.CancellationToken ct = default)
+            => Task.FromResult(Groups);
+        public Task<List<ProductGroup>> GetActiveAsync(System.Threading.CancellationToken ct = default)
+            => Task.FromResult(Groups);
+        public Task<Guid> AddAsync(ProductGroup group, System.Threading.CancellationToken ct = default)
+        {
+            group.Id = Guid.NewGuid();
+            Groups.Add(group);
+            return Task.FromResult(group.Id);
+        }
+        public Task UpdateAsync(ProductGroup group, System.Threading.CancellationToken ct = default)
+        {
+            Updated = group;
+            return Task.CompletedTask;
+        }
+    }
+
+    [Fact]
+    public async Task LoadAsync_FillsCollection()
+    {
+        var service = new FakeService();
+        service.Groups.Add(new ProductGroup { Id = Guid.NewGuid(), Name = "G" });
+        var vm = new ProductGroupMasterViewModel(service);
+
+        await vm.LoadAsync();
+
+        Assert.Single(vm.ProductGroups);
+    }
+
+    [Fact]
+    public async Task DeleteSelectedCommand_ArchivesItem()
+    {
+        var service = new FakeService();
+        var group = new ProductGroup { Id = Guid.NewGuid(), Name = "X" };
+        service.Groups.Add(group);
+        var vm = new ProductGroupMasterViewModel(service);
+        await vm.LoadAsync();
+
+        vm.SelectedItem = vm.ProductGroups[0];
+        vm.DeleteSelectedCommand.Execute(null);
+        await Task.Delay(10);
+
+        Assert.True(group.IsArchived);
+        Assert.Equal(group, service.Updated);
+    }
+}

--- a/tests/viewmodels/ProductMasterViewModelTests.cs
+++ b/tests/viewmodels/ProductMasterViewModelTests.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+using Wrecept.Wpf.ViewModels;
+using Wrecept.Core.Models;
+using Wrecept.Core.Services;
+
+namespace Wrecept.Tests.ViewModels;
+
+public class ProductMasterViewModelTests
+{
+    private class FakeProductService : IProductService
+    {
+        public List<Product> Products { get; } = new();
+        public Product? Updated;
+        public Task<List<Product>> GetAllAsync(System.Threading.CancellationToken ct = default)
+            => Task.FromResult(Products);
+        public Task<List<Product>> GetActiveAsync(System.Threading.CancellationToken ct = default)
+            => Task.FromResult(Products);
+        public Task<int> AddAsync(Product product, System.Threading.CancellationToken ct = default)
+        {
+            product.Id = Products.Count + 1;
+            Products.Add(product);
+            return Task.FromResult(product.Id);
+        }
+        public Task UpdateAsync(Product product, System.Threading.CancellationToken ct = default)
+        {
+            Updated = product;
+            return Task.CompletedTask;
+        }
+    }
+
+    private class FakeTaxRateService : ITaxRateService
+    {
+        public List<TaxRate> Rates { get; } = new();
+        public Task<List<TaxRate>> GetAllAsync(System.Threading.CancellationToken ct = default)
+            => Task.FromResult(Rates);
+        public Task<List<TaxRate>> GetActiveAsync(DateTime asOf, System.Threading.CancellationToken ct = default)
+            => Task.FromResult(Rates);
+        public Task<Guid> AddAsync(TaxRate taxRate, System.Threading.CancellationToken ct = default)
+            => Task.FromResult(Guid.NewGuid());
+        public Task UpdateAsync(TaxRate taxRate, System.Threading.CancellationToken ct = default)
+            => Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task LoadAsync_FillsCollections()
+    {
+        var productSvc = new FakeProductService();
+        var taxSvc = new FakeTaxRateService();
+        productSvc.Products.Add(new Product { Id = 1, Name = "Test" });
+        taxSvc.Rates.Add(new TaxRate { Id = Guid.NewGuid(), Percentage = 27 });
+
+        var vm = new ProductMasterViewModel(productSvc, taxSvc);
+
+        await vm.LoadAsync();
+
+        Assert.Single(vm.Products);
+        Assert.Single(vm.TaxRates);
+    }
+
+    [Fact]
+    public async Task DeleteSelectedCommand_ArchivesItem()
+    {
+        var productSvc = new FakeProductService();
+        var taxSvc = new FakeTaxRateService();
+        var product = new Product { Id = 1, Name = "Del" };
+        productSvc.Products.Add(product);
+        var vm = new ProductMasterViewModel(productSvc, taxSvc);
+        await vm.LoadAsync();
+
+        vm.SelectedItem = vm.Products[0];
+        vm.DeleteSelectedCommand.Execute(null);
+        await Task.Delay(10);
+
+        Assert.True(product.IsArchived);
+        Assert.Equal(product, productSvc.Updated);
+    }
+}

--- a/tests/viewmodels/ScreenModeViewModelTests.cs
+++ b/tests/viewmodels/ScreenModeViewModelTests.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Runtime.Serialization;
+using System.Threading.Tasks;
+using System.Windows;
+using Xunit;
+using Wrecept.Wpf.ViewModels;
+using Wrecept.Wpf.Services;
+using Wrecept.Core;
+using Wrecept.Core.Entities;
+using Wrecept.Core.Services;
+
+namespace Wrecept.Tests.ViewModels;
+
+public class ScreenModeViewModelTests
+{
+    private class FakeSettingsService : ISettingsService
+    {
+        public AppSettings Saved = new();
+        public AppSettings LoadValue = new();
+        public Task<AppSettings> LoadAsync() => Task.FromResult(LoadValue);
+        public Task SaveAsync(AppSettings settings)
+        {
+            Saved = settings;
+            return Task.CompletedTask;
+        }
+    }
+
+    private static void EnsureApp()
+    {
+        if (Application.Current == null)
+            new Application();
+    }
+
+    private static MainWindow CreateWindow() =>
+        (MainWindow)FormatterServices.GetUninitializedObject(typeof(MainWindow));
+
+    [StaFact]
+    public async Task ApplyCommand_ChangesModeAndCloses()
+    {
+        EnsureApp();
+        var settings = new FakeSettingsService();
+        var manager = new ScreenModeManager(settings);
+        var vm = new ScreenModeViewModel(manager) { SelectedMode = ScreenMode.Small };
+        var window = new Window();
+        Application.Current.MainWindow = CreateWindow();
+
+        await vm.ApplyCommand.ExecuteAsync(window);
+
+        Assert.Equal(ScreenMode.Small, manager.CurrentMode);
+        Assert.True(window.DialogResult);
+        Assert.Equal(ScreenMode.Small, settings.Saved.ScreenMode);
+    }
+}

--- a/tests/viewmodels/StageViewModelTests.cs
+++ b/tests/viewmodels/StageViewModelTests.cs
@@ -1,0 +1,139 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.Serialization;
+using System.Threading.Tasks;
+using Xunit;
+using Wrecept.Wpf.ViewModels;
+using Wrecept.Wpf.Services;
+using Wrecept.Core.Services;
+using Wrecept.Core.Models;
+using Wrecept.Core.Entities;
+
+namespace Wrecept.Tests.ViewModels;
+
+public class StageViewModelTests
+{
+    private static T CreateUninitialized<T>() => (T)FormatterServices.GetUninitializedObject(typeof(T));
+
+    private class FakeDbHealth : IDbHealthService
+    {
+        public int Calls;
+        public Task<bool> CheckAsync(System.Threading.CancellationToken ct = default)
+        {
+            Calls++;
+            return Task.FromResult(true);
+        }
+    }
+
+    private class FakeSession : ISessionService
+    {
+        public int? Last;
+        public Task<int?> LoadLastInvoiceIdAsync(System.Threading.CancellationToken ct = default)
+            => Task.FromResult(Last);
+        public Task SaveLastInvoiceIdAsync(int? invoiceId, System.Threading.CancellationToken ct = default)
+        {
+            Last = invoiceId;
+            return Task.CompletedTask;
+        }
+    }
+
+    private class FakeUserInfoService : IUserInfoService
+    {
+        public Task<UserInfo> LoadAsync() => Task.FromResult(new UserInfo());
+        public Task SaveAsync(UserInfo info) => Task.CompletedTask;
+    }
+
+    private StageViewModel Create(StageMenuAction last)
+    {
+        var state = new AppStateService(Path.GetTempFileName())
+        {
+            LastView = last,
+            CurrentInvoiceId = null
+        };
+        var invoice = CreateUninitialized<InvoiceEditorViewModel>();
+        var product = new ProductMasterViewModel(new FakeProductService(), new FakeTaxRateService());
+        var group = new ProductGroupMasterViewModel(new FakeProductGroupService());
+        var supplier = new SupplierMasterViewModel(new FakeSupplierService());
+        var tax = new TaxRateMasterViewModel(new FakeTaxRateService());
+        var payment = new PaymentMethodMasterViewModel(new FakePaymentMethodService());
+        var unit = new UnitMasterViewModel(new FakeUnitService());
+        var user = new UserInfoViewModel(new FakeUserInfoService());
+        var about = new AboutViewModel(new FakeUserInfoService());
+        var placeholder = new PlaceholderViewModel();
+        var status = new StatusBarViewModel();
+        var db = new FakeDbHealth();
+        var session = new FakeSession();
+
+        return new StageViewModel(invoice, product, group, supplier, tax, payment, unit, user, about, placeholder, status, db, session, state);
+    }
+
+    private class FakeProductService : IProductService
+    {
+        public List<Product> Products { get; } = new();
+        public Task<List<Product>> GetActiveAsync(System.Threading.CancellationToken ct = default) => Task.FromResult(Products);
+        public Task<List<Product>> GetAllAsync(System.Threading.CancellationToken ct = default) => Task.FromResult(Products);
+        public Task<int> AddAsync(Product product, System.Threading.CancellationToken ct = default) => Task.FromResult(0);
+        public Task UpdateAsync(Product product, System.Threading.CancellationToken ct = default) => Task.CompletedTask;
+    }
+
+    private class FakeProductGroupService : IProductGroupService
+    {
+        public List<ProductGroup> Groups { get; } = new();
+        public Task<List<ProductGroup>> GetActiveAsync(System.Threading.CancellationToken ct = default) => Task.FromResult(Groups);
+        public Task<List<ProductGroup>> GetAllAsync(System.Threading.CancellationToken ct = default) => Task.FromResult(Groups);
+        public Task<Guid> AddAsync(ProductGroup group, System.Threading.CancellationToken ct = default) => Task.FromResult(Guid.NewGuid());
+        public Task UpdateAsync(ProductGroup group, System.Threading.CancellationToken ct = default) => Task.CompletedTask;
+    }
+
+    private class FakeSupplierService : ISupplierService
+    {
+        public List<Supplier> Suppliers { get; } = new();
+        public Task<List<Supplier>> GetActiveAsync(System.Threading.CancellationToken ct = default) => Task.FromResult(Suppliers);
+        public Task<List<Supplier>> GetAllAsync(System.Threading.CancellationToken ct = default) => Task.FromResult(Suppliers);
+        public Task<int> AddAsync(Supplier supplier, System.Threading.CancellationToken ct = default) => Task.FromResult(0);
+        public Task UpdateAsync(Supplier supplier, System.Threading.CancellationToken ct = default) => Task.CompletedTask;
+    }
+
+    private class FakeTaxRateService : ITaxRateService
+    {
+        public List<TaxRate> Rates { get; } = new();
+        public Task<List<TaxRate>> GetAllAsync(System.Threading.CancellationToken ct = default) => Task.FromResult(Rates);
+        public Task<List<TaxRate>> GetActiveAsync(DateTime asOf, System.Threading.CancellationToken ct = default) => Task.FromResult(Rates);
+        public Task<Guid> AddAsync(TaxRate taxRate, System.Threading.CancellationToken ct = default) => Task.FromResult(Guid.NewGuid());
+        public Task UpdateAsync(TaxRate taxRate, System.Threading.CancellationToken ct = default) => Task.CompletedTask;
+    }
+
+    private class FakePaymentMethodService : IPaymentMethodService
+    {
+        public List<PaymentMethod> Methods { get; } = new();
+        public Task<List<PaymentMethod>> GetAllAsync(System.Threading.CancellationToken ct = default) => Task.FromResult(Methods);
+        public Task<List<PaymentMethod>> GetActiveAsync(System.Threading.CancellationToken ct = default) => Task.FromResult(Methods);
+        public Task<Guid> AddAsync(PaymentMethod method, System.Threading.CancellationToken ct = default) => Task.FromResult(Guid.NewGuid());
+        public Task UpdateAsync(PaymentMethod method, System.Threading.CancellationToken ct = default) => Task.CompletedTask;
+    }
+
+    private class FakeUnitService : IUnitService
+    {
+        public List<Unit> Units { get; } = new();
+        public Task<List<Unit>> GetAllAsync(System.Threading.CancellationToken ct = default) => Task.FromResult(Units);
+        public Task<List<Unit>> GetActiveAsync(System.Threading.CancellationToken ct = default) => Task.FromResult(Units);
+        public Task<Guid> AddAsync(Unit unit, System.Threading.CancellationToken ct = default) => Task.FromResult(Guid.NewGuid());
+        public Task UpdateAsync(Unit unit, System.Threading.CancellationToken ct = default) => Task.CompletedTask;
+    }
+
+    [StaFact]
+    public void Constructor_RespectsSavedView()
+    {
+        var vm = Create(StageMenuAction.EditSuppliers);
+        Assert.IsType<SupplierMasterViewModel>(vm.CurrentViewModel);
+    }
+
+    [StaFact]
+    public async Task HandleMenuCommand_SwitchesViewAndState()
+    {
+        var vm = Create(StageMenuAction.EditProducts);
+        await vm.HandleMenuCommand.ExecuteAsync(StageMenuAction.EditUnits);
+        Assert.IsType<UnitMasterViewModel>(vm.CurrentViewModel);
+    }
+}

--- a/tests/viewmodels/SupplierMasterViewModelTests.cs
+++ b/tests/viewmodels/SupplierMasterViewModelTests.cs
@@ -1,0 +1,61 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+using Wrecept.Wpf.ViewModels;
+using Wrecept.Core.Models;
+using Wrecept.Core.Services;
+
+namespace Wrecept.Tests.ViewModels;
+
+public class SupplierMasterViewModelTests
+{
+    private class FakeSupplierService : ISupplierService
+    {
+        public List<Supplier> Suppliers { get; } = new();
+        public Supplier? Updated;
+        public Task<List<Supplier>> GetAllAsync(System.Threading.CancellationToken ct = default)
+            => Task.FromResult(Suppliers);
+        public Task<List<Supplier>> GetActiveAsync(System.Threading.CancellationToken ct = default)
+            => Task.FromResult(Suppliers);
+        public Task<int> AddAsync(Supplier supplier, System.Threading.CancellationToken ct = default)
+        {
+            supplier.Id = Suppliers.Count + 1;
+            Suppliers.Add(supplier);
+            return Task.FromResult(supplier.Id);
+        }
+        public Task UpdateAsync(Supplier supplier, System.Threading.CancellationToken ct = default)
+        {
+            Updated = supplier;
+            return Task.CompletedTask;
+        }
+    }
+
+    [Fact]
+    public async Task LoadAsync_FillsCollection()
+    {
+        var service = new FakeSupplierService();
+        service.Suppliers.Add(new Supplier { Id = 1, Name = "Test" });
+        var vm = new SupplierMasterViewModel(service);
+
+        await vm.LoadAsync();
+
+        Assert.Single(vm.Suppliers);
+    }
+
+    [Fact]
+    public async Task DeleteSelectedCommand_ArchivesItem()
+    {
+        var service = new FakeSupplierService();
+        var supplier = new Supplier { Id = 1, Name = "X" };
+        service.Suppliers.Add(supplier);
+        var vm = new SupplierMasterViewModel(service);
+        await vm.LoadAsync();
+
+        vm.SelectedItem = vm.Suppliers[0];
+        vm.DeleteSelectedCommand.Execute(null);
+        await Task.Delay(10);
+
+        Assert.True(supplier.IsArchived);
+        Assert.Equal(supplier, service.Updated);
+    }
+}

--- a/tests/viewmodels/TaxRateMasterViewModelTests.cs
+++ b/tests/viewmodels/TaxRateMasterViewModelTests.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+using Wrecept.Wpf.ViewModels;
+using Wrecept.Core.Models;
+using Wrecept.Core.Services;
+
+namespace Wrecept.Tests.ViewModels;
+
+public class TaxRateMasterViewModelTests
+{
+    private class FakeService : ITaxRateService
+    {
+        public List<TaxRate> Rates { get; } = new();
+        public TaxRate? Updated;
+        public Task<List<TaxRate>> GetAllAsync(System.Threading.CancellationToken ct = default)
+            => Task.FromResult(Rates);
+        public Task<List<TaxRate>> GetActiveAsync(DateTime asOf, System.Threading.CancellationToken ct = default)
+            => Task.FromResult(Rates);
+        public Task<Guid> AddAsync(TaxRate rate, System.Threading.CancellationToken ct = default)
+        {
+            rate.Id = Guid.NewGuid();
+            Rates.Add(rate);
+            return Task.FromResult(rate.Id);
+        }
+        public Task UpdateAsync(TaxRate rate, System.Threading.CancellationToken ct = default)
+        {
+            Updated = rate;
+            return Task.CompletedTask;
+        }
+    }
+
+    [Fact]
+    public async Task LoadAsync_FillsCollection()
+    {
+        var service = new FakeService();
+        service.Rates.Add(new TaxRate { Id = Guid.NewGuid(), Percentage = 27 });
+        var vm = new TaxRateMasterViewModel(service);
+
+        await vm.LoadAsync();
+
+        Assert.Single(vm.TaxRates);
+    }
+
+    [Fact]
+    public async Task DeleteSelectedCommand_ArchivesItem()
+    {
+        var service = new FakeService();
+        var rate = new TaxRate { Id = Guid.NewGuid(), Percentage = 10 };
+        service.Rates.Add(rate);
+        var vm = new TaxRateMasterViewModel(service);
+        await vm.LoadAsync();
+
+        vm.SelectedItem = vm.TaxRates[0];
+        vm.DeleteSelectedCommand.Execute(null);
+        await Task.Delay(10);
+
+        Assert.True(rate.IsArchived);
+        Assert.Equal(rate, service.Updated);
+    }
+}

--- a/tests/viewmodels/UnitMasterViewModelTests.cs
+++ b/tests/viewmodels/UnitMasterViewModelTests.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+using Wrecept.Wpf.ViewModels;
+using Wrecept.Core.Models;
+using Wrecept.Core.Services;
+
+namespace Wrecept.Tests.ViewModels;
+
+public class UnitMasterViewModelTests
+{
+    private class FakeService : IUnitService
+    {
+        public List<Unit> Units { get; } = new();
+        public Unit? Updated;
+        public Task<List<Unit>> GetAllAsync(System.Threading.CancellationToken ct = default)
+            => Task.FromResult(Units);
+        public Task<List<Unit>> GetActiveAsync(System.Threading.CancellationToken ct = default)
+            => Task.FromResult(Units);
+        public Task<Guid> AddAsync(Unit unit, System.Threading.CancellationToken ct = default)
+        {
+            unit.Id = Guid.NewGuid();
+            Units.Add(unit);
+            return Task.FromResult(unit.Id);
+        }
+        public Task UpdateAsync(Unit unit, System.Threading.CancellationToken ct = default)
+        {
+            Updated = unit;
+            return Task.CompletedTask;
+        }
+    }
+
+    [Fact]
+    public async Task LoadAsync_FillsCollection()
+    {
+        var service = new FakeService();
+        service.Units.Add(new Unit { Id = Guid.NewGuid(), Name = "pc" });
+        var vm = new UnitMasterViewModel(service);
+
+        await vm.LoadAsync();
+
+        Assert.Single(vm.Units);
+    }
+
+    [Fact]
+    public async Task DeleteSelectedCommand_ArchivesItem()
+    {
+        var service = new FakeService();
+        var unit = new Unit { Id = Guid.NewGuid(), Name = "kg" };
+        service.Units.Add(unit);
+        var vm = new UnitMasterViewModel(service);
+        await vm.LoadAsync();
+
+        vm.SelectedItem = vm.Units[0];
+        vm.DeleteSelectedCommand.Execute(null);
+        await Task.Delay(10);
+
+        Assert.True(unit.IsArchived);
+        Assert.Equal(unit, service.Updated);
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests for ProductMaster, SupplierMaster, ProductGroupMaster, PaymentMethodMaster, TaxRateMaster and UnitMaster viewmodels
- cover StageViewModel and ScreenModeViewModel basic behaviour
- log progress

## Testing
- `dotnet test --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_686abcccbb788322bad03a4d558e3187