### PR TITLE
Add tests for utilities

### DIFF
--- a/Wrecept.Core.Tests/Utilities/NumberToWordsConverterTests.cs
+++ b/Wrecept.Core.Tests/Utilities/NumberToWordsConverterTests.cs
@@ -1,0 +1,35 @@
+using Wrecept.Core.Utilities;
+using Xunit;
+
+namespace Wrecept.Core.Tests.Utilities;
+
+public class NumberToWordsConverterTests
+{
+    [Fact]
+    public void Convert_Zero_ReturnsNulla()
+    {
+        var result = NumberToWordsConverter.Convert(0);
+        Assert.Equal("nulla", result);
+    }
+
+    [Fact]
+    public void Convert_Negative_ReturnsMinusPrefix()
+    {
+        var result = NumberToWordsConverter.Convert(-1);
+        Assert.Equal("mínusz egy", result);
+    }
+
+    [Fact]
+    public void Convert_CompoundNumber_ReturnsExpectedString()
+    {
+        var result = NumberToWordsConverter.Convert(123);
+        Assert.Equal("száz húszhárom", result);
+    }
+
+    [Fact]
+    public void Convert_LargeNumber_ReturnsExpectedString()
+    {
+        var result = NumberToWordsConverter.Convert(1100000);
+        Assert.Equal("egy millió száz ezer", result);
+    }
+}

--- a/Wrecept.Core.Tests/Utilities/ProgressReportTests.cs
+++ b/Wrecept.Core.Tests/Utilities/ProgressReportTests.cs
@@ -1,0 +1,17 @@
+using Wrecept.Core.Utilities;
+using Xunit;
+
+namespace Wrecept.Core.Tests.Utilities;
+
+public class ProgressReportTests
+{
+    [Fact]
+    public void DefaultValues_AreZeroAndEmpty()
+    {
+        var report = new ProgressReport();
+
+        Assert.Equal(0, report.GlobalPercent);
+        Assert.Equal(0, report.SubtaskPercent);
+        Assert.Equal(string.Empty, report.Message);
+    }
+}

--- a/docs/progress/2025-07-06_18-53-46_test_agent.md
+++ b/docs/progress/2025-07-06_18-53-46_test_agent.md
@@ -1,0 +1,1 @@
+- Added tests for NumberToWordsConverter and ProgressReport verifying conversion and defaults.


### PR DESCRIPTION
## Summary
- cover `NumberToWordsConverter` with unit tests
- cover `ProgressReport` defaults with unit test
- document progress

## Testing
- `dotnet test Wrecept.Core.Tests/Wrecept.Core.Tests.csproj -v q`

------
https://chatgpt.com/codex/tasks/task_e_686ac5762064832287cf2c9cca958cce