### PR TITLE
Add service and startup test coverage

### DIFF
--- a/docs/progress/2025-07-06_19-01-40_test_agent.md
+++ b/docs/progress/2025-07-06_19-01-40_test_agent.md
@@ -1,0 +1,3 @@
+- Added unit tests for SettingsService, SessionService and LogService covering file handling.
+- Added tests for StartupOrchestrator to verify database empty check and seeding progress.
+- `dotnet test` still fails due to missing WindowsDesktop targets.

--- a/tests/Wrecept.Storage.Tests/SettingsSessionLogServiceTests.cs
+++ b/tests/Wrecept.Storage.Tests/SettingsSessionLogServiceTests.cs
@@ -1,0 +1,106 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Wrecept.Core.Entities;
+using Wrecept.Storage.Services;
+using Xunit;
+
+namespace Wrecept.Storage.Tests;
+
+public class SettingsSessionLogServiceTests
+{
+    [Fact]
+    public async Task SettingsService_LoadsDefaults_WhenFileMissing()
+    {
+        var path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        var svc = new SettingsService(path);
+
+        var settings = await svc.LoadAsync();
+
+        Assert.NotNull(settings);
+        Assert.Equal(string.Empty, settings.DatabasePath);
+        Assert.Equal(string.Empty, settings.UserInfoPath);
+    }
+
+    [Fact]
+    public async Task SettingsService_SaveAndLoad_RoundTrip()
+    {
+        var path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        var svc = new SettingsService(path);
+        var original = new AppSettings
+        {
+            DatabasePath = "db",
+            UserInfoPath = "info",
+            ScreenMode = ScreenMode.Small
+        };
+
+        await svc.SaveAsync(original);
+        var loaded = await svc.LoadAsync();
+
+        Assert.Equal(original.DatabasePath, loaded.DatabasePath);
+        Assert.Equal(original.UserInfoPath, loaded.UserInfoPath);
+        Assert.Equal(original.ScreenMode, loaded.ScreenMode);
+    }
+
+    [Fact]
+    public async Task SessionService_ReturnsNull_WhenFileMissing()
+    {
+        var path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        var svc = new SessionService(path);
+
+        var id = await svc.LoadLastInvoiceIdAsync();
+
+        Assert.Null(id);
+    }
+
+    [Fact]
+    public async Task SessionService_SaveAndLoad_RoundTrip()
+    {
+        var path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        var svc = new SessionService(path);
+
+        await svc.SaveLastInvoiceIdAsync(12);
+        var loaded = await svc.LoadLastInvoiceIdAsync();
+
+        Assert.Equal(12, loaded);
+    }
+
+    [Fact]
+    public async Task SessionService_Delete_WhenNullPassed()
+    {
+        var path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        var svc = new SessionService(path);
+
+        await svc.SaveLastInvoiceIdAsync(5);
+        await svc.SaveLastInvoiceIdAsync(null);
+
+        Assert.False(File.Exists(path));
+    }
+
+    [Fact]
+    public async Task LogService_WritesFile()
+    {
+        var tempHome = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(tempHome);
+        var oldHome = Environment.GetEnvironmentVariable("HOME");
+        Environment.SetEnvironmentVariable("HOME", tempHome);
+
+        try
+        {
+            var svc = new LogService();
+            await svc.LogError("test", new InvalidOperationException());
+
+            var logDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+                "Wrecept", "logs");
+            Assert.True(Directory.Exists(logDir));
+            var files = Directory.GetFiles(logDir);
+            Assert.NotEmpty(files);
+            var content = await File.ReadAllTextAsync(files[0]);
+            Assert.Contains("test", content);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("HOME", oldHome);
+        }
+    }
+}

--- a/tests/Wrecept.Storage.Tests/SettingsSessionLogServiceTests.cs
+++ b/tests/Wrecept.Storage.Tests/SettingsSessionLogServiceTests.cs
@@ -82,8 +82,8 @@ public class SettingsSessionLogServiceTests
     {
         var tempHome = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
         Directory.CreateDirectory(tempHome);
-        var oldHome = Environment.GetEnvironmentVariable("HOME");
-        Environment.SetEnvironmentVariable("HOME", tempHome);
+        var oldAppData = Environment.GetEnvironmentVariable("APPDATA");
+        Environment.SetEnvironmentVariable("APPDATA", tempHome);
 
         try
         {

--- a/tests/Wrecept.Storage.Tests/SettingsSessionLogServiceTests.cs
+++ b/tests/Wrecept.Storage.Tests/SettingsSessionLogServiceTests.cs
@@ -101,6 +101,10 @@ public class SettingsSessionLogServiceTests
         finally
         {
             Environment.SetEnvironmentVariable("HOME", oldHome);
+            if (Directory.Exists(tempHome))
+            {
+                Directory.Delete(tempHome, recursive: true);
+            }
         }
     }
 }

--- a/tests/Wrecept.Tests/StartupOrchestratorTests.cs
+++ b/tests/Wrecept.Tests/StartupOrchestratorTests.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Wrecept.Core.Services;
+using Wrecept.Core.Utilities;
+using Wrecept.Wpf;
+using Xunit;
+
+namespace Wrecept.Tests;
+
+public class StartupOrchestratorTests
+{
+    private class DummyProgress : IProgress<ProgressReport>
+    {
+        public readonly List<ProgressReport> Reports = new();
+        public void Report(ProgressReport value) => Reports.Add(value);
+    }
+
+    [Fact]
+    public async Task DatabaseEmptyAsync_ReturnsTrue_ForNewDatabase()
+    {
+        var path = Path.Combine(Path.GetTempPath(), Guid.NewGuid()+".db");
+        App.DbPath = path;
+        var orchestrator = new StartupOrchestrator(new NullLogService());
+
+        var empty = await orchestrator.DatabaseEmptyAsync(CancellationToken.None);
+
+        Assert.True(empty);
+    }
+
+    [Fact]
+    public async Task SeedAsync_ReturnsSeededAndReports()
+    {
+        var path = Path.Combine(Path.GetTempPath(), Guid.NewGuid()+".db");
+        App.DbPath = path;
+        var orchestrator = new StartupOrchestrator(new NullLogService());
+        var progress = new DummyProgress();
+
+        var status = await orchestrator.SeedAsync(progress, CancellationToken.None,
+            1, 1, 1, 1, 1, false);
+
+        Assert.Equal(SeedStatus.Seeded, status);
+        Assert.Contains(progress.Reports, r => r.GlobalPercent == 100);
+    }
+}


### PR DESCRIPTION
## Summary
- extend test suite: `SettingsService`, `SessionService`, `LogService`
- cover public methods of `StartupOrchestrator`
- record progress for test agent

## Testing
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ac7100e60832284c0cc1d263ce3ac