### PR TITLE
Integrate FSM with navigation service

### DIFF
--- a/Wrecept.Wpf/App.xaml.cs
+++ b/Wrecept.Wpf/App.xaml.cs
@@ -41,6 +41,7 @@ public static IServiceProvider Provider => Services ?? throw new InvalidOperatio
         var serviceCollection = new ServiceCollection();
         await ConfigureServicesAsync(serviceCollection, settings);
         Services = serviceCollection.BuildServiceProvider();
+        NavigationService.State = Services.GetRequiredService<AppStateService>();
         ThemeManager.ApplyDarkTheme(false);
     }
 

--- a/Wrecept.Wpf/Services/NavigationService.cs
+++ b/Wrecept.Wpf/Services/NavigationService.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Threading.Tasks;
 using System.Windows;
 using Microsoft.Win32;
 using Wrecept.Wpf.Dialogs;
@@ -6,15 +8,38 @@ namespace Wrecept.Wpf.Services;
 
 public static class NavigationService
 {
+    public static AppStateService? State { get; set; }
+
+    private static async Task<T> WithStateAsync<T>(Func<T> action)
+    {
+        if (State is { } state)
+        {
+            T result = default!;
+            await state.WithDialogOpen(async () =>
+            {
+                result = action();
+                await Task.CompletedTask;
+            });
+            return result;
+        }
+
+        return action();
+    }
+
     public static bool ShowCenteredDialog(Window dialog)
     {
-        if (Application.Current.MainWindow is { } owner)
-            DialogHelper.CenterToOwner(dialog, owner);
-        return dialog.ShowDialog() == true;
+        return WithStateAsync(() =>
+        {
+            if (Application.Current.MainWindow is { } owner)
+                DialogHelper.CenterToOwner(dialog, owner);
+            return dialog.ShowDialog() == true;
+        }).GetAwaiter().GetResult();
     }
 
     public static bool ShowFileDialog(FileDialog dialog)
     {
-        return dialog.ShowDialog(Application.Current.MainWindow) == true;
+        return WithStateAsync(() =>
+            dialog.ShowDialog(Application.Current.MainWindow) == true)
+            .GetAwaiter().GetResult();
     }
 }

--- a/Wrecept.Wpf/ViewModels/InvoiceEditorViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/InvoiceEditorViewModel.cs
@@ -548,20 +548,17 @@ private void UpdateSupplierId(string name)
     [RelayCommand]
     private async Task SavePdfAsync()
     {
-        await _state.WithDialogOpen(async () =>
+        var dlg = new SaveFileDialog
         {
-            var dlg = new SaveFileDialog
-            {
-                Filter = "PDF (*.pdf)|*.pdf",
-                FileName = $"{Number}.pdf"
-            };
-            if (NavigationService.ShowFileDialog(dlg))
-            {
-                var invoice = await _invoiceService.GetAsync(InvoiceId);
-                if (invoice != null)
-                    await _exporter.SavePdfAsync(invoice, dlg.FileName);
-            }
-        });
+            Filter = "PDF (*.pdf)|*.pdf",
+            FileName = $"{Number}.pdf"
+        };
+        if (NavigationService.ShowFileDialog(dlg))
+        {
+            var invoice = await _invoiceService.GetAsync(InvoiceId);
+            if (invoice != null)
+                await _exporter.SavePdfAsync(invoice, dlg.FileName);
+        }
     }
 
     [RelayCommand]

--- a/Wrecept.Wpf/ViewModels/StageViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/StageViewModel.cs
@@ -214,7 +214,6 @@ private async Task HandleMenu(StageMenuAction action)
                 }
                 break;
             case StageMenuAction.BackupData:
-                await _state.WithDialogOpen(async () =>
                 {
                     var saveDlg = new SaveFileDialog
                     {
@@ -228,10 +227,9 @@ private async Task HandleMenu(StageMenuAction action)
                         await svc.BackupAsync(saveDlg.FileName);
                         _statusBar.Message = Resources.Strings.Stage_BackupSuccess;
                     }
-                });
+                }
                 break;
             case StageMenuAction.RestoreData:
-                await _state.WithDialogOpen(async () =>
                 {
                     var openDlg = new OpenFileDialog
                     {
@@ -244,20 +242,18 @@ private async Task HandleMenu(StageMenuAction action)
                         await svc.RestoreAsync(openDlg.FileName);
                         _statusBar.Message = Resources.Strings.Stage_RestoreSuccess;
                     }
-                });
+                }
                 break;
             case StageMenuAction.ScreenSettings:
-                await _state.WithDialogOpen(async () =>
                 {
                     var win = App.Provider.GetRequiredService<ScreenModeWindow>();
                     win.Owner = App.Current.MainWindow;
                     win.ShowDialog();
                     _statusBar.Message = "Képernyő mód frissítve";
                     await Task.CompletedTask;
-                });
+                }
                 break;
             case StageMenuAction.EditUserInfo:
-                await _state.WithDialogOpen(async () =>
                 {
                     _statusBar.Message = Resources.Strings.Stage_UserInfoEditOpened;
                     await _userInfo.LoadAsync();
@@ -295,15 +291,14 @@ private async Task HandleMenu(StageMenuAction action)
                         _userInfo.TaxNumber = editorVm.TaxNumber;
                         _userInfo.BankAccount = editorVm.BankAccount;
                     }
-                });
+                }
                 break;
             case StageMenuAction.UserInfo:
-                await _state.WithDialogOpen(async () =>
                 {
                     CurrentViewModel = _about;
                     _statusBar.Message = Resources.Strings.Stage_AboutOpened;
                     await _about.LoadAsync();
-                });
+                }
                 break;
             case StageMenuAction.ExitApplication:
                 Application.Current.Shutdown();

--- a/docs/progress/2025-07-06_21-55-24_code_agent.md
+++ b/docs/progress/2025-07-06_21-55-24_code_agent.md
@@ -1,0 +1,4 @@
+- NavigationService now uses AppStateService to set DialogOpen automatically.
+- StageViewModel and InvoiceEditorViewModel simplified; dialogs rely on NavigationService.
+- ui_state_machine.md updated with NavigationService note.
+- StageViewModelTests updated to configure NavigationService.State.

--- a/docs/ui_state_machine.md
+++ b/docs/ui_state_machine.md
@@ -27,3 +27,4 @@ Ez a központi állapotkezelés garantálja, hogy minden ViewModel csak a saját
 ## Modális párbeszédek kezelése
 
 A `WithDialogOpen(Func<Task>)` segédfüggvény biztosítja, hogy minden párbeszédablak megnyitásakor az `InteractionState` értéke átmenetileg `DialogOpen` legyen. A hívó által megadott művelet lefutása után automatikusan visszaáll az előző állapot.
+Ezt a logikát a `NavigationService` is kihasználja, így minden `ShowCenteredDialog` vagy `ShowFileDialog` hívás automatikusan kezeli az állapotváltást.

--- a/tests/viewmodels/StageViewModelTests.cs
+++ b/tests/viewmodels/StageViewModelTests.cs
@@ -134,6 +134,7 @@ public class StageViewModelTests
     public async Task HandleMenuCommand_SwitchesViewAndState()
     {
         var state = new AppStateService(Path.GetTempFileName());
+        NavigationService.State = state;
         var invoice = new InvoiceEditorViewModel();
         var vm = new StageViewModel(
             invoice,
@@ -160,6 +161,7 @@ public class StageViewModelTests
     public async Task HandleMenu_UserInfo_TemporarilyOpensDialog()
     {
         var state = new AppStateService(Path.GetTempFileName());
+        NavigationService.State = state;
         var invoice = new InvoiceEditorViewModel();
         var changes = new List<AppInteractionState>();
         state.InteractionStateChanged += s => changes.Add(s);


### PR DESCRIPTION
## Summary
- connect NavigationService with AppStateService
- simplify StageViewModel and InvoiceEditorViewModel dialog handling
- document automatic dialog state handling
- update StageViewModelTests
- log progress

## Testing
- `dotnet format --no-restore`
- `dotnet test --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_686aef55374083229e29964e252a4774