### PR TITLE
Add Focus and Keyboard manager tests

### DIFF
--- a/docs/progress/2025-07-06_22-14-57_test_agent.md
+++ b/docs/progress/2025-07-06_22-14-57_test_agent.md
@@ -1,0 +1,2 @@
+- Added FocusManagerTests verifying RequestFocus and state-triggered focus.
+- Added KeyboardManagerTests using fake handlers to check Process results.

--- a/tests/Wrecept.Tests/FocusManagerTests.cs
+++ b/tests/Wrecept.Tests/FocusManagerTests.cs
@@ -1,0 +1,54 @@
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Threading;
+using Wrecept.Core.Enums;
+using Wrecept.Wpf.Services;
+using Xunit;
+
+namespace Wrecept.Tests;
+
+public class FocusManagerTests
+{
+    private static void EnsureApp()
+    {
+        if (Application.Current == null)
+            new Application();
+    }
+
+    [StaFact]
+    public void RequestFocus_FocusesElement()
+    {
+        EnsureApp();
+        var state = new AppStateService("x");
+        var manager = new FocusManager(state);
+        var window = new Window();
+        var box = new TextBox();
+        window.Content = box;
+        window.Show();
+
+        manager.RequestFocus(box);
+        box.Dispatcher.Invoke(() => { }, DispatcherPriority.ContextIdle);
+
+        Assert.True(box.IsKeyboardFocused);
+        window.Close();
+    }
+
+    [StaFact]
+    public void InteractionStateChange_TriggersFocus()
+    {
+        EnsureApp();
+        var state = new AppStateService("x");
+        var manager = new FocusManager(state);
+        var window = new Window();
+        var box = new TextBox();
+        window.Content = box;
+        window.Show();
+
+        manager.Register(AppInteractionState.MainMenu, () => box);
+        state.InteractionState = AppInteractionState.MainMenu;
+        box.Dispatcher.Invoke(() => { }, DispatcherPriority.ContextIdle);
+
+        Assert.True(box.IsKeyboardFocused);
+        window.Close();
+    }
+}

--- a/tests/Wrecept.Tests/KeyboardManagerTests.cs
+++ b/tests/Wrecept.Tests/KeyboardManagerTests.cs
@@ -1,0 +1,78 @@
+using System.Windows.Input;
+using System.Windows;
+using Wrecept.Core.Enums;
+using Wrecept.Wpf.Services;
+using Xunit;
+
+namespace Wrecept.Tests;
+
+public class KeyboardManagerTests
+{
+    private class FakeSource : PresentationSource
+    {
+        public override Visual RootVisual { get; set; } = new UIElement();
+        public override bool IsDisposed => false;
+        protected override CompositionTarget GetCompositionTargetCore() => null!;
+    }
+
+    private static KeyEventArgs CreateArgs(Key key)
+        => new KeyEventArgs(Keyboard.PrimaryDevice, new FakeSource(), 0, key)
+        { RoutedEvent = Keyboard.KeyDownEvent };
+
+    private class TrueHandler : IKeyboardHandler
+    {
+        public bool Called;
+        public bool HandleKey(KeyEventArgs e) { Called = true; return true; }
+    }
+
+    private class FalseHandler : IKeyboardHandler
+    {
+        public bool Called;
+        public bool HandleKey(KeyEventArgs e) { Called = true; return false; }
+    }
+
+    [StaFact]
+    public void Process_ReturnsHandlerResult_ForCurrentState()
+    {
+        var state = new AppStateService("x") { InteractionState = AppInteractionState.MainMenu };
+        var manager = new KeyboardManager(state);
+        var handler = new TrueHandler();
+        manager.Register(AppInteractionState.MainMenu, handler);
+
+        var result = manager.Process(CreateArgs(Key.Enter));
+
+        Assert.True(result);
+        Assert.True(handler.Called);
+    }
+
+    [StaFact]
+    public void Process_ReturnsFalse_WhenNoHandler()
+    {
+        var state = new AppStateService("x") { InteractionState = AppInteractionState.None };
+        var manager = new KeyboardManager(state);
+
+        var result = manager.Process(CreateArgs(Key.Enter));
+
+        Assert.False(result);
+    }
+
+    [StaFact]
+    public void Process_SwitchesHandlersWithState()
+    {
+        var state = new AppStateService("x") { InteractionState = AppInteractionState.MainMenu };
+        var manager = new KeyboardManager(state);
+        var trueHandler = new TrueHandler();
+        var falseHandler = new FalseHandler();
+        manager.Register(AppInteractionState.MainMenu, trueHandler);
+        manager.Register(AppInteractionState.EditingInvoice, falseHandler);
+
+        var result1 = manager.Process(CreateArgs(Key.A));
+        state.InteractionState = AppInteractionState.EditingInvoice;
+        var result2 = manager.Process(CreateArgs(Key.B));
+
+        Assert.True(result1);
+        Assert.True(trueHandler.Called);
+        Assert.True(falseHandler.Called);
+        Assert.False(result2);
+    }
+}


### PR DESCRIPTION
## Summary
- test FocusManager to ensure RequestFocus sets focus
- test KeyboardManager return values with fake handlers
- log progress

## Testing
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_686af45b4d308322ba9a249f78b80ec2