### PR TITLE
Add storage repository CRUD tests

### DIFF
--- a/docs/progress/2025-07-06_22-23-19_test_agent.md
+++ b/docs/progress/2025-07-06_22-23-19_test_agent.md
@@ -1,0 +1,2 @@
+- Added CRUD tests for PaymentMethod, ProductGroup, Product, TaxRate and Unit repositories using temporary databases.
+- Fixed SettingsSessionLogServiceTests namespace and variable typo to enable compilation.

--- a/tests/Wrecept.Storage.Tests/PaymentMethodRepositoryTests.cs
+++ b/tests/Wrecept.Storage.Tests/PaymentMethodRepositoryTests.cs
@@ -1,0 +1,77 @@
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Wrecept.Core.Models;
+using Wrecept.Core.Services;
+using Wrecept.Storage.Data;
+using Wrecept.Storage.Repositories;
+using Xunit;
+
+namespace Wrecept.Storage.Tests;
+
+public class PaymentMethodRepositoryTests
+{
+    private class DummyLogService : ILogService
+    {
+        public Task LogError(string message, Exception ex) => Task.CompletedTask;
+    }
+
+    private static async Task<AppDbContext> CreateContextAsync(string db)
+    {
+        var opts = new DbContextOptionsBuilder<AppDbContext>()
+            .UseSqlite($"Data Source={db}")
+            .Options;
+        var ctx = new AppDbContext(opts);
+        await DbInitializer.EnsureCreatedAndMigratedAsync(ctx, new DummyLogService());
+        return ctx;
+    }
+
+    [Fact]
+    public async Task AddAsync_CreatesMethod()
+    {
+        var db = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".db");
+        await using var ctx = await CreateContextAsync(db);
+        var repo = new PaymentMethodRepository(ctx);
+        var method = new PaymentMethod { Name = "Cash" };
+
+        var id = await repo.AddAsync(method);
+
+        Assert.NotEqual(Guid.Empty, id);
+        Assert.Equal("Cash", (await ctx.PaymentMethods.FindAsync(id))!.Name);
+    }
+
+    [Fact]
+    public async Task GetActiveAsync_ExcludesArchived()
+    {
+        var db = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".db");
+        await using var ctx = await CreateContextAsync(db);
+        var repo = new PaymentMethodRepository(ctx);
+        ctx.PaymentMethods.AddRange(
+            new PaymentMethod { Name = "A" },
+            new PaymentMethod { Name = "B", IsArchived = true });
+        await ctx.SaveChangesAsync();
+
+        var list = await repo.GetActiveAsync();
+
+        Assert.Single(list);
+        Assert.Equal("A", list[0].Name);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_PersistsChanges()
+    {
+        var db = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".db");
+        await using var ctx = await CreateContextAsync(db);
+        var repo = new PaymentMethodRepository(ctx);
+        var method = new PaymentMethod { Name = "Card" };
+        ctx.PaymentMethods.Add(method);
+        await ctx.SaveChangesAsync();
+
+        method.Name = "Transfer";
+        await repo.UpdateAsync(method);
+        var stored = await ctx.PaymentMethods.FindAsync(method.Id);
+
+        Assert.Equal("Transfer", stored!.Name);
+    }
+}

--- a/tests/Wrecept.Storage.Tests/ProductGroupRepositoryTests.cs
+++ b/tests/Wrecept.Storage.Tests/ProductGroupRepositoryTests.cs
@@ -1,0 +1,77 @@
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Wrecept.Core.Models;
+using Wrecept.Core.Services;
+using Wrecept.Storage.Data;
+using Wrecept.Storage.Repositories;
+using Xunit;
+
+namespace Wrecept.Storage.Tests;
+
+public class ProductGroupRepositoryTests
+{
+    private class DummyLogService : ILogService
+    {
+        public Task LogError(string message, Exception ex) => Task.CompletedTask;
+    }
+
+    private static async Task<AppDbContext> CreateContextAsync(string db)
+    {
+        var opts = new DbContextOptionsBuilder<AppDbContext>()
+            .UseSqlite($"Data Source={db}")
+            .Options;
+        var ctx = new AppDbContext(opts);
+        await DbInitializer.EnsureCreatedAndMigratedAsync(ctx, new DummyLogService());
+        return ctx;
+    }
+
+    [Fact]
+    public async Task AddAsync_CreatesGroup()
+    {
+        var db = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".db");
+        await using var ctx = await CreateContextAsync(db);
+        var repo = new ProductGroupRepository(ctx);
+        var group = new ProductGroup { Name = "General" };
+
+        var id = await repo.AddAsync(group);
+
+        Assert.NotEqual(Guid.Empty, id);
+        Assert.Equal("General", (await ctx.ProductGroups.FindAsync(id))!.Name);
+    }
+
+    [Fact]
+    public async Task GetActiveAsync_ExcludesArchived()
+    {
+        var db = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".db");
+        await using var ctx = await CreateContextAsync(db);
+        var repo = new ProductGroupRepository(ctx);
+        ctx.ProductGroups.AddRange(
+            new ProductGroup { Name = "A" },
+            new ProductGroup { Name = "B", IsArchived = true });
+        await ctx.SaveChangesAsync();
+
+        var list = await repo.GetActiveAsync();
+
+        Assert.Single(list);
+        Assert.Equal("A", list[0].Name);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_PersistsChanges()
+    {
+        var db = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".db");
+        await using var ctx = await CreateContextAsync(db);
+        var repo = new ProductGroupRepository(ctx);
+        var group = new ProductGroup { Name = "Old" };
+        ctx.ProductGroups.Add(group);
+        await ctx.SaveChangesAsync();
+
+        group.Name = "New";
+        await repo.UpdateAsync(group);
+        var stored = await ctx.ProductGroups.FindAsync(group.Id);
+
+        Assert.Equal("New", stored!.Name);
+    }
+}

--- a/tests/Wrecept.Storage.Tests/ProductRepositoryTests.cs
+++ b/tests/Wrecept.Storage.Tests/ProductRepositoryTests.cs
@@ -1,0 +1,96 @@
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Wrecept.Core.Models;
+using Wrecept.Core.Services;
+using Wrecept.Storage.Data;
+using Wrecept.Storage.Repositories;
+using Xunit;
+
+namespace Wrecept.Storage.Tests;
+
+public class ProductRepositoryTests
+{
+    private class DummyLogService : ILogService
+    {
+        public Task LogError(string message, Exception ex) => Task.CompletedTask;
+    }
+
+    private static async Task<AppDbContext> CreateContextAsync(string db)
+    {
+        var opts = new DbContextOptionsBuilder<AppDbContext>()
+            .UseSqlite($"Data Source={db}")
+            .Options;
+        var ctx = new AppDbContext(opts);
+        await DbInitializer.EnsureCreatedAndMigratedAsync(ctx, new DummyLogService());
+        return ctx;
+    }
+
+    [Fact]
+    public async Task AddAsync_CreatesProduct()
+    {
+        var db = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".db");
+        await using var ctx = await CreateContextAsync(db);
+        var repo = new ProductRepository(ctx);
+        var tax = new TaxRate { Id = Guid.NewGuid(), Code = "T1", Name = "Tax", Percentage = 10m, EffectiveFrom = DateTime.UtcNow };
+        var unit = new Unit { Id = Guid.NewGuid(), Code = "DB", Name = "db" };
+        var group = new ProductGroup { Id = Guid.NewGuid(), Name = "Group" };
+        ctx.TaxRates.Add(tax);
+        ctx.Units.Add(unit);
+        ctx.ProductGroups.Add(group);
+        await ctx.SaveChangesAsync();
+        var product = new Product { Name = "Item", Net = 100m, Gross = 110m, TaxRateId = tax.Id, UnitId = unit.Id, ProductGroupId = group.Id };
+
+        var id = await repo.AddAsync(product);
+
+        Assert.True(id > 0);
+        Assert.Equal("Item", (await ctx.Products.FindAsync(id))!.Name);
+    }
+
+    [Fact]
+    public async Task GetActiveAsync_ExcludesArchived()
+    {
+        var db = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".db");
+        await using var ctx = await CreateContextAsync(db);
+        var repo = new ProductRepository(ctx);
+        var tax = new TaxRate { Id = Guid.NewGuid(), Code = "T", Name = "T", Percentage = 5m, EffectiveFrom = DateTime.UtcNow };
+        var unit = new Unit { Id = Guid.NewGuid(), Code = "U", Name = "u" };
+        var group = new ProductGroup { Id = Guid.NewGuid(), Name = "g" };
+        ctx.TaxRates.Add(tax);
+        ctx.Units.Add(unit);
+        ctx.ProductGroups.Add(group);
+        ctx.Products.AddRange(
+            new Product { Name = "A", TaxRateId = tax.Id, UnitId = unit.Id, ProductGroupId = group.Id },
+            new Product { Name = "B", IsArchived = true, TaxRateId = tax.Id, UnitId = unit.Id, ProductGroupId = group.Id });
+        await ctx.SaveChangesAsync();
+
+        var list = await repo.GetActiveAsync();
+
+        Assert.Single(list);
+        Assert.Equal("A", list[0].Name);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_PersistsChanges()
+    {
+        var db = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".db");
+        await using var ctx = await CreateContextAsync(db);
+        var repo = new ProductRepository(ctx);
+        var tax = new TaxRate { Id = Guid.NewGuid(), Code = "T2", Name = "T", Percentage = 5m, EffectiveFrom = DateTime.UtcNow };
+        var unit = new Unit { Id = Guid.NewGuid(), Code = "U2", Name = "u" };
+        var group = new ProductGroup { Id = Guid.NewGuid(), Name = "g" };
+        ctx.TaxRates.Add(tax);
+        ctx.Units.Add(unit);
+        ctx.ProductGroups.Add(group);
+        var product = new Product { Name = "Old", Net = 1m, Gross = 1.1m, TaxRateId = tax.Id, UnitId = unit.Id, ProductGroupId = group.Id };
+        ctx.Products.Add(product);
+        await ctx.SaveChangesAsync();
+
+        product.Name = "New";
+        await repo.UpdateAsync(product);
+        var stored = await ctx.Products.FindAsync(product.Id);
+
+        Assert.Equal("New", stored!.Name);
+    }
+}

--- a/tests/Wrecept.Storage.Tests/SettingsSessionLogServiceTests.cs
+++ b/tests/Wrecept.Storage.Tests/SettingsSessionLogServiceTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Threading.Tasks;
 using Wrecept.Core.Entities;
+using Wrecept.Core;
 using Wrecept.Storage.Services;
 using Xunit;
 
@@ -100,7 +101,7 @@ public class SettingsSessionLogServiceTests
         }
         finally
         {
-            Environment.SetEnvironmentVariable("HOME", oldHome);
+            Environment.SetEnvironmentVariable("APPDATA", oldAppData);
             if (Directory.Exists(tempHome))
             {
                 Directory.Delete(tempHome, recursive: true);

--- a/tests/Wrecept.Storage.Tests/TaxRateRepositoryTests.cs
+++ b/tests/Wrecept.Storage.Tests/TaxRateRepositoryTests.cs
@@ -1,0 +1,78 @@
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Wrecept.Core.Models;
+using Wrecept.Core.Services;
+using Wrecept.Storage.Data;
+using Wrecept.Storage.Repositories;
+using Xunit;
+
+namespace Wrecept.Storage.Tests;
+
+public class TaxRateRepositoryTests
+{
+    private class DummyLogService : ILogService
+    {
+        public Task LogError(string message, Exception ex) => Task.CompletedTask;
+    }
+
+    private static async Task<AppDbContext> CreateContextAsync(string db)
+    {
+        var opts = new DbContextOptionsBuilder<AppDbContext>()
+            .UseSqlite($"Data Source={db}")
+            .Options;
+        var ctx = new AppDbContext(opts);
+        await DbInitializer.EnsureCreatedAndMigratedAsync(ctx, new DummyLogService());
+        return ctx;
+    }
+
+    [Fact]
+    public async Task AddAsync_CreatesTaxRate()
+    {
+        var db = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".db");
+        await using var ctx = await CreateContextAsync(db);
+        var repo = new TaxRateRepository(ctx);
+        var tax = new TaxRate { Code = "A27", Name = "A", Percentage = 27m, EffectiveFrom = DateTime.UtcNow };
+
+        var id = await repo.AddAsync(tax);
+
+        Assert.NotEqual(Guid.Empty, id);
+        Assert.Equal("A", (await ctx.TaxRates.FindAsync(id))!.Name);
+    }
+
+    [Fact]
+    public async Task GetActiveAsync_RespectsDate()
+    {
+        var db = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".db");
+        await using var ctx = await CreateContextAsync(db);
+        var repo = new TaxRateRepository(ctx);
+        var now = DateTime.UtcNow;
+        ctx.TaxRates.AddRange(
+            new TaxRate { Code = "O", Name = "Old", Percentage = 5m, EffectiveFrom = now.AddMonths(-2), EffectiveTo = now.AddMonths(-1) },
+            new TaxRate { Code = "C", Name = "Current", Percentage = 27m, EffectiveFrom = now.AddMonths(-1) });
+        await ctx.SaveChangesAsync();
+
+        var list = await repo.GetActiveAsync(now);
+
+        Assert.Single(list);
+        Assert.Equal("Current", list[0].Name);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_PersistsChanges()
+    {
+        var db = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".db");
+        await using var ctx = await CreateContextAsync(db);
+        var repo = new TaxRateRepository(ctx);
+        var tax = new TaxRate { Code = "A0", Name = "Old", Percentage = 5m, EffectiveFrom = DateTime.UtcNow };
+        ctx.TaxRates.Add(tax);
+        await ctx.SaveChangesAsync();
+
+        tax.Name = "New";
+        await repo.UpdateAsync(tax);
+        var stored = await ctx.TaxRates.FindAsync(tax.Id);
+
+        Assert.Equal("New", stored!.Name);
+    }
+}

--- a/tests/Wrecept.Storage.Tests/UnitRepositoryTests.cs
+++ b/tests/Wrecept.Storage.Tests/UnitRepositoryTests.cs
@@ -1,0 +1,77 @@
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Wrecept.Core.Models;
+using Wrecept.Core.Services;
+using Wrecept.Storage.Data;
+using Wrecept.Storage.Repositories;
+using Xunit;
+
+namespace Wrecept.Storage.Tests;
+
+public class UnitRepositoryTests
+{
+    private class DummyLogService : ILogService
+    {
+        public Task LogError(string message, Exception ex) => Task.CompletedTask;
+    }
+
+    private static async Task<AppDbContext> CreateContextAsync(string db)
+    {
+        var opts = new DbContextOptionsBuilder<AppDbContext>()
+            .UseSqlite($"Data Source={db}")
+            .Options;
+        var ctx = new AppDbContext(opts);
+        await DbInitializer.EnsureCreatedAndMigratedAsync(ctx, new DummyLogService());
+        return ctx;
+    }
+
+    [Fact]
+    public async Task AddAsync_CreatesUnit()
+    {
+        var db = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".db");
+        await using var ctx = await CreateContextAsync(db);
+        var repo = new UnitRepository(ctx);
+        var unit = new Unit { Code = "KG", Name = "kg" };
+
+        var id = await repo.AddAsync(unit);
+
+        Assert.NotEqual(Guid.Empty, id);
+        Assert.Equal("kg", (await ctx.Units.FindAsync(id))!.Name);
+    }
+
+    [Fact]
+    public async Task GetActiveAsync_ExcludesArchived()
+    {
+        var db = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".db");
+        await using var ctx = await CreateContextAsync(db);
+        var repo = new UnitRepository(ctx);
+        ctx.Units.AddRange(
+            new Unit { Code = "DB", Name = "db" },
+            new Unit { Code = "KG", Name = "kg", IsArchived = true });
+        await ctx.SaveChangesAsync();
+
+        var list = await repo.GetActiveAsync();
+
+        Assert.Single(list);
+        Assert.Equal("db", list[0].Name);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_PersistsChanges()
+    {
+        var db = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".db");
+        await using var ctx = await CreateContextAsync(db);
+        var repo = new UnitRepository(ctx);
+        var unit = new Unit { Code = "PC", Name = "pcs" };
+        ctx.Units.Add(unit);
+        await ctx.SaveChangesAsync();
+
+        unit.Name = "piece";
+        await repo.UpdateAsync(unit);
+        var stored = await ctx.Units.FindAsync(unit.Id);
+
+        Assert.Equal("piece", stored!.Name);
+    }
+}


### PR DESCRIPTION
## Summary
- cover PaymentMethodRepository, ProductGroupRepository, ProductRepository, TaxRateRepository and UnitRepository
- fix SettingsSessionLogServiceTests compile issue
- log progress

## Testing
- `dotnet test tests/Wrecept.Storage.Tests/Wrecept.Storage.Tests.csproj --no-build --verbosity normal`
- `dotnet test --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_686af5c4b1cc83228c548a0993f42138