### PR TITLE
Add ViewModel tests

### DIFF
--- a/docs/progress/2025-07-06_22-30-18_code_agent.md
+++ b/docs/progress/2025-07-06_22-30-18_code_agent.md
@@ -1,0 +1,3 @@
+- Added unit tests for SetupViewModel, ProgressViewModel and all *CreatorViewModel classes.
+- Each test verifies default property values and command availability.
+- dotnet test executed but failed due to missing WindowsDesktop SDK.

--- a/tests/viewmodels/PaymentMethodCreatorViewModelTests.cs
+++ b/tests/viewmodels/PaymentMethodCreatorViewModelTests.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Runtime.Serialization;
+using System.Threading.Tasks;
+using Xunit;
+using Wrecept.Wpf.ViewModels;
+using Wrecept.Core.Models;
+using Wrecept.Core.Services;
+
+namespace Wrecept.Tests.ViewModels;
+
+public class PaymentMethodCreatorViewModelTests
+{
+    private static T CreateUninitialized<T>() => (T)FormatterServices.GetUninitializedObject(typeof(T));
+
+    private class FakeService : IPaymentMethodService
+    {
+        public Task<List<PaymentMethod>> GetAllAsync(System.Threading.CancellationToken ct = default) => Task.FromResult(new List<PaymentMethod>());
+        public Task<List<PaymentMethod>> GetActiveAsync(System.Threading.CancellationToken ct = default) => Task.FromResult(new List<PaymentMethod>());
+        public Task<Guid> AddAsync(PaymentMethod method, System.Threading.CancellationToken ct = default)
+        {
+            method.Id = Guid.NewGuid();
+            return Task.FromResult(method.Id);
+        }
+        public Task UpdateAsync(PaymentMethod method, System.Threading.CancellationToken ct = default) => Task.CompletedTask;
+    }
+
+    [Fact]
+    public void Defaults_AreEmptyAndCommandsAvailable()
+    {
+        var parent = CreateUninitialized<InvoiceEditorViewModel>();
+        var vm = new PaymentMethodCreatorViewModel(parent, new FakeService());
+
+        Assert.Equal(string.Empty, vm.Name);
+        Assert.Equal(0, vm.DueInDays);
+        Assert.True(vm.ConfirmAsyncCommand.CanExecute(null));
+        Assert.True(vm.CancelCommand.CanExecute(null));
+    }
+}

--- a/tests/viewmodels/ProductCreatorViewModelTests.cs
+++ b/tests/viewmodels/ProductCreatorViewModelTests.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+using System.Threading.Tasks;
+using Xunit;
+using Wrecept.Wpf.ViewModels;
+using Wrecept.Core.Models;
+using Wrecept.Core.Services;
+
+namespace Wrecept.Tests.ViewModels;
+
+public class ProductCreatorViewModelTests
+{
+    private static T CreateUninitialized<T>() => (T)FormatterServices.GetUninitializedObject(typeof(T));
+
+    private class FakeService : IProductService
+    {
+        public Task<List<Product>> GetAllAsync(System.Threading.CancellationToken ct = default) => Task.FromResult(new List<Product>());
+        public Task<List<Product>> GetActiveAsync(System.Threading.CancellationToken ct = default) => Task.FromResult(new List<Product>());
+        public Task<int> AddAsync(Product product, System.Threading.CancellationToken ct = default)
+        {
+            product.Id = 1;
+            return Task.FromResult(product.Id);
+        }
+        public Task UpdateAsync(Product product, System.Threading.CancellationToken ct = default) => Task.CompletedTask;
+    }
+
+    [Fact]
+    public void Defaults_AreEmptyAndCommandsAvailable()
+    {
+        var parent = CreateUninitialized<InvoiceEditorViewModel>();
+        var row = new InvoiceItemRowViewModel(parent);
+        var vm = new ProductCreatorViewModel(parent, row, new FakeService());
+
+        Assert.True(vm.IsInlineOpen);
+        Assert.Equal(string.Empty, vm.Name);
+        Assert.Equal(0, vm.Net);
+        Assert.Equal(0, vm.Gross);
+        Assert.True(vm.ConfirmAsyncCommand.CanExecute(null));
+        Assert.True(vm.CancelCommand.CanExecute(null));
+    }
+}

--- a/tests/viewmodels/ProgressViewModelTests.cs
+++ b/tests/viewmodels/ProgressViewModelTests.cs
@@ -1,0 +1,18 @@
+using Xunit;
+using Wrecept.Wpf.ViewModels;
+
+namespace Wrecept.Tests.ViewModels;
+
+public class ProgressViewModelTests
+{
+    [Fact]
+    public void DefaultValues_AreZero()
+    {
+        var vm = new ProgressViewModel();
+
+        Assert.Equal(0, vm.GlobalProgress);
+        Assert.Equal(0, vm.SubProgress);
+        Assert.Equal(string.Empty, vm.StatusMessage);
+        Assert.Null(vm.CancelCommand);
+    }
+}

--- a/tests/viewmodels/SetupViewModelTests.cs
+++ b/tests/viewmodels/SetupViewModelTests.cs
@@ -1,0 +1,21 @@
+using System.Windows;
+using Xunit;
+using Wrecept.Wpf.ViewModels;
+
+namespace Wrecept.Tests.ViewModels;
+
+public class SetupViewModelTests
+{
+    [Fact]
+    public void Constructor_SetsPropertiesAndCommands()
+    {
+        var vm = new SetupViewModel("db.db", "cfg.json");
+
+        Assert.Equal("db.db", vm.DatabasePath);
+        Assert.Equal("cfg.json", vm.ConfigPath);
+        Assert.True(vm.OkCommand.CanExecute(null));
+        Assert.True(vm.CancelCommand.CanExecute(null));
+        Assert.NotNull(vm.BrowseDbCommand);
+        Assert.NotNull(vm.BrowseConfigCommand);
+    }
+}

--- a/tests/viewmodels/SupplierCreatorViewModelTests.cs
+++ b/tests/viewmodels/SupplierCreatorViewModelTests.cs
@@ -1,0 +1,37 @@
+using System.Runtime.Serialization;
+using System.Threading.Tasks;
+using Xunit;
+using Wrecept.Wpf.ViewModels;
+using Wrecept.Core.Models;
+using Wrecept.Core.Services;
+
+namespace Wrecept.Tests.ViewModels;
+
+public class SupplierCreatorViewModelTests
+{
+    private static T CreateUninitialized<T>() => (T)FormatterServices.GetUninitializedObject(typeof(T));
+
+    private class FakeService : ISupplierService
+    {
+        public Task<List<Supplier>> GetAllAsync(System.Threading.CancellationToken ct = default) => Task.FromResult(new List<Supplier>());
+        public Task<List<Supplier>> GetActiveAsync(System.Threading.CancellationToken ct = default) => Task.FromResult(new List<Supplier>());
+        public Task<int> AddAsync(Supplier supplier, System.Threading.CancellationToken ct = default)
+        {
+            supplier.Id = 1;
+            return Task.FromResult(supplier.Id);
+        }
+        public Task UpdateAsync(Supplier supplier, System.Threading.CancellationToken ct = default) => Task.CompletedTask;
+    }
+
+    [Fact]
+    public void Defaults_AreEmptyAndCommandsAvailable()
+    {
+        var parent = CreateUninitialized<InvoiceEditorViewModel>();
+        var vm = new SupplierCreatorViewModel(parent, new FakeService());
+
+        Assert.Equal(string.Empty, vm.Name);
+        Assert.Equal(string.Empty, vm.TaxId);
+        Assert.True(vm.ConfirmAsyncCommand.CanExecute(null));
+        Assert.True(vm.CancelCommand.CanExecute(null));
+    }
+}

--- a/tests/viewmodels/TaxRateCreatorViewModelTests.cs
+++ b/tests/viewmodels/TaxRateCreatorViewModelTests.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Runtime.Serialization;
+using System.Threading.Tasks;
+using Xunit;
+using Wrecept.Wpf.ViewModels;
+using Wrecept.Core.Models;
+using Wrecept.Core.Services;
+
+namespace Wrecept.Tests.ViewModels;
+
+public class TaxRateCreatorViewModelTests
+{
+    private static T CreateUninitialized<T>() => (T)FormatterServices.GetUninitializedObject(typeof(T));
+
+    private class FakeService : ITaxRateService
+    {
+        public Task<List<TaxRate>> GetAllAsync(System.Threading.CancellationToken ct = default) => Task.FromResult(new List<TaxRate>());
+        public Task<List<TaxRate>> GetActiveAsync(DateTime asOf, System.Threading.CancellationToken ct = default) => Task.FromResult(new List<TaxRate>());
+        public Task<Guid> AddAsync(TaxRate taxRate, System.Threading.CancellationToken ct = default)
+        {
+            taxRate.Id = Guid.NewGuid();
+            return Task.FromResult(taxRate.Id);
+        }
+        public Task UpdateAsync(TaxRate taxRate, System.Threading.CancellationToken ct = default) => Task.CompletedTask;
+    }
+
+    [Fact]
+    public void Defaults_AreEmptyAndCommandsAvailable()
+    {
+        var parent = CreateUninitialized<InvoiceEditorViewModel>();
+        var vm = new TaxRateCreatorViewModel(parent, new FakeService());
+
+        Assert.Equal(string.Empty, vm.Name);
+        Assert.Equal(string.Empty, vm.Code);
+        Assert.Equal(0, vm.Percentage);
+        Assert.True(vm.ConfirmAsyncCommand.CanExecute(null));
+        Assert.True(vm.CancelCommand.CanExecute(null));
+    }
+}

--- a/tests/viewmodels/UnitCreatorViewModelTests.cs
+++ b/tests/viewmodels/UnitCreatorViewModelTests.cs
@@ -1,0 +1,37 @@
+using System.Runtime.Serialization;
+using System.Threading.Tasks;
+using Xunit;
+using Wrecept.Wpf.ViewModels;
+using Wrecept.Core.Models;
+using Wrecept.Core.Services;
+
+namespace Wrecept.Tests.ViewModels;
+
+public class UnitCreatorViewModelTests
+{
+    private static T CreateUninitialized<T>() => (T)FormatterServices.GetUninitializedObject(typeof(T));
+
+    private class FakeUnitService : IUnitService
+    {
+        public Task<List<Unit>> GetAllAsync(System.Threading.CancellationToken ct = default) => Task.FromResult(new List<Unit>());
+        public Task<List<Unit>> GetActiveAsync(System.Threading.CancellationToken ct = default) => Task.FromResult(new List<Unit>());
+        public Task<Guid> AddAsync(Unit unit, System.Threading.CancellationToken ct = default)
+        {
+            unit.Id = Guid.NewGuid();
+            return Task.FromResult(unit.Id);
+        }
+        public Task UpdateAsync(Unit unit, System.Threading.CancellationToken ct = default) => Task.CompletedTask;
+    }
+
+    [Fact]
+    public void Defaults_AreEmptyAndCommandsAvailable()
+    {
+        var parent = CreateUninitialized<InvoiceEditorViewModel>();
+        var vm = new UnitCreatorViewModel(parent, new FakeUnitService());
+
+        Assert.Equal(string.Empty, vm.Name);
+        Assert.Equal(string.Empty, vm.Code);
+        Assert.True(vm.ConfirmAsyncCommand.CanExecute(null));
+        Assert.True(vm.CancelCommand.CanExecute(null));
+    }
+}


### PR DESCRIPTION
## Summary
- test SetupViewModel basic commands
- test ProgressViewModel defaults
- test Unit/Product/Supplier/TaxRate/PaymentMethod creator viewmodels
- log progress

## Testing
- `dotnet test --no-build` *(fails: missing WindowsDesktop SDK)*

------
https://chatgpt.com/codex/tasks/task_e_686af7c3678c8322a5cfb2a5bb24268a