### PR TITLE
Add converter unit tests

### DIFF
--- a/docs/progress/2025-07-06_22-36-45_test_agent.md
+++ b/docs/progress/2025-07-06_22-36-45_test_agent.md
@@ -1,0 +1,1 @@
+- Added unit tests for all WPF converters checking Convert and ConvertBack with normal and edge inputs.

--- a/tests/Wrecept.Tests/BooleanToRowDetailsConverterTests.cs
+++ b/tests/Wrecept.Tests/BooleanToRowDetailsConverterTests.cs
@@ -1,0 +1,42 @@
+using System.Globalization;
+using System.Windows.Controls;
+using Wrecept.Wpf.Converters;
+using Xunit;
+
+namespace Wrecept.Tests;
+
+public class BooleanToRowDetailsConverterTests
+{
+    [Fact]
+    public void Convert_ReturnsVisible_ForTrue()
+    {
+        var c = new BooleanToRowDetailsConverter();
+        var result = c.Convert(true, typeof(DataGridRowDetailsVisibilityMode), null, CultureInfo.InvariantCulture);
+        Assert.Equal(DataGridRowDetailsVisibilityMode.Visible, result);
+    }
+
+    [Fact]
+    public void Convert_ReturnsCollapsed_ForFalseOrInvalid()
+    {
+        var c = new BooleanToRowDetailsConverter();
+        Assert.Equal(DataGridRowDetailsVisibilityMode.Collapsed, c.Convert(false, typeof(object), null, CultureInfo.InvariantCulture));
+        Assert.Equal(DataGridRowDetailsVisibilityMode.Collapsed, c.Convert(null!, typeof(object), null, CultureInfo.InvariantCulture));
+        Assert.Equal(DataGridRowDetailsVisibilityMode.Collapsed, c.Convert("x", typeof(object), null, CultureInfo.InvariantCulture));
+    }
+
+    [Fact]
+    public void ConvertBack_ReturnsTrue_WhenVisible()
+    {
+        var c = new BooleanToRowDetailsConverter();
+        Assert.True((bool)c.ConvertBack(DataGridRowDetailsVisibilityMode.Visible, typeof(bool), null, CultureInfo.InvariantCulture));
+        Assert.True((bool)c.ConvertBack(DataGridRowDetailsVisibilityMode.VisibleWhenSelected, typeof(bool), null, CultureInfo.InvariantCulture));
+    }
+
+    [Fact]
+    public void ConvertBack_ReturnsFalse_ForCollapsedOrInvalid()
+    {
+        var c = new BooleanToRowDetailsConverter();
+        Assert.False((bool)c.ConvertBack(DataGridRowDetailsVisibilityMode.Collapsed, typeof(bool), null, CultureInfo.InvariantCulture));
+        Assert.False((bool)c.ConvertBack(5, typeof(bool), null, CultureInfo.InvariantCulture));
+    }
+}

--- a/tests/Wrecept.Tests/InvoiceLineTotalsConverterTests.cs
+++ b/tests/Wrecept.Tests/InvoiceLineTotalsConverterTests.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Windows.Data;
+using Wrecept.Core.Models;
+using Wrecept.Wpf.Converters;
+using Xunit;
+
+namespace Wrecept.Tests;
+
+public class InvoiceLineTotalsConverterTests
+{
+    private readonly Guid _taxId = Guid.NewGuid();
+    private readonly List<TaxRate> _taxes;
+
+    public InvoiceLineTotalsConverterTests()
+    {
+        _taxes = new List<TaxRate>
+        {
+            new() { Id = _taxId, Percentage = 27m }
+        };
+    }
+
+    [Fact]
+    public void Convert_ReturnsExpectedTotals()
+    {
+        var conv = new InvoiceLineTotalsConverter { Mode = InvoiceLineTotalsConverterMode.Net };
+        object[] values = { 2m, 10m, _taxId, false, _taxes };
+
+        var net = conv.Convert(values, typeof(decimal), null, CultureInfo.InvariantCulture);
+        Assert.Equal(20m, net);
+
+        conv.Mode = InvoiceLineTotalsConverterMode.Vat;
+        var vat = conv.Convert(values, typeof(decimal), null, CultureInfo.InvariantCulture);
+        Assert.Equal(5.4m, vat);
+
+        conv.Mode = InvoiceLineTotalsConverterMode.Gross;
+        var gross = conv.Convert(values, typeof(decimal), null, CultureInfo.InvariantCulture);
+        Assert.Equal(25.4m, gross);
+    }
+
+    [Fact]
+    public void Convert_NegativeQuantity_ReturnsNegativeTotals()
+    {
+        var conv = new InvoiceLineTotalsConverter { Mode = InvoiceLineTotalsConverterMode.Net };
+        object[] values = { -3m, 10m, _taxId, false, _taxes };
+        var result = conv.Convert(values, typeof(decimal), null, CultureInfo.InvariantCulture);
+        Assert.Equal(-30m, result);
+    }
+
+    [Fact]
+    public void Convert_ReturnsDoNothing_OnInvalidInput()
+    {
+        var conv = new InvoiceLineTotalsConverter();
+        var culture = CultureInfo.InvariantCulture;
+
+        var resultShort = conv.Convert(new object[] { 1m, 2m }, typeof(decimal), null, culture);
+        Assert.Equal(Binding.DoNothing, resultShort);
+
+        var resultType = conv.Convert(new object[] { 1m, "2", _taxId, false, _taxes }, typeof(decimal), null, culture);
+        Assert.Equal(Binding.DoNothing, resultType);
+    }
+
+    [Fact]
+    public void ConvertBack_ReturnsEmptyArray()
+    {
+        var conv = new InvoiceLineTotalsConverter();
+        var back = conv.ConvertBack(10m, Type.EmptyTypes, null, CultureInfo.InvariantCulture);
+        Assert.Empty(back);
+    }
+}

--- a/tests/Wrecept.Tests/IsReadOnlyBindingConverterTests.cs
+++ b/tests/Wrecept.Tests/IsReadOnlyBindingConverterTests.cs
@@ -1,0 +1,38 @@
+using System.Globalization;
+using System.Windows.Data;
+using Wrecept.Wpf.Converters;
+using Xunit;
+
+namespace Wrecept.Tests;
+
+public class IsReadOnlyBindingConverterTests
+{
+    [Fact]
+    public void Convert_ReturnsValue()
+    {
+        var c = new IsReadOnlyBindingConverter();
+        Assert.True((bool)c.Convert(true, typeof(bool), null, CultureInfo.InvariantCulture));
+        Assert.False((bool)c.Convert(false, typeof(bool), null, CultureInfo.InvariantCulture));
+    }
+
+    [Fact]
+    public void Convert_Inverts_WhenSet()
+    {
+        var c = new IsReadOnlyBindingConverter { Invert = true };
+        Assert.False((bool)c.Convert(true, typeof(bool), null, CultureInfo.InvariantCulture));
+    }
+
+    [Fact]
+    public void Convert_ReturnsFalse_ForNonBool()
+    {
+        var c = new IsReadOnlyBindingConverter();
+        Assert.False((bool)c.Convert("x", typeof(bool), null, CultureInfo.InvariantCulture));
+    }
+
+    [Fact]
+    public void ConvertBack_ReturnsDoNothing()
+    {
+        var c = new IsReadOnlyBindingConverter();
+        Assert.Equal(Binding.DoNothing, c.ConvertBack(true, typeof(bool), null, CultureInfo.InvariantCulture));
+    }
+}

--- a/tests/Wrecept.Tests/NegativeValueForegroundConverterTests.cs
+++ b/tests/Wrecept.Tests/NegativeValueForegroundConverterTests.cs
@@ -1,0 +1,35 @@
+using System.Globalization;
+using System.Windows.Data;
+using System.Windows.Media;
+using Wrecept.Wpf.Converters;
+using Xunit;
+
+namespace Wrecept.Tests;
+
+public class NegativeValueForegroundConverterTests
+{
+    [Fact]
+    public void Convert_ReturnsNegativeBrush_ForNegative()
+    {
+        var blue = new SolidColorBrush(Colors.Blue);
+        var c = new NegativeValueForegroundConverter { NegativeBrush = blue };
+        var result = c.Convert(-1m, typeof(Brush), null, CultureInfo.InvariantCulture);
+        Assert.Same(blue, result);
+    }
+
+    [Fact]
+    public void Convert_ReturnsPositiveBrush_ForNonNegativeOrInvalid()
+    {
+        var green = new SolidColorBrush(Colors.Green);
+        var c = new NegativeValueForegroundConverter { PositiveBrush = green };
+        Assert.Same(green, c.Convert(0m, typeof(Brush), null, CultureInfo.InvariantCulture));
+        Assert.Same(green, c.Convert("x", typeof(Brush), null, CultureInfo.InvariantCulture));
+    }
+
+    [Fact]
+    public void ConvertBack_ReturnsDoNothing()
+    {
+        var c = new NegativeValueForegroundConverter();
+        Assert.Equal(Binding.DoNothing, c.ConvertBack(Brushes.Red, typeof(decimal), null, CultureInfo.InvariantCulture));
+    }
+}

--- a/tests/Wrecept.Tests/QuantityToStyleConverterTests.cs
+++ b/tests/Wrecept.Tests/QuantityToStyleConverterTests.cs
@@ -1,0 +1,35 @@
+using System.Globalization;
+using System.Windows.Data;
+using System.Windows.Media;
+using Wrecept.Wpf.Converters;
+using Xunit;
+
+namespace Wrecept.Tests;
+
+public class QuantityToStyleConverterTests
+{
+    [Fact]
+    public void Convert_ReturnsNegativeBrush_ForNegative()
+    {
+        var red = new SolidColorBrush(Colors.Red);
+        var c = new QuantityToStyleConverter { NegativeBrush = red };
+        var result = c.Convert(-5m, typeof(Brush), null, CultureInfo.InvariantCulture);
+        Assert.Same(red, result);
+    }
+
+    [Fact]
+    public void Convert_ReturnsNormalBrush_ForNonNegativeOrInvalid()
+    {
+        var normal = new SolidColorBrush(Colors.White);
+        var c = new QuantityToStyleConverter { NormalBrush = normal };
+        Assert.Same(normal, c.Convert(0m, typeof(Brush), null, CultureInfo.InvariantCulture));
+        Assert.Same(normal, c.Convert("x", typeof(Brush), null, CultureInfo.InvariantCulture));
+    }
+
+    [Fact]
+    public void ConvertBack_ReturnsDoNothing()
+    {
+        var c = new QuantityToStyleConverter();
+        Assert.Equal(Binding.DoNothing, c.ConvertBack(Brushes.Red, typeof(decimal), null, CultureInfo.InvariantCulture));
+    }
+}

--- a/tests/Wrecept.Tests/StringNullOrEmptyToVisibilityConverterTests.cs
+++ b/tests/Wrecept.Tests/StringNullOrEmptyToVisibilityConverterTests.cs
@@ -1,0 +1,41 @@
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+using Wrecept.Wpf.Converters;
+using Xunit;
+
+namespace Wrecept.Tests;
+
+public class StringNullOrEmptyToVisibilityConverterTests
+{
+    [Fact]
+    public void Convert_ReturnsVisible_ForNullOrEmpty()
+    {
+        var c = new StringNullOrEmptyToVisibilityConverter();
+        Assert.Equal(Visibility.Visible, c.Convert(null!, typeof(Visibility), null, CultureInfo.InvariantCulture));
+        Assert.Equal(Visibility.Visible, c.Convert(string.Empty, typeof(Visibility), null, CultureInfo.InvariantCulture));
+    }
+
+    [Fact]
+    public void Convert_ReturnsCollapsed_ForNonEmpty()
+    {
+        var c = new StringNullOrEmptyToVisibilityConverter();
+        Assert.Equal(Visibility.Collapsed, c.Convert("x", typeof(Visibility), null, CultureInfo.InvariantCulture));
+        Assert.Equal(Visibility.Collapsed, c.Convert(42, typeof(Visibility), null, CultureInfo.InvariantCulture));
+    }
+
+    [Fact]
+    public void Convert_Inverts_WhenSet()
+    {
+        var c = new StringNullOrEmptyToVisibilityConverter { Invert = true };
+        Assert.Equal(Visibility.Collapsed, c.Convert(null!, typeof(Visibility), null, CultureInfo.InvariantCulture));
+        Assert.Equal(Visibility.Visible, c.Convert("x", typeof(Visibility), null, CultureInfo.InvariantCulture));
+    }
+
+    [Fact]
+    public void ConvertBack_ReturnsDoNothing()
+    {
+        var c = new StringNullOrEmptyToVisibilityConverter();
+        Assert.Equal(Binding.DoNothing, c.ConvertBack(Visibility.Visible, typeof(string), null, CultureInfo.InvariantCulture));
+    }
+}


### PR DESCRIPTION
## Summary
- add BooleanToRowDetailsConverter unit tests
- add InvoiceLineTotalsConverter unit tests
- add IsReadOnlyBindingConverter unit tests
- add NegativeValueForegroundConverter unit tests
- add QuantityToStyleConverter unit tests
- add StringNullOrEmptyToVisibilityConverter unit tests
- log progress for test suite

## Testing
- `dotnet test --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_686af95b8b7c8322b4d972b23dd30fa2