### PR TITLE
Add dialog behavior tests

### DIFF
--- a/docs/progress/2025-07-06_22-44-45_test_agent.md
+++ b/docs/progress/2025-07-06_22-44-45_test_agent.md
@@ -1,0 +1,2 @@
+- Added DialogHelperTests covering window centering logic.
+- Added EditEntityDialogTests verifying view binding and Initialize behavior.

--- a/tests/Wrecept.Tests/DialogHelperTests.cs
+++ b/tests/Wrecept.Tests/DialogHelperTests.cs
@@ -1,0 +1,28 @@
+using System.Windows;
+using Wrecept.Wpf.Dialogs;
+using Xunit;
+
+namespace Wrecept.Tests;
+
+public class DialogHelperTests
+{
+    private static void EnsureApp()
+    {
+        if (Application.Current == null)
+            new Application();
+    }
+
+    [StaFact]
+    public void CenterToOwner_SetsOwnerAndPosition()
+    {
+        EnsureApp();
+        var owner = new Window { Left = 50, Top = 40, Width = 300, Height = 200 };
+        var dialog = new Window { Width = 100, Height = 80 };
+
+        DialogHelper.CenterToOwner(dialog, owner);
+
+        Assert.Same(owner, dialog.Owner);
+        Assert.Equal(owner.Left + (owner.Width - dialog.Width) / 2, dialog.Left);
+        Assert.Equal(owner.Top + (owner.Height - dialog.Height) / 2, dialog.Top);
+    }
+}

--- a/tests/Wrecept.Tests/EditEntityDialogTests.cs
+++ b/tests/Wrecept.Tests/EditEntityDialogTests.cs
@@ -1,0 +1,46 @@
+using System.Windows;
+using System.Windows.Controls;
+using CommunityToolkit.Mvvm.Input;
+using Wrecept.Wpf.Dialogs;
+using Xunit;
+
+namespace Wrecept.Tests;
+
+public class EditEntityDialogTests
+{
+    private static void EnsureApp()
+    {
+        if (Application.Current == null)
+            new Application();
+    }
+
+    [StaFact]
+    public void Constructor_SetsContentAndDataContext()
+    {
+        EnsureApp();
+        var vm = new object();
+
+        var dialog = new EditEntityDialog<Grid, object>(vm);
+
+        Assert.Same(vm, dialog.ViewModel);
+        Assert.IsType<Grid>(dialog.Content);
+        var view = (FrameworkElement)dialog.Content!;
+        Assert.Same(vm, view.DataContext);
+    }
+
+    [StaFact]
+    public void Initialize_CentersToMainWindow()
+    {
+        EnsureApp();
+        var main = new Window { Left = 20, Top = 30, Width = 400, Height = 300 };
+        Application.Current.MainWindow = main;
+        var vm = new object();
+        var dialog = new EditEntityDialog<Grid, object>(vm) { Width = 200, Height = 100 };
+
+        dialog.Initialize(new RelayCommand(() => { }), new RelayCommand(() => { }));
+
+        Assert.Same(main, dialog.Owner);
+        Assert.Equal(main.Left + (main.Width - dialog.Width) / 2, dialog.Left);
+        Assert.Equal(main.Top + (main.Height - dialog.Height) / 2, dialog.Top);
+    }
+}


### PR DESCRIPTION
## Summary
- add DialogHelperTests for centering logic
- add EditEntityDialogTests for binding and centering
- log progress for test additions

## Testing
- `dotnet test --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_686afbadd2f88322b14dafdcbebbed29