### PR TITLE
Add WalPragmaInterceptor unit test

### DIFF
--- a/docs/progress/2025-07-06_22-51-04_test_agent.md
+++ b/docs/progress/2025-07-06_22-51-04_test_agent.md
@@ -1,0 +1,1 @@
+- Added WalPragmaInterceptorTests verifying PRAGMA execution when opening a SQLite connection.

--- a/tests/Wrecept.Storage.Tests/WalPragmaInterceptorTests.cs
+++ b/tests/Wrecept.Storage.Tests/WalPragmaInterceptorTests.cs
@@ -1,0 +1,35 @@
+using Microsoft.Data.Sqlite;
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Wrecept.Storage.Data;
+using Xunit;
+
+namespace Wrecept.Storage.Tests;
+
+public class WalPragmaInterceptorTests
+{
+    [Fact]
+    public async Task ConnectionOpenedAsync_SetsJournalModeToWal()
+    {
+        var path = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".db");
+        await using var connection = new SqliteConnection($"Data Source={path}");
+        await connection.OpenAsync();
+        await using (var cmd = connection.CreateCommand())
+        {
+            cmd.CommandText = "PRAGMA journal_mode";
+            var initial = (string)await cmd.ExecuteScalarAsync();
+            Assert.NotEqual("wal", initial.ToLowerInvariant());
+        }
+
+        var interceptor = new WalPragmaInterceptor();
+        await interceptor.ConnectionOpenedAsync(connection, null!);
+
+        await using (var cmd = connection.CreateCommand())
+        {
+            cmd.CommandText = "PRAGMA journal_mode";
+            var mode = (string)await cmd.ExecuteScalarAsync();
+            Assert.Equal("wal", mode.ToLowerInvariant());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- cover WalPragmaInterceptor with a unit test verifying PRAGMA call
- log progress

## Testing
- `dotnet test tests/Wrecept.Storage.Tests/Wrecept.Storage.Tests.csproj`
- `dotnet test Wrecept.Core.Tests/Wrecept.Core.Tests.csproj`
- `dotnet test tests/Wrecept.Tests/Wrecept.Tests.csproj` *(fails: incompatible WindowsDesktop SDK)*

------
https://chatgpt.com/codex/tasks/task_e_686afcb704d4832284ee9ed18eb17f93