### PR TITLE
Add NullNumberingService unit test

### DIFF
--- a/Wrecept.Core.Tests/Services/NullNumberingServiceTests.cs
+++ b/Wrecept.Core.Tests/Services/NullNumberingServiceTests.cs
@@ -1,0 +1,19 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Wrecept.Core.Services;
+using Xunit;
+
+namespace Wrecept.Core.Tests.Services;
+
+public class NullNumberingServiceTests
+{
+    [Fact]
+    public async Task GetNextInvoiceNumberAsync_ReturnsEmptyString()
+    {
+        var service = new NullNumberingService();
+
+        var result = await service.GetNextInvoiceNumberAsync(CancellationToken.None);
+
+        Assert.Equal(string.Empty, result);
+    }
+}

--- a/docs/progress/2025-07-06_23-33-44_test_agent.md
+++ b/docs/progress/2025-07-06_23-33-44_test_agent.md
@@ -1,0 +1,1 @@
+- Added NullNumberingServiceTests verifying empty string result.


### PR DESCRIPTION
## Summary
- add test for NullNumberingService verifying empty invoice number
- log progress

## Testing
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets missing)*

------
https://chatgpt.com/codex/tasks/task_e_686b06f4a8a083229abdcddc66925733