### PR TITLE
Add unit test for NullLogService

### DIFF
--- a/Wrecept.Core.Tests/Services/NullLogServiceTests.cs
+++ b/Wrecept.Core.Tests/Services/NullLogServiceTests.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Threading.Tasks;
+using Wrecept.Core.Services;
+using Xunit;
+
+namespace Wrecept.Core.Tests.Services;
+
+public class NullLogServiceTests
+{
+    [Fact]
+    public async Task LogError_DoesNotThrow()
+    {
+        var service = new NullLogService();
+
+        await service.LogError("test", new Exception());
+    }
+}

--- a/docs/progress/2025-07-06_23-40-13_test_agent.md
+++ b/docs/progress/2025-07-06_23-40-13_test_agent.md
@@ -1,0 +1,1 @@
+- Added NullLogServiceTests verifying LogError doesn't throw.


### PR DESCRIPTION
## Summary
- add NullLogServiceTests verifying LogError does not throw
- log progress

## Testing
- `dotnet test ./Wrecept.Core.Tests/Wrecept.Core.Tests.csproj`
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b084a26308322925758330b595f5a