### PR TITLE
Add AddCore registration test

### DIFF
--- a/Wrecept.Core.Tests/Wrecept.Core.Tests.csproj
+++ b/Wrecept.Core.Tests/Wrecept.Core.Tests.csproj
@@ -11,6 +11,9 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\tests\Wrecept.Core.Tests\*.cs" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\Wrecept.Core\Wrecept.Core.csproj" />
     <ProjectReference Include="..\Wrecept.Storage\Wrecept.Storage.csproj" />
   </ItemGroup>

--- a/docs/progress/2025-07-06_23-46-52_test_agent.md
+++ b/docs/progress/2025-07-06_23-46-52_test_agent.md
@@ -1,0 +1,1 @@
+- Added ServiceCollectionExtensionsTests verifying AddCore DI registrations.

--- a/tests/Wrecept.Core.Tests/ServiceCollectionExtensionsTests.cs
+++ b/tests/Wrecept.Core.Tests/ServiceCollectionExtensionsTests.cs
@@ -1,0 +1,33 @@
+using Microsoft.Extensions.DependencyInjection;
+using System.Linq;
+using Wrecept.Core;
+using Wrecept.Core.Services;
+using Xunit;
+
+namespace Wrecept.Core.Tests;
+
+public class ServiceCollectionExtensionsTests
+{
+    [Fact]
+    public void AddCore_RegistersDependencies()
+    {
+        var services = new ServiceCollection();
+        services.AddCore();
+
+        Assert.Contains(services, d => d.ServiceType == typeof(IProductService) && d.ImplementationType == typeof(ProductService));
+        Assert.Contains(services, d => d.ServiceType == typeof(IInvoiceService) && d.ImplementationType == typeof(InvoiceService));
+        Assert.Contains(services, d => d.ServiceType == typeof(InvoiceCalculator) && d.ImplementationType == typeof(InvoiceCalculator));
+        Assert.Contains(services, d => d.ServiceType == typeof(ISupplierService) && d.ImplementationType == typeof(SupplierService));
+        Assert.Contains(services, d => d.ServiceType == typeof(IProductGroupService) && d.ImplementationType == typeof(ProductGroupService));
+        Assert.Contains(services, d => d.ServiceType == typeof(ITaxRateService) && d.ImplementationType == typeof(TaxRateService));
+        Assert.Contains(services, d => d.ServiceType == typeof(IPaymentMethodService) && d.ImplementationType == typeof(PaymentMethodService));
+        Assert.Contains(services, d => d.ServiceType == typeof(IUnitService) && d.ImplementationType == typeof(UnitService));
+
+        var numDesc = services.First(d => d.ServiceType == typeof(INumberingService));
+        var logDesc = services.First(d => d.ServiceType == typeof(ILogService));
+        Assert.Equal(ServiceLifetime.Singleton, numDesc.Lifetime);
+        Assert.Equal(ServiceLifetime.Singleton, logDesc.Lifetime);
+        Assert.Equal(typeof(NullNumberingService), numDesc.ImplementationType);
+        Assert.Equal(typeof(NullLogService), logDesc.ImplementationType);
+    }
+}


### PR DESCRIPTION
## Summary
- add ServiceCollectionExtensionsTests verifying AddCore DI descriptors and singleton lifetimes
- include new test files in Wrecept.Core.Tests project
- log progress

## Testing
- `dotnet test Wrecept.Core.Tests/Wrecept.Core.Tests.csproj --no-build -v n`
- `dotnet test tests/Wrecept.Tests/Wrecept.Tests.csproj --no-build -v n` *(fails: no output)*

------
https://chatgpt.com/codex/tasks/task_e_686b0a17518083228fc9d165680dac68