### PR TITLE
Add ProductGroupService unit tests

### DIFF
--- a/Wrecept.Core.Tests/Services/ProductGroupServiceTests.cs
+++ b/Wrecept.Core.Tests/Services/ProductGroupServiceTests.cs
@@ -1,0 +1,71 @@
+using Wrecept.Core.Models;
+using Wrecept.Core.Repositories;
+using Wrecept.Core.Services;
+using Xunit;
+
+namespace Wrecept.Core.Tests.Services;
+
+public class ProductGroupServiceTests
+{
+    private sealed class FakeRepo : IProductGroupRepository
+    {
+        public ProductGroup? Added;
+        public ProductGroup? Updated;
+        public Task<List<ProductGroup>> GetAllAsync(CancellationToken ct = default) => Task.FromResult(new List<ProductGroup>());
+        public Task<List<ProductGroup>> GetActiveAsync(CancellationToken ct = default) => Task.FromResult(new List<ProductGroup>());
+        public Task<Guid> AddAsync(ProductGroup group, CancellationToken ct = default)
+        {
+            Added = group;
+            return Task.FromResult(Guid.NewGuid());
+        }
+        public Task UpdateAsync(ProductGroup group, CancellationToken ct = default)
+        {
+            Updated = group;
+            return Task.CompletedTask;
+        }
+    }
+
+    [Fact]
+    public async Task AddAsync_Throws_WhenNameMissing()
+    {
+        var repo = new FakeRepo();
+        var svc = new ProductGroupService(repo);
+        var group = new ProductGroup { Name = "" };
+
+        await Assert.ThrowsAsync<ArgumentException>(() => svc.AddAsync(group));
+    }
+
+    [Fact]
+    public async Task AddAsync_CallsRepository()
+    {
+        var repo = new FakeRepo();
+        var svc = new ProductGroupService(repo);
+        var group = new ProductGroup { Name = "Group" };
+
+        await svc.AddAsync(group);
+
+        Assert.NotNull(repo.Added);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_Throws_WhenIdInvalid()
+    {
+        var repo = new FakeRepo();
+        var svc = new ProductGroupService(repo);
+        var group = new ProductGroup { Name = "Group" };
+
+        await Assert.ThrowsAsync<ArgumentException>(() => svc.UpdateAsync(group));
+    }
+
+    [Fact]
+    public async Task UpdateAsync_CallsRepository()
+    {
+        var repo = new FakeRepo();
+        var svc = new ProductGroupService(repo);
+        var group = new ProductGroup { Id = Guid.NewGuid(), Name = "Group" };
+
+        await svc.UpdateAsync(group);
+
+        Assert.NotNull(repo.Updated);
+    }
+}

--- a/docs/PROJECT_STRUCTURE.md
+++ b/docs/PROJECT_STRUCTURE.md
@@ -1587,6 +1587,13 @@ Minden fájl leírása az alábbi mezőket tartalmazza:
   - Responsibility: Funkcionális logika
   - Interaction: Repositories, ViewModels
   - Special Notes: -
+- **Wrecept.Core.Tests/Services/ProductGroupServiceTests.cs**
+  - Purpose: Üzleti szolgáltatás
+  - Layer: Tests
+  - Type: C#
+  - Responsibility: Funkcionális logika
+  - Interaction: Repositories, ViewModels
+  - Special Notes: -
 - **Wrecept.Core.Tests/Services/SupplierServiceTests.cs**
   - Purpose: Üzleti szolgáltatás
   - Layer: Tests

--- a/docs/progress/2025-07-06_23-56-48_test_agent.md
+++ b/docs/progress/2025-07-06_23-56-48_test_agent.md
@@ -1,0 +1,1 @@
+- Added ProductGroupServiceTests covering validation and repository calls.


### PR DESCRIPTION
## Summary
- add ProductGroupService unit tests verifying validation and repository calls
- document new test file location in PROJECT_STRUCTURE
- log progress

## Testing
- `dotnet test Wrecept.Core.Tests/Wrecept.Core.Tests.csproj -v q`


------
https://chatgpt.com/codex/tasks/task_e_686b0c275d288322b1467c38f0763387