### PR TITLE
AddStorageAsync default path test

### DIFF
--- a/docs/progress/2025-07-07_00-08-47_root_agent.md
+++ b/docs/progress/2025-07-07_00-08-47_root_agent.md
@@ -1,0 +1,2 @@
+- Added EmptyDbPath_ResolvesServicesAndCreatesFile test in WalPragmaTests.
+- Verifies AddStorageAsync default path, service resolution and file creation.


### PR DESCRIPTION
## Summary
- extend WalPragmaTests to check AddStorageAsync with empty DB path
- log progress

## Testing
- `dotnet test tests/Wrecept.Tests/Wrecept.Tests.csproj --verbosity minimal` *(fails: Project Wrecept.Wpf is not compatible with net8.0)*

------
https://chatgpt.com/codex/tasks/task_e_686b0f7812a08322bea7f434f305f622