### PR TITLE
Add ViewModel unit tests

### DIFF
--- a/docs/progress/2025-07-07_05-50-48_test_agent.md
+++ b/docs/progress/2025-07-07_05-50-48_test_agent.md
@@ -1,0 +1,1 @@
+- Added unit tests for various prompt and editor view models increasing coverage.

--- a/tests/viewmodels/AboutViewModelTests.cs
+++ b/tests/viewmodels/AboutViewModelTests.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Reflection;
+using System.Threading.Tasks;
+using Xunit;
+using Wrecept.Wpf.ViewModels;
+using Wrecept.Core.Entities;
+using Wrecept.Core.Services;
+
+namespace Wrecept.Tests.ViewModels;
+
+public class AboutViewModelTests
+{
+    private class FakeService : IUserInfoService
+    {
+        public Task<UserInfo> LoadAsync() => Task.FromResult(new UserInfo
+        {
+            CompanyName = "ACME",
+            Address = "X",
+            Phone = "1",
+            Email = "a@b.c"
+        });
+        public Task SaveAsync(UserInfo info) => Task.CompletedTask;
+    }
+
+    [Fact]
+    public void StripFrontMatter_RemovesHeader()
+    {
+        var mi = typeof(AboutViewModel).GetMethod("StripFrontMatter", BindingFlags.NonPublic | BindingFlags.Static)!;
+        var text = "---\ntitle: t\n---\nHello";
+        var result = (string)mi.Invoke(null, new object[] { text })!;
+        Assert.Equal("Hello", result);
+    }
+
+    [Fact]
+    public async Task LoadAsync_AppendsUserInfo()
+    {
+        var vm = new AboutViewModel(new FakeService());
+        await vm.LoadAsync();
+        Assert.Contains("ACME", vm.AboutText);
+    }
+}

--- a/tests/viewmodels/ArchivePromptViewModelTests.cs
+++ b/tests/viewmodels/ArchivePromptViewModelTests.cs
@@ -1,0 +1,99 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Xunit;
+using Wrecept.Wpf.ViewModels;
+using Wrecept.Core.Models;
+using Wrecept.Core.Services;
+using Wrecept.Wpf.Services;
+
+namespace Wrecept.Tests.ViewModels;
+
+public class ArchivePromptViewModelTests
+{
+    private class FakeInvoiceService : IInvoiceService
+    {
+        public bool Archived;
+        public Task<bool> CreateAsync(Invoice invoice, System.Threading.CancellationToken ct = default) => Task.FromResult(true);
+        public Task<int> CreateHeaderAsync(Invoice invoice, System.Threading.CancellationToken ct = default) => Task.FromResult(1);
+        public Task<int> AddItemAsync(InvoiceItem item, System.Threading.CancellationToken ct = default) => Task.FromResult(1);
+        public Task UpdateInvoiceHeaderAsync(int id, DateOnly date, DateOnly dueDate, int supplierId, Guid paymentMethodId, bool isGross, System.Threading.CancellationToken ct = default) => Task.CompletedTask;
+        public Task ArchiveAsync(int id, System.Threading.CancellationToken ct = default)
+        {
+            Archived = true;
+            return Task.CompletedTask;
+        }
+        public Task<Invoice?> GetAsync(int id, System.Threading.CancellationToken ct = default) => Task.FromResult<Invoice?>(null);
+        public Task<List<Invoice>> GetRecentAsync(int count, System.Threading.CancellationToken ct = default) => Task.FromResult(new List<Invoice>());
+        public InvoiceCalculationResult RecalculateTotals(Invoice invoice) => new();
+    }
+
+    private class DummyService<T> : IPaymentMethodService, ITaxRateService, ISupplierService, IUnitService, IProductGroupService where T : class
+    {
+        public Task<List<PaymentMethod>> GetActiveAsync(System.Threading.CancellationToken ct = default) => Task.FromResult(new List<PaymentMethod>());
+        public Task<List<PaymentMethod>> GetAllAsync(System.Threading.CancellationToken ct = default) => Task.FromResult(new List<PaymentMethod>());
+        public Task<Guid> AddAsync(PaymentMethod method, System.Threading.CancellationToken ct = default) => Task.FromResult(Guid.NewGuid());
+        public Task UpdateAsync(PaymentMethod method, System.Threading.CancellationToken ct = default) => Task.CompletedTask;
+        public Task<List<TaxRate>> GetAllAsync(System.Threading.CancellationToken ct = default) => Task.FromResult(new List<TaxRate>());
+        public Task<List<TaxRate>> GetActiveAsync(DateTime asOf, System.Threading.CancellationToken ct = default) => Task.FromResult(new List<TaxRate>());
+        public Task<Guid> AddAsync(TaxRate taxRate, System.Threading.CancellationToken ct = default) => Task.FromResult(Guid.NewGuid());
+        public Task UpdateAsync(TaxRate taxRate, System.Threading.CancellationToken ct = default) => Task.CompletedTask;
+        public Task<List<Supplier>> GetAllAsync(System.Threading.CancellationToken ct = default) => Task.FromResult(new List<Supplier>());
+        public Task<List<Supplier>> GetActiveAsync(System.Threading.CancellationToken ct = default) => Task.FromResult(new List<Supplier>());
+        public Task<int> AddAsync(Supplier supplier, System.Threading.CancellationToken ct = default) => Task.FromResult(1);
+        public Task UpdateAsync(Supplier supplier, System.Threading.CancellationToken ct = default) => Task.CompletedTask;
+        public Task<List<Unit>> GetAllAsync(System.Threading.CancellationToken ct = default) => Task.FromResult(new List<Unit>());
+        public Task<List<Unit>> GetActiveAsync(System.Threading.CancellationToken ct = default) => Task.FromResult(new List<Unit>());
+        public Task<Guid> AddAsync(Unit unit, System.Threading.CancellationToken ct = default) => Task.FromResult(Guid.NewGuid());
+        public Task UpdateAsync(Unit unit, System.Threading.CancellationToken ct = default) => Task.CompletedTask;
+        public Task<List<ProductGroup>> GetAllAsync(System.Threading.CancellationToken ct = default) => Task.FromResult(new List<ProductGroup>());
+        public Task<List<ProductGroup>> GetActiveAsync(System.Threading.CancellationToken ct = default) => Task.FromResult(new List<ProductGroup>());
+        public Task<Guid> AddAsync(ProductGroup group, System.Threading.CancellationToken ct = default) => Task.FromResult(Guid.NewGuid());
+        public Task UpdateAsync(ProductGroup group, System.Threading.CancellationToken ct = default) => Task.CompletedTask;
+    }
+
+    private class DummyLogService : ILogService
+    {
+        public Task LogError(string message, Exception ex) => Task.CompletedTask;
+    }
+
+    private class DummyNotificationService : INotificationService
+    {
+        public void ShowError(string message) { }
+        public void ShowInfo(string message) { }
+        public bool Confirm(string message) => true;
+    }
+
+    private static InvoiceEditorViewModel CreateEditor(FakeInvoiceService invoice)
+    {
+        var lookup = new InvoiceLookupViewModel(invoice, new FakeNumberingService(), new AppStateService(Path.GetTempFileName()));
+        var state = new AppStateService(Path.GetTempFileName());
+        return new InvoiceEditorViewModel(new DummyService<object>(), new DummyService<object>(), new DummyService<object>(), new FakeProductService(), new DummyService<object>(), new DummyService<object>(), invoice, new DummyLogService(), new DummyNotificationService(), state, lookup);
+    }
+
+    [Fact]
+    public async Task ConfirmAsync_ArchivesAndCloses()
+    {
+        var invoice = new FakeInvoiceService();
+        var vm = CreateEditor(invoice);
+        var prompt = new ArchivePromptViewModel(vm);
+        vm.ArchivePrompt = prompt;
+
+        await prompt.ConfirmAsyncCommand.ExecuteAsync(null);
+
+        Assert.True(invoice.Archived);
+        Assert.Null(vm.ArchivePrompt);
+    }
+
+    [Fact]
+    public void Cancel_ClosesPrompt()
+    {
+        var vm = CreateEditor(new FakeInvoiceService());
+        var prompt = new ArchivePromptViewModel(vm);
+        vm.ArchivePrompt = prompt;
+
+        prompt.CancelCommand.Execute(null);
+
+        Assert.Null(vm.ArchivePrompt);
+    }
+}

--- a/tests/viewmodels/DeleteItemPromptViewModelTests.cs
+++ b/tests/viewmodels/DeleteItemPromptViewModelTests.cs
@@ -1,0 +1,97 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Xunit;
+using Wrecept.Wpf.ViewModels;
+using Wrecept.Core.Models;
+using Wrecept.Core.Services;
+using Wrecept.Wpf.Services;
+
+namespace Wrecept.Tests.ViewModels;
+
+public class DeleteItemPromptViewModelTests
+{
+    private class FakeInvoiceService : IInvoiceService
+    {
+        public Task<bool> CreateAsync(Invoice invoice, System.Threading.CancellationToken ct = default) => Task.FromResult(true);
+        public Task<int> CreateHeaderAsync(Invoice invoice, System.Threading.CancellationToken ct = default) => Task.FromResult(1);
+        public Task<int> AddItemAsync(InvoiceItem item, System.Threading.CancellationToken ct = default) => Task.FromResult(1);
+        public Task UpdateInvoiceHeaderAsync(int id, DateOnly date, DateOnly dueDate, int supplierId, Guid paymentMethodId, bool isGross, System.Threading.CancellationToken ct = default) => Task.CompletedTask;
+        public Task ArchiveAsync(int id, System.Threading.CancellationToken ct = default) => Task.CompletedTask;
+        public Task<Invoice?> GetAsync(int id, System.Threading.CancellationToken ct = default) => Task.FromResult<Invoice?>(null);
+        public Task<List<Invoice>> GetRecentAsync(int count, System.Threading.CancellationToken ct = default) => Task.FromResult(new List<Invoice>());
+        public InvoiceCalculationResult RecalculateTotals(Invoice invoice) => new();
+    }
+
+    private class DummyService<T> : IPaymentMethodService, ITaxRateService, ISupplierService, IUnitService, IProductGroupService where T : class
+    {
+        public Task<List<PaymentMethod>> GetActiveAsync(System.Threading.CancellationToken ct = default) => Task.FromResult(new List<PaymentMethod>());
+        public Task<List<PaymentMethod>> GetAllAsync(System.Threading.CancellationToken ct = default) => Task.FromResult(new List<PaymentMethod>());
+        public Task<Guid> AddAsync(PaymentMethod method, System.Threading.CancellationToken ct = default) => Task.FromResult(Guid.NewGuid());
+        public Task UpdateAsync(PaymentMethod method, System.Threading.CancellationToken ct = default) => Task.CompletedTask;
+        public Task<List<TaxRate>> GetAllAsync(System.Threading.CancellationToken ct = default) => Task.FromResult(new List<TaxRate>());
+        public Task<List<TaxRate>> GetActiveAsync(DateTime asOf, System.Threading.CancellationToken ct = default) => Task.FromResult(new List<TaxRate>());
+        public Task<Guid> AddAsync(TaxRate taxRate, System.Threading.CancellationToken ct = default) => Task.FromResult(Guid.NewGuid());
+        public Task UpdateAsync(TaxRate taxRate, System.Threading.CancellationToken ct = default) => Task.CompletedTask;
+        public Task<List<Supplier>> GetAllAsync(System.Threading.CancellationToken ct = default) => Task.FromResult(new List<Supplier>());
+        public Task<List<Supplier>> GetActiveAsync(System.Threading.CancellationToken ct = default) => Task.FromResult(new List<Supplier>());
+        public Task<int> AddAsync(Supplier supplier, System.Threading.CancellationToken ct = default) => Task.FromResult(1);
+        public Task UpdateAsync(Supplier supplier, System.Threading.CancellationToken ct = default) => Task.CompletedTask;
+        public Task<List<Unit>> GetAllAsync(System.Threading.CancellationToken ct = default) => Task.FromResult(new List<Unit>());
+        public Task<List<Unit>> GetActiveAsync(System.Threading.CancellationToken ct = default) => Task.FromResult(new List<Unit>());
+        public Task<Guid> AddAsync(Unit unit, System.Threading.CancellationToken ct = default) => Task.FromResult(Guid.NewGuid());
+        public Task UpdateAsync(Unit unit, System.Threading.CancellationToken ct = default) => Task.CompletedTask;
+        public Task<List<ProductGroup>> GetAllAsync(System.Threading.CancellationToken ct = default) => Task.FromResult(new List<ProductGroup>());
+        public Task<List<ProductGroup>> GetActiveAsync(System.Threading.CancellationToken ct = default) => Task.FromResult(new List<ProductGroup>());
+        public Task<Guid> AddAsync(ProductGroup group, System.Threading.CancellationToken ct = default) => Task.FromResult(Guid.NewGuid());
+        public Task UpdateAsync(ProductGroup group, System.Threading.CancellationToken ct = default) => Task.CompletedTask;
+    }
+
+    private class DummyLogService : ILogService
+    {
+        public Task LogError(string message, Exception ex) => Task.CompletedTask;
+    }
+
+    private class DummyNotificationService : INotificationService
+    {
+        public void ShowError(string message) { }
+        public void ShowInfo(string message) { }
+        public bool Confirm(string message) => true;
+    }
+
+    private static InvoiceEditorViewModel CreateEditor()
+    {
+        var invoice = new FakeInvoiceService();
+        var lookup = new InvoiceLookupViewModel(invoice, new FakeNumberingService(), new AppStateService(Path.GetTempFileName()));
+        var state = new AppStateService(Path.GetTempFileName());
+        return new InvoiceEditorViewModel(new DummyService<object>(), new DummyService<object>(), new DummyService<object>(), new FakeProductService(), new DummyService<object>(), new DummyService<object>(), invoice, new DummyLogService(), new DummyNotificationService(), state, lookup);
+    }
+
+    [Fact]
+    public void Confirm_RemovesRowAndCloses()
+    {
+        var vm = CreateEditor();
+        vm.Items.Insert(1, new InvoiceItemRowViewModel(vm) { Product = "X" });
+        var row = vm.Items[1];
+        var prompt = new DeleteItemPromptViewModel(vm, row);
+        vm.DeletePrompt = prompt;
+
+        prompt.ConfirmCommand.Execute(null);
+
+        Assert.Equal(1, vm.Items.Count);
+        Assert.Null(vm.DeletePrompt);
+    }
+
+    [Fact]
+    public void Cancel_ClosesPrompt()
+    {
+        var vm = CreateEditor();
+        var row = new InvoiceItemRowViewModel(vm);
+        var prompt = new DeleteItemPromptViewModel(vm, row);
+        vm.DeletePrompt = prompt;
+
+        prompt.CancelCommand.Execute(null);
+
+        Assert.Null(vm.DeletePrompt);
+    }
+}

--- a/tests/viewmodels/EditableItemViewModelTests.cs
+++ b/tests/viewmodels/EditableItemViewModelTests.cs
@@ -1,0 +1,37 @@
+using System;
+using Xunit;
+using Wrecept.Wpf.ViewModels;
+
+namespace Wrecept.Tests.ViewModels;
+
+public class EditableItemViewModelTests
+{
+    [Fact]
+    public void ExistingItem_CopiesProperties()
+    {
+        var parent = new InvoiceEditorViewModel();
+        var source = new InvoiceItemRowViewModel(parent)
+        {
+            Product = "P",
+            Quantity = 2,
+            UnitPrice = 5,
+            TaxRateId = Guid.NewGuid(),
+            UnitId = Guid.NewGuid(),
+            UnitName = "u",
+            TaxRateName = "t",
+            ProductGroup = "g",
+            Description = "d"
+        };
+        var vm = new ExistingLineItemEditViewModel(parent, source);
+        Assert.True(vm.IsEditingExisting);
+        Assert.Equal(source.Product, vm.Product);
+        Assert.Equal(source.Quantity, vm.Quantity);
+        Assert.Equal(source.UnitPrice, vm.UnitPrice);
+        Assert.Equal(source.TaxRateId, vm.TaxRateId);
+        Assert.Equal(source.UnitId, vm.UnitId);
+        Assert.Equal(source.UnitName, vm.UnitName);
+        Assert.Equal(source.TaxRateName, vm.TaxRateName);
+        Assert.Equal(source.ProductGroup, vm.ProductGroup);
+        Assert.Equal(source.Description, vm.Description);
+    }
+}

--- a/tests/viewmodels/EditableMasterDataViewModelTests.cs
+++ b/tests/viewmodels/EditableMasterDataViewModelTests.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+using Wrecept.Wpf.ViewModels;
+using Wrecept.Wpf.Services;
+using Wrecept.Core.Enums;
+
+namespace Wrecept.Tests.ViewModels;
+
+public class EditableMasterDataViewModelTests
+{
+    private class TestViewModel : EditableMasterDataViewModel<string>
+    {
+        public int DeleteCalls;
+        public TestViewModel(AppStateService s) : base(s) { }
+        protected override Task<List<string>> GetItemsAsync() => Task.FromResult(new List<string> { "a", "b" });
+        protected override Task DeleteAsync() { DeleteCalls++; return Task.CompletedTask; }
+    }
+
+    [Fact]
+    public async Task LoadAsync_FillsItemsAndCommands()
+    {
+        var state = new AppStateService("x");
+        var vm = new TestViewModel(state);
+        await vm.LoadAsync();
+        Assert.Equal(2, vm.Items.Count);
+        Assert.False(vm.EditSelectedCommand.CanExecute(null));
+        vm.SelectedItem = vm.Items[0];
+        Assert.True(vm.EditSelectedCommand.CanExecute(null));
+        vm.EditSelectedCommand.Execute(null);
+        Assert.True(vm.IsEditing);
+        vm.CloseDetailsCommand.Execute(null);
+        Assert.False(vm.IsEditing);
+        vm.DeleteSelectedCommand.Execute(null);
+        Assert.Equal(1, vm.DeleteCalls);
+    }
+}

--- a/tests/viewmodels/InvoiceCreatePromptViewModelTests.cs
+++ b/tests/viewmodels/InvoiceCreatePromptViewModelTests.cs
@@ -1,0 +1,61 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Xunit;
+using Wrecept.Wpf.ViewModels;
+using Wrecept.Core.Models;
+using Wrecept.Core.Services;
+using Wrecept.Wpf.Services;
+
+namespace Wrecept.Tests.ViewModels;
+
+public class InvoiceCreatePromptViewModelTests
+{
+    private class FakeInvoiceService : IInvoiceService
+    {
+        public readonly List<Invoice> Created = new();
+        public Task<bool> CreateAsync(Invoice invoice, System.Threading.CancellationToken ct = default)
+        {
+            Created.Add(invoice);
+            return Task.FromResult(true);
+        }
+        public Task<int> CreateHeaderAsync(Invoice invoice, System.Threading.CancellationToken ct = default)
+        {
+            Created.Add(invoice);
+            return Task.FromResult(1);
+        }
+        public Task<int> AddItemAsync(InvoiceItem item, System.Threading.CancellationToken ct = default) => Task.FromResult(1);
+        public Task UpdateInvoiceHeaderAsync(int id, DateOnly date, DateOnly dueDate, int supplierId, Guid paymentMethodId, bool isGross, System.Threading.CancellationToken ct = default) => Task.CompletedTask;
+        public Task ArchiveAsync(int id, System.Threading.CancellationToken ct = default) => Task.CompletedTask;
+        public Task<Invoice?> GetAsync(int id, System.Threading.CancellationToken ct = default) => Task.FromResult<Invoice?>(null);
+        public Task<List<Invoice>> GetRecentAsync(int count, System.Threading.CancellationToken ct = default) => Task.FromResult(new List<Invoice>());
+        public InvoiceCalculationResult RecalculateTotals(Invoice invoice) => new();
+    }
+
+    [Fact]
+    public async Task ConfirmAsync_CreatesEntryAndCloses()
+    {
+        var service = new FakeInvoiceService();
+        var lookup = new InvoiceLookupViewModel(service, new FakeNumberingService(), new AppStateService(Path.GetTempFileName()));
+        var prompt = new InvoiceCreatePromptViewModel(lookup, "A1");
+        lookup.InlinePrompt = prompt;
+
+        await prompt.ConfirmAsyncCommand.ExecuteAsync(null);
+
+        Assert.Null(lookup.InlinePrompt);
+        Assert.Single(lookup.Invoices);
+    }
+
+    [Fact]
+    public void Cancel_ClosesPrompt()
+    {
+        var service = new FakeInvoiceService();
+        var lookup = new InvoiceLookupViewModel(service, new FakeNumberingService(), new AppStateService(Path.GetTempFileName()));
+        var prompt = new InvoiceCreatePromptViewModel(lookup, "A1");
+        lookup.InlinePrompt = prompt;
+
+        prompt.CancelCommand.Execute(null);
+
+        Assert.Null(lookup.InlinePrompt);
+    }
+}

--- a/tests/viewmodels/ProductEditorViewModelTests.cs
+++ b/tests/viewmodels/ProductEditorViewModelTests.cs
@@ -1,0 +1,24 @@
+using System;
+using Xunit;
+using Wrecept.Wpf.ViewModels;
+
+namespace Wrecept.Tests.ViewModels;
+
+public class ProductEditorViewModelTests
+{
+    [Fact]
+    public void Commands_InvokeDelegates()
+    {
+        var vm = new ProductEditorViewModel();
+        bool ok = false;
+        bool cancel = false;
+        vm.OnOk = _ => ok = true;
+        vm.OnCancel = () => cancel = true;
+
+        vm.OkCommand.Execute(null);
+        vm.CancelCommand.Execute(null);
+
+        Assert.True(ok);
+        Assert.True(cancel);
+    }
+}

--- a/tests/viewmodels/SaveLinePromptViewModelTests.cs
+++ b/tests/viewmodels/SaveLinePromptViewModelTests.cs
@@ -1,0 +1,122 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Xunit;
+using Wrecept.Wpf.ViewModels;
+using Wrecept.Core.Models;
+using Wrecept.Core.Services;
+using Wrecept.Wpf.Services;
+
+namespace Wrecept.Tests.ViewModels;
+
+public class SaveLinePromptViewModelTests
+{
+    private class FakeInvoiceService : IInvoiceService
+    {
+        public int ItemCalls;
+        public Task<bool> CreateAsync(Invoice invoice, System.Threading.CancellationToken ct = default) => Task.FromResult(true);
+        public Task<int> CreateHeaderAsync(Invoice invoice, System.Threading.CancellationToken ct = default) => Task.FromResult(1);
+        public Task<int> AddItemAsync(InvoiceItem item, System.Threading.CancellationToken ct = default)
+        {
+            ItemCalls++;
+            return Task.FromResult(1);
+        }
+        public Task UpdateInvoiceHeaderAsync(int id, DateOnly date, DateOnly dueDate, int supplierId, Guid paymentMethodId, bool isGross, System.Threading.CancellationToken ct = default) => Task.CompletedTask;
+        public Task ArchiveAsync(int id, System.Threading.CancellationToken ct = default) => Task.CompletedTask;
+        public Task<Invoice?> GetAsync(int id, System.Threading.CancellationToken ct = default) => Task.FromResult<Invoice?>(null);
+        public Task<List<Invoice>> GetRecentAsync(int count, System.Threading.CancellationToken ct = default) => Task.FromResult(new List<Invoice>());
+        public InvoiceCalculationResult RecalculateTotals(Invoice invoice) => new();
+    }
+
+    private class FakeProductService : IProductService
+    {
+        public readonly List<Product> Products = new();
+        public Task<List<Product>> GetAllAsync(System.Threading.CancellationToken ct = default) => Task.FromResult(new List<Product>(Products));
+        public Task<List<Product>> GetActiveAsync(System.Threading.CancellationToken ct = default) => Task.FromResult(new List<Product>(Products));
+        public Task<int> AddAsync(Product product, System.Threading.CancellationToken ct = default) => Task.FromResult(0);
+        public Task UpdateAsync(Product product, System.Threading.CancellationToken ct = default) => Task.CompletedTask;
+    }
+
+    private class DummyService<T> : IPaymentMethodService, ITaxRateService, ISupplierService, IUnitService, IProductGroupService where T : class
+    {
+        public Task<List<PaymentMethod>> GetActiveAsync(System.Threading.CancellationToken ct = default) => Task.FromResult(new List<PaymentMethod>());
+        public Task<List<PaymentMethod>> GetAllAsync(System.Threading.CancellationToken ct = default) => Task.FromResult(new List<PaymentMethod>());
+        public Task<Guid> AddAsync(PaymentMethod method, System.Threading.CancellationToken ct = default) => Task.FromResult(Guid.NewGuid());
+        public Task UpdateAsync(PaymentMethod method, System.Threading.CancellationToken ct = default) => Task.CompletedTask;
+        public Task<List<TaxRate>> GetAllAsync(System.Threading.CancellationToken ct = default) => Task.FromResult(new List<TaxRate>());
+        public Task<List<TaxRate>> GetActiveAsync(DateTime asOf, System.Threading.CancellationToken ct = default) => Task.FromResult(new List<TaxRate>());
+        public Task<Guid> AddAsync(TaxRate taxRate, System.Threading.CancellationToken ct = default) => Task.FromResult(Guid.NewGuid());
+        public Task UpdateAsync(TaxRate taxRate, System.Threading.CancellationToken ct = default) => Task.CompletedTask;
+        public Task<List<Supplier>> GetAllAsync(System.Threading.CancellationToken ct = default) => Task.FromResult(new List<Supplier>());
+        public Task<List<Supplier>> GetActiveAsync(System.Threading.CancellationToken ct = default) => Task.FromResult(new List<Supplier>());
+        public Task<int> AddAsync(Supplier supplier, System.Threading.CancellationToken ct = default) => Task.FromResult(1);
+        public Task UpdateAsync(Supplier supplier, System.Threading.CancellationToken ct = default) => Task.CompletedTask;
+        public Task<List<Unit>> GetAllAsync(System.Threading.CancellationToken ct = default) => Task.FromResult(new List<Unit>());
+        public Task<List<Unit>> GetActiveAsync(System.Threading.CancellationToken ct = default) => Task.FromResult(new List<Unit>());
+        public Task<Guid> AddAsync(Unit unit, System.Threading.CancellationToken ct = default) => Task.FromResult(Guid.NewGuid());
+        public Task UpdateAsync(Unit unit, System.Threading.CancellationToken ct = default) => Task.CompletedTask;
+        public Task<List<ProductGroup>> GetAllAsync(System.Threading.CancellationToken ct = default) => Task.FromResult(new List<ProductGroup>());
+        public Task<List<ProductGroup>> GetActiveAsync(System.Threading.CancellationToken ct = default) => Task.FromResult(new List<ProductGroup>());
+        public Task<Guid> AddAsync(ProductGroup group, System.Threading.CancellationToken ct = default) => Task.FromResult(Guid.NewGuid());
+        public Task UpdateAsync(ProductGroup group, System.Threading.CancellationToken ct = default) => Task.CompletedTask;
+    }
+
+    private class DummyLogService : ILogService
+    {
+        public Task LogError(string message, Exception ex) => Task.CompletedTask;
+    }
+
+    private class DummyNotificationService : INotificationService
+    {
+        public void ShowError(string message) { }
+        public void ShowInfo(string message) { }
+        public bool Confirm(string message) => true;
+    }
+
+    private static InvoiceEditorViewModel CreateEditor(FakeInvoiceService invoice, FakeProductService products)
+    {
+        var numberSvc = new FakeNumberingService();
+        var lookup = new InvoiceLookupViewModel(invoice, numberSvc, new AppStateService(Path.GetTempFileName()));
+        var state = new AppStateService(Path.GetTempFileName());
+        return new InvoiceEditorViewModel(new DummyService<object>(), new DummyService<object>(), new DummyService<object>(), products, new DummyService<object>(), new DummyService<object>(), invoice, new DummyLogService(), new DummyNotificationService(), state, lookup);
+    }
+
+    [Fact]
+    public async Task ConfirmAsync_AddsLineAndClosesPrompt()
+    {
+        var invoice = new FakeInvoiceService();
+        var products = new FakeProductService();
+        var taxId = Guid.NewGuid();
+        products.Products.Add(new Product { Id = 1, Name = "Test", TaxRateId = taxId });
+        var vm = CreateEditor(invoice, products);
+        var row = vm.Items[0];
+        row.Product = "Test";
+        row.Quantity = 1;
+        row.UnitPrice = 10;
+        row.TaxRateId = taxId;
+        var prompt = new SaveLinePromptViewModel(vm);
+        vm.SavePrompt = prompt;
+        vm.IsInLineFinalizationPrompt = true;
+
+        await prompt.ConfirmAsyncCommand.ExecuteAsync(null);
+
+        Assert.Equal(1, invoice.ItemCalls);
+        Assert.Equal(2, vm.Items.Count);
+        Assert.Null(vm.SavePrompt);
+        Assert.False(vm.IsInLineFinalizationPrompt);
+    }
+
+    [Fact]
+    public void Cancel_ClosesPrompt()
+    {
+        var vm = CreateEditor(new FakeInvoiceService(), new FakeProductService());
+        var prompt = new SaveLinePromptViewModel(vm);
+        vm.SavePrompt = prompt;
+        vm.IsInLineFinalizationPrompt = true;
+
+        prompt.CancelCommand.Execute(null);
+
+        Assert.Null(vm.SavePrompt);
+        Assert.False(vm.IsInLineFinalizationPrompt);
+    }
+}

--- a/tests/viewmodels/SeedOptionsViewModelTests.cs
+++ b/tests/viewmodels/SeedOptionsViewModelTests.cs
@@ -1,0 +1,36 @@
+using System.Windows;
+using Xunit;
+using Wrecept.Wpf.ViewModels;
+
+namespace Wrecept.Tests.ViewModels;
+
+public class SeedOptionsViewModelTests
+{
+    private static void EnsureApp()
+    {
+        if (Application.Current == null)
+            new Application();
+    }
+
+    [StaFact]
+    public void OkCommand_SetsDialogResult()
+    {
+        EnsureApp();
+        var vm = new SeedOptionsViewModel();
+        var window = new Window();
+        vm.OkCommand.Execute(window);
+        Assert.False(window.IsVisible);
+        Assert.True(window.DialogResult);
+    }
+
+    [StaFact]
+    public void CancelCommand_SetsDialogResultFalse()
+    {
+        EnsureApp();
+        var vm = new SeedOptionsViewModel();
+        var window = new Window();
+        vm.CancelCommand.Execute(window);
+        Assert.False(window.IsVisible);
+        Assert.False(window.DialogResult);
+    }
+}

--- a/tests/viewmodels/StatusBarViewModelTests.cs
+++ b/tests/viewmodels/StatusBarViewModelTests.cs
@@ -1,0 +1,24 @@
+using System.Windows;
+using System.Windows.Threading;
+using Xunit;
+using Wrecept.Wpf.ViewModels;
+
+namespace Wrecept.Tests.ViewModels;
+
+public class StatusBarViewModelTests
+{
+    private static void EnsureApp()
+    {
+        if (Application.Current == null)
+            new Application();
+    }
+
+    [StaFact]
+    public void Constructor_StartsTimer()
+    {
+        EnsureApp();
+        var vm = new StatusBarViewModel();
+        Dispatcher.CurrentDispatcher.Invoke(() => { }, DispatcherPriority.ContextIdle);
+        Assert.False(string.IsNullOrWhiteSpace(vm.DateTime));
+    }
+}

--- a/tests/viewmodels/UserInfoViewModelTests.cs
+++ b/tests/viewmodels/UserInfoViewModelTests.cs
@@ -1,0 +1,61 @@
+using System.Threading.Tasks;
+using Xunit;
+using Wrecept.Wpf.ViewModels;
+using Wrecept.Core.Entities;
+using Wrecept.Core.Services;
+
+namespace Wrecept.Tests.ViewModels;
+
+public class UserInfoViewModelTests
+{
+    private class FakeService : IUserInfoService
+    {
+        public UserInfo? Saved;
+        public Task<UserInfo> LoadAsync() => Task.FromResult(new UserInfo
+        {
+            CompanyName = "C",
+            Address = "A",
+            Phone = "P",
+            Email = "E",
+            TaxNumber = "T",
+            BankAccount = "B"
+        });
+        public Task SaveAsync(UserInfo info)
+        {
+            Saved = info;
+            return Task.CompletedTask;
+        }
+    }
+
+    [Fact]
+    public async Task LoadAsync_FillsProperties()
+    {
+        var service = new FakeService();
+        var vm = new UserInfoViewModel(service);
+        await vm.LoadAsync();
+        Assert.Equal("C", vm.CompanyName);
+        Assert.Equal("A", vm.Address);
+        Assert.Equal("P", vm.Phone);
+        Assert.Equal("E", vm.Email);
+        Assert.Equal("T", vm.TaxNumber);
+        Assert.Equal("B", vm.BankAccount);
+    }
+
+    [Fact]
+    public async Task SaveAsync_PassesDataToService()
+    {
+        var service = new FakeService();
+        var vm = new UserInfoViewModel(service)
+        {
+            CompanyName = "X",
+            Address = "Y",
+            Phone = "Z",
+            Email = "E",
+            TaxNumber = "N",
+            BankAccount = "A"
+        };
+        await vm.SaveAsyncCommand.ExecuteAsync(null);
+        Assert.NotNull(service.Saved);
+        Assert.Equal("X", service.Saved!.CompanyName);
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests for multiple prompts and editor viewmodels
- log progress for new tests

## Testing
- `dotnet test --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b5a278624832282323e372edb4617