### PR TITLE
Add missing ViewModel and DI registration tests

### DIFF
--- a/docs/progress/2025-07-07_06-14-19_test_agent.md
+++ b/docs/progress/2025-07-07_06-14-19_test_agent.md
@@ -1,0 +1,1 @@
+- Added unit tests for MasterDataBaseViewModel, PlaceholderViewModel and ensured storage service registrations are verified.

--- a/tests/Wrecept.Tests/AddStorageRegistrationTests.cs
+++ b/tests/Wrecept.Tests/AddStorageRegistrationTests.cs
@@ -1,0 +1,54 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Wrecept.Storage;
+using Wrecept.Storage.Data;
+using Wrecept.Core.Repositories;
+using Wrecept.Core.Services;
+using Xunit;
+
+namespace Wrecept.Tests;
+
+public class AddStorageRegistrationTests
+{
+    [Fact]
+    public async Task All_Storage_Services_Are_Resolvable()
+    {
+        var dbPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".db");
+        var userPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".json");
+        var settingsPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".json");
+
+        var services = new ServiceCollection();
+        await services.AddStorageAsync(dbPath, userPath, settingsPath);
+        using var provider = services.BuildServiceProvider();
+
+        Type[] required =
+        {
+            typeof(IDbContextFactory<AppDbContext>),
+            typeof(IInvoiceRepository),
+            typeof(IProductRepository),
+            typeof(ISupplierRepository),
+            typeof(IPaymentMethodRepository),
+            typeof(IProductGroupRepository),
+            typeof(ITaxRateRepository),
+            typeof(IUnitRepository),
+            typeof(ILogService),
+            typeof(IUserInfoService),
+            typeof(ISettingsService),
+            typeof(ISessionService),
+            typeof(INumberingService),
+            typeof(IBackupService),
+            typeof(IDbHealthService),
+            typeof(WalPragmaInterceptor)
+        };
+
+        foreach (var type in required)
+        {
+            var service = provider.GetService(type);
+            Assert.NotNull(service);
+        }
+    }
+}

--- a/tests/viewmodels/MasterDataBaseViewModelTests.cs
+++ b/tests/viewmodels/MasterDataBaseViewModelTests.cs
@@ -1,0 +1,36 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+using Wrecept.Wpf.ViewModels;
+
+namespace Wrecept.Tests.ViewModels;
+
+public class MasterDataBaseViewModelTests
+{
+    private class FakeVm : MasterDataBaseViewModel<string>
+    {
+        public bool Changed;
+        protected override Task<List<string>> GetItemsAsync()
+            => Task.FromResult(new List<string> { "A", "B" });
+        protected override void SelectedItemChanged(string? value)
+            => Changed = true;
+    }
+
+    [Fact]
+    public async Task LoadAsync_PopulatesItems()
+    {
+        var vm = new FakeVm();
+        await vm.LoadAsync();
+        Assert.Equal(2, vm.Items.Count);
+        Assert.Contains("A", vm.Items);
+        Assert.Contains("B", vm.Items);
+    }
+
+    [Fact]
+    public void SelectedItem_Set_RaisesCallback()
+    {
+        var vm = new FakeVm();
+        vm.SelectedItem = "X";
+        Assert.True(vm.Changed);
+    }
+}

--- a/tests/viewmodels/PlaceholderViewModelTests.cs
+++ b/tests/viewmodels/PlaceholderViewModelTests.cs
@@ -1,0 +1,26 @@
+using System.ComponentModel;
+using Xunit;
+using Wrecept.Wpf.ViewModels;
+
+namespace Wrecept.Tests.ViewModels;
+
+public class PlaceholderViewModelTests
+{
+    [Fact]
+    public void Default_Message_Is_Set()
+    {
+        var vm = new PlaceholderViewModel();
+        Assert.Equal("Funkció fejlesztés alatt", vm.Message);
+    }
+
+    [Fact]
+    public void Setting_Message_Raises_PropertyChanged()
+    {
+        var vm = new PlaceholderViewModel();
+        bool raised = false;
+        vm.PropertyChanged += (_, e) => { if (e.PropertyName == nameof(vm.Message)) raised = true; };
+        vm.Message = "Hello";
+        Assert.True(raised);
+        Assert.Equal("Hello", vm.Message);
+    }
+}


### PR DESCRIPTION
## Summary
- test `MasterDataBaseViewModel` basic loading and callback behavior
- add `PlaceholderViewModel` unit tests
- verify all services registered by `AddStorageAsync`
- log progress

## Testing
- `dotnet test --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b60cbf7588322864c3c4ad606a450