### PR TITLE
Add startup and edge case tests with coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,5 +20,6 @@ jobs:
         run: dotnet build Wrecept.sln --no-restore
       - name: Test
         run: |
-          dotnet test Wrecept.Core.Tests/Wrecept.Core.Tests.csproj --no-build
-          dotnet test tests/Wrecept.Tests/Wrecept.Tests.csproj --no-build
+          dotnet test Wrecept.Core.Tests/Wrecept.Core.Tests.csproj --no-build --collect:"XPlat Code Coverage"
+          dotnet test tests/Wrecept.Tests/Wrecept.Tests.csproj --no-build --collect:"XPlat Code Coverage"
+          dotnet test tests/Wrecept.Storage.Tests/Wrecept.Storage.Tests.csproj --no-build --collect:"XPlat Code Coverage"

--- a/Wrecept.Core.Tests/Services/InvoiceServiceTests.cs
+++ b/Wrecept.Core.Tests/Services/InvoiceServiceTests.cs
@@ -49,6 +49,42 @@ public class InvoiceServiceTests
     }
 
     [Fact]
+    public async Task CreateAsync_ReturnsFalse_WhenNumberEmpty()
+    {
+        var repo = new FakeInvoiceRepository();
+        var service = new InvoiceService(repo, new InvoiceCalculator());
+        var invoice = new Invoice { Number = "", SupplierId = 1 };
+        invoice.Items.Add(new InvoiceItem { ProductId = 1, Quantity = 1, UnitPrice = 10, TaxRate = new TaxRate { Id = Guid.NewGuid(), Percentage = 27 } });
+
+        var result = await service.CreateAsync(invoice);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task CreateAsync_ReturnsFalse_WhenItemMissingProductOrTax()
+    {
+        var repo = new FakeInvoiceRepository();
+        var service = new InvoiceService(repo, new InvoiceCalculator());
+        var invoice = new Invoice { Number = "INV1", SupplierId = 1 };
+        invoice.Items.Add(new InvoiceItem { Quantity = 1, UnitPrice = 10 });
+
+        var result = await service.CreateAsync(invoice);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task AddItemAsync_Throws_OnInvalidIds()
+    {
+        var repo = new FakeInvoiceRepository();
+        var service = new InvoiceService(repo, new InvoiceCalculator());
+        var item = new InvoiceItem { InvoiceId = 0, ProductId = 0, Quantity = 1, UnitPrice = 10 };
+
+        await Assert.ThrowsAsync<ArgumentException>(() => service.AddItemAsync(item));
+    }
+
+    [Fact]
     public async Task CreateAsync_Allows_Negative_Quantity()
     {
         var repo = new FakeInvoiceRepository();

--- a/Wrecept.Core.Tests/Services/NumberingServiceTests.cs
+++ b/Wrecept.Core.Tests/Services/NumberingServiceTests.cs
@@ -26,6 +26,19 @@ public class NumberingServiceTests : IDisposable
         Assert.Equal("INV2", second);
     }
 
+    [Fact]
+    public async Task ReturnsInv1_WhenFileCorrupted()
+    {
+        await File.WriteAllTextAsync(_file, "abc");
+        var svc = new NumberingService(_file);
+
+        var result = await svc.GetNextInvoiceNumberAsync();
+
+        Assert.Equal("INV1", result);
+        var text = await File.ReadAllTextAsync(_file);
+        Assert.Equal("1", text);
+    }
+
     public void Dispose()
     {
         if (File.Exists(_file))

--- a/Wrecept.Core.Tests/Wrecept.Core.Tests.csproj
+++ b/Wrecept.Core.Tests/Wrecept.Core.Tests.csproj
@@ -4,11 +4,13 @@
     <IsPackable>false</IsPackable>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <Threshold>100</Threshold>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="xunit" Version="2.5.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\tests\Wrecept.Core.Tests\*.cs" />

--- a/docs/TEST_STRATEGY.md
+++ b/docs/TEST_STRATEGY.md
@@ -2,7 +2,7 @@
 title: "Testing Strategy"
 purpose: "Unit, integration and UI testing principles"
 author: "docs_agent"
-date: "2025-06-27"
+date: "2025-07-07"
 ---
 
 # 🧪 Testing Strategy
@@ -27,6 +27,9 @@ A Wrecept stabilitását több szinten biztosítjuk.
 
 * Minimum 100% kódfedettségre törekszünk. A Core és ViewModel rétegek kritikus útvonalait teljesen lefedjük.
 * A tesztek minden commit után futnak GitHub Actions alatt (`dotnet test`). Ha bármely teszt megbukik, a build elutasításra kerül.
+* Kódfedettséget a `dotnet test --collect:"XPlat Code Coverage"` paranccsal mérünk.
+  A CI szintén ezt használja, és a projektfájlokban szereplő `<Threshold>100</Threshold>`
+  beállítás miatt bármilyen visszaesés hibát eredményez.
 
 *Megjegyzés: a `wrecept.db` néven szereplő adatbázis csak a migrációk tervezési szakaszában használatos.*
 

--- a/docs/progress/2025-07-07_06-39-02_test_agent.md
+++ b/docs/progress/2025-07-07_06-39-02_test_agent.md
@@ -1,0 +1,4 @@
+- Added AppStartupTests for LoadSettingsAsync success and error branches.
+- Extended InvoiceServiceTests and NumberingServiceTests with edge cases.
+- Enabled coverage collection in CI and set <Threshold> to 100.
+- Documented coverage steps in TEST_STRATEGY.md.

--- a/tests/Wrecept.Storage.Tests/Wrecept.Storage.Tests.csproj
+++ b/tests/Wrecept.Storage.Tests/Wrecept.Storage.Tests.csproj
@@ -4,12 +4,14 @@
     <IsPackable>false</IsPackable>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <Threshold>100</Threshold>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="xunit" Version="2.5.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.6" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Wrecept.Storage\Wrecept.Storage.csproj" />

--- a/tests/Wrecept.Tests/AppStartupTests.cs
+++ b/tests/Wrecept.Tests/AppStartupTests.cs
@@ -1,0 +1,67 @@
+using System;
+using System.IO;
+using System.Reflection;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Xunit;
+using Wrecept.Wpf;
+using Wrecept.Core.Entities;
+
+namespace Wrecept.Tests;
+
+public class AppStartupTests
+{
+    private static async Task<AppSettings> InvokeLoadAsync()
+    {
+        var method = typeof(App).GetMethod("LoadSettingsAsync", BindingFlags.NonPublic | BindingFlags.Static)!;
+        return await (Task<AppSettings>)method.Invoke(null, null)!;
+    }
+
+    [StaFact]
+    public async Task LoadSettingsAsync_Returns_Settings_FromJson()
+    {
+        var temp = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Environment.SetEnvironmentVariable("APPDATA", temp);
+        Directory.CreateDirectory(Path.Combine(temp, "Wrecept"));
+        var file = Path.Combine(temp, "Wrecept", "settings.json");
+        var expected = new AppSettings { DatabasePath = "db", UserInfoPath = "user" };
+        await File.WriteAllTextAsync(file, JsonSerializer.Serialize(expected));
+
+        try
+        {
+            var settings = await InvokeLoadAsync();
+            Assert.Equal(expected.DatabasePath, settings.DatabasePath);
+            Assert.Equal(expected.UserInfoPath, settings.UserInfoPath);
+        }
+        finally
+        {
+            Directory.Delete(temp, true);
+            Environment.SetEnvironmentVariable("APPDATA", null);
+        }
+    }
+
+    [StaFact]
+    public async Task LoadSettingsAsync_Returns_Default_OnInvalidJson()
+    {
+        var temp = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Environment.SetEnvironmentVariable("APPDATA", temp);
+        Directory.CreateDirectory(Path.Combine(temp, "Wrecept"));
+        var file = Path.Combine(temp, "Wrecept", "settings.json");
+        await File.WriteAllTextAsync(file, "{ invalid }");
+
+        try
+        {
+            var settings = await InvokeLoadAsync();
+            Assert.Equal(string.Empty, settings.DatabasePath);
+            Assert.Equal(string.Empty, settings.UserInfoPath);
+            var logDir = Path.Combine(temp, "Wrecept", "logs");
+            Assert.True(Directory.Exists(logDir));
+            Assert.NotEmpty(Directory.GetFiles(logDir));
+        }
+        finally
+        {
+            Directory.Delete(temp, true);
+            Environment.SetEnvironmentVariable("APPDATA", null);
+        }
+    }
+}

--- a/tests/Wrecept.Tests/Wrecept.Tests.csproj
+++ b/tests/Wrecept.Tests/Wrecept.Tests.csproj
@@ -4,12 +4,14 @@
     <IsPackable>false</IsPackable>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <Threshold>100</Threshold>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="xunit" Version="2.5.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="Xunit.StaFact" Version="2.1.7" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Wrecept.Wpf\Wrecept.Wpf.csproj" />


### PR DESCRIPTION
## Summary
- test loading AppSettings from JSON and error case
- cover InvoiceService and NumberingService edge cases
- collect coverage in CI and enforce 100% threshold
- document coverage process

## Testing
- `dotnet test Wrecept.Core.Tests/Wrecept.Core.Tests.csproj --collect:"XPlat Code Coverage"`
- `dotnet test tests/Wrecept.Storage.Tests/Wrecept.Storage.Tests.csproj --collect:"XPlat Code Coverage"`
- `dotnet test tests/Wrecept.Tests/Wrecept.Tests.csproj --collect:"XPlat Code Coverage"` *(fails: Project Wrecept.Wpf is not compatible with net8.0)*

------
https://chatgpt.com/codex/tasks/task_e_686b67e56ffc832298df63ffac5905a2