### PR TITLE
Add TaxRate service tests

### DIFF
--- a/Wrecept.Core.Tests/Services/TaxRateServiceTests.cs
+++ b/Wrecept.Core.Tests/Services/TaxRateServiceTests.cs
@@ -1,0 +1,85 @@
+using Wrecept.Core.Models;
+using Wrecept.Core.Repositories;
+using Wrecept.Core.Services;
+using Xunit;
+
+namespace Wrecept.Core.Tests.Services;
+
+public class TaxRateServiceTests
+{
+    private sealed class FakeRepo : ITaxRateRepository
+    {
+        public TaxRate? Added;
+        public TaxRate? Updated;
+        public Task<List<TaxRate>> GetAllAsync(CancellationToken ct = default) => Task.FromResult(new List<TaxRate>());
+        public Task<List<TaxRate>> GetActiveAsync(DateTime asOf, CancellationToken ct = default) => Task.FromResult(new List<TaxRate>());
+        public Task<Guid> AddAsync(TaxRate rate, CancellationToken ct = default)
+        {
+            Added = rate;
+            return Task.FromResult(Guid.NewGuid());
+        }
+        public Task UpdateAsync(TaxRate rate, CancellationToken ct = default)
+        {
+            Updated = rate;
+            return Task.CompletedTask;
+        }
+    }
+
+    [Fact]
+    public async Task AddAsync_SetsDates()
+    {
+        var repo = new FakeRepo();
+        var svc = new TaxRateService(repo);
+        var rate = new TaxRate { Name = "ÁFA", Percentage = 27 };
+        var before = DateTime.UtcNow;
+
+        await svc.AddAsync(rate);
+
+        Assert.NotNull(repo.Added);
+        Assert.True(repo.Added!.CreatedAt >= before);
+        Assert.True(repo.Added.UpdatedAt >= before);
+    }
+
+    [Fact]
+    public async Task AddAsync_Throws_WhenNameMissing()
+    {
+        var repo = new FakeRepo();
+        var svc = new TaxRateService(repo);
+
+        await Assert.ThrowsAsync<ArgumentException>(() => svc.AddAsync(new TaxRate()));
+    }
+
+    [Fact]
+    public async Task UpdateAsync_SetsUpdatedAt()
+    {
+        var repo = new FakeRepo();
+        var svc = new TaxRateService(repo);
+        var rate = new TaxRate { Id = Guid.NewGuid(), Name = "ÁFA", Percentage = 27 };
+        var before = DateTime.UtcNow;
+
+        await svc.UpdateAsync(rate);
+
+        Assert.NotNull(repo.Updated);
+        Assert.True(repo.Updated!.UpdatedAt >= before);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_Throws_WhenIdInvalid()
+    {
+        var repo = new FakeRepo();
+        var svc = new TaxRateService(repo);
+        var rate = new TaxRate { Name = "ÁFA", Percentage = 27 };
+
+        await Assert.ThrowsAsync<ArgumentException>(() => svc.UpdateAsync(rate));
+    }
+
+    [Fact]
+    public async Task UpdateAsync_Throws_WhenNameMissing()
+    {
+        var repo = new FakeRepo();
+        var svc = new TaxRateService(repo);
+        var rate = new TaxRate { Id = Guid.NewGuid() };
+
+        await Assert.ThrowsAsync<ArgumentException>(() => svc.UpdateAsync(rate));
+    }
+}

--- a/docs/progress/2025-07-07_07-01-24_test_agent.md
+++ b/docs/progress/2025-07-07_07-01-24_test_agent.md
@@ -1,0 +1,1 @@
+- Added TaxRateServiceTests covering AddAsync and UpdateAsync validation.


### PR DESCRIPTION
## Summary
- add unit tests for `TaxRateService` covering validation and timestamps
- log progress for the test addition

## Testing
- `dotnet test Wrecept.Core.Tests/Wrecept.Core.Tests.csproj --no-build`
- `dotnet test tests/Wrecept.Storage.Tests/Wrecept.Storage.Tests.csproj --no-build`


------
https://chatgpt.com/codex/tasks/task_e_686b6f3b5fe083229bdabf7d93e0a5ee