### PR TITLE
Add unit tests for core services and utilities

### DIFF
--- a/docs/progress/2025-07-07_07-34-38_test_agent.md
+++ b/docs/progress/2025-07-07_07-34-38_test_agent.md
@@ -1,0 +1,2 @@
+- Added unit tests covering service layer methods and helper classes.
+- Verified Null services behavior and InvoiceCalculator error handling.

--- a/tests/Wrecept.Core.Tests/InvoiceCalculatorTests.cs
+++ b/tests/Wrecept.Core.Tests/InvoiceCalculatorTests.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+using Wrecept.Core.Models;
+using Wrecept.Core.Services;
+using Xunit;
+
+namespace Wrecept.Core.Tests;
+
+public class InvoiceCalculatorTests
+{
+    [Fact]
+    public void Calculate_ComputesTotals()
+    {
+        var rate27 = new TaxRate { Id = Guid.NewGuid(), Percentage = 27 };
+        var rate0 = new TaxRate { Id = Guid.NewGuid(), Percentage = 0 };
+        var invoice = new Invoice
+        {
+            Items = new List<InvoiceItem>
+            {
+                new() { Quantity = 2, UnitPrice = 100m, TaxRate = rate27 },
+                new() { Quantity = 1, UnitPrice = 50m, TaxRate = rate0 }
+            }
+        };
+        var calc = new InvoiceCalculator();
+
+        var result = calc.Calculate(invoice);
+
+        Assert.Equal(250m, result.TotalNet);
+        Assert.Equal(54m, result.TotalTax);
+        Assert.Equal(304m, result.TotalGross);
+        Assert.Equal(200m, result.PerTaxRateBreakdown[rate27.Id].Net);
+        Assert.Equal(54m, result.PerTaxRateBreakdown[rate27.Id].Tax);
+        Assert.Equal(254m, result.PerTaxRateBreakdown[rate27.Id].Gross);
+        Assert.Equal(50m, result.PerTaxRateBreakdown[rate0.Id].Gross);
+    }
+
+    [Fact]
+    public void Calculate_MissingTaxRate_Throws()
+    {
+        var invoice = new Invoice
+        {
+            Items = new List<InvoiceItem>
+            {
+                new() { Quantity = 1, UnitPrice = 10m }
+            }
+        };
+        var calc = new InvoiceCalculator();
+
+        Assert.Throws<InvalidOperationException>(() => calc.Calculate(invoice));
+    }
+}

--- a/tests/Wrecept.Core.Tests/InvoiceServiceTests.cs
+++ b/tests/Wrecept.Core.Tests/InvoiceServiceTests.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Wrecept.Core.Models;
+using Wrecept.Core.Repositories;
+using Wrecept.Core.Services;
+using Xunit;
+
+namespace Wrecept.Core.Tests;
+
+public class InvoiceServiceTests
+{
+    private class FakeRepo : IInvoiceRepository
+    {
+        public Invoice? AddedInvoice;
+        public InvoiceItem? AddedItem;
+        public Task<int> AddAsync(Invoice invoice, CancellationToken ct = default) { AddedInvoice = invoice; return Task.FromResult(1); }
+        public Task<int> AddItemAsync(InvoiceItem item, CancellationToken ct = default) { AddedItem = item; return Task.FromResult(1); }
+        public Task UpdateHeaderAsync(int id, DateOnly date, DateOnly dueDate, int supplierId, Guid paymentMethodId, bool isGross, CancellationToken ct = default) => Task.CompletedTask;
+        public Task SetArchivedAsync(int id, bool isArchived, CancellationToken ct = default) => Task.CompletedTask;
+        public Task<Invoice?> GetAsync(int id, CancellationToken ct = default) => Task.FromResult<Invoice?>(null);
+        public Task<List<Invoice>> GetRecentAsync(int count, CancellationToken ct = default) => Task.FromResult(new List<Invoice>());
+        public Task<LastUsageData?> GetLastUsageDataAsync(int supplierId, int productId, CancellationToken ct = default) => Task.FromResult<LastUsageData?>(null);
+        public Task<Dictionary<int, LastUsageData>> GetLastUsageDataBatchAsync(int supplierId, IEnumerable<int> productIds, CancellationToken ct = default) => Task.FromResult(new Dictionary<int, LastUsageData>());
+    }
+
+    [Fact]
+    public async Task CreateAsync_ValidInvoice_SetsDates()
+    {
+        var repo = new FakeRepo();
+        var svc = new InvoiceService(repo, new InvoiceCalculator());
+        var rate = new TaxRate { Id = Guid.NewGuid(), Percentage = 27 };
+        var invoice = new Invoice
+        {
+            Number = "I1",
+            Date = new DateOnly(2024,1,1),
+            SupplierId = 1,
+            PaymentMethod = new PaymentMethod { Id = Guid.NewGuid(), DueInDays = 5 },
+            Items = new List<InvoiceItem>
+            {
+                new() { ProductId = 1, Quantity = 1, UnitPrice = 100m, TaxRate = rate }
+            }
+        };
+
+        var ok = await svc.CreateAsync(invoice);
+
+        Assert.True(ok);
+        Assert.Equal(invoice, repo.AddedInvoice);
+        Assert.NotEqual(DateTime.MinValue, invoice.CreatedAt);
+        Assert.NotEqual(DateTime.MinValue, invoice.Items.First().CreatedAt);
+        Assert.Equal(invoice.Date.AddDays(5), invoice.DueDate);
+    }
+
+    [Fact]
+    public async Task CreateAsync_Invalid_ReturnsFalse()
+    {
+        var repo = new FakeRepo();
+        var svc = new InvoiceService(repo, new InvoiceCalculator());
+        var invoice = new Invoice();
+
+        var ok = await svc.CreateAsync(invoice);
+
+        Assert.False(ok);
+        Assert.Null(repo.AddedInvoice);
+    }
+
+    [Fact]
+    public async Task AddItemAsync_SetsTimestamps()
+    {
+        var repo = new FakeRepo();
+        var svc = new InvoiceService(repo, new InvoiceCalculator());
+        var item = new InvoiceItem { InvoiceId = 1, ProductId = 2, UnitPrice = 10m, Quantity = 1, TaxRate = new TaxRate { Id = Guid.NewGuid(), Percentage = 5 }, CreatedAt = DateTime.MinValue, UpdatedAt = DateTime.MinValue };
+
+        await svc.AddItemAsync(item);
+
+        Assert.Equal(item, repo.AddedItem);
+        Assert.NotEqual(DateTime.MinValue, repo.AddedItem!.CreatedAt);
+        Assert.NotEqual(DateTime.MinValue, repo.AddedItem!.UpdatedAt);
+    }
+
+    [Fact]
+    public async Task AddItemAsync_Invalid_Throws()
+    {
+        var svc = new InvoiceService(new FakeRepo(), new InvoiceCalculator());
+        var item = new InvoiceItem { InvoiceId = 0, ProductId = 0 };
+        await Assert.ThrowsAsync<ArgumentException>(() => svc.AddItemAsync(item));
+    }
+}

--- a/tests/Wrecept.Core.Tests/NullLogServiceTests.cs
+++ b/tests/Wrecept.Core.Tests/NullLogServiceTests.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Threading.Tasks;
+using Wrecept.Core.Services;
+using Xunit;
+
+namespace Wrecept.Core.Tests;
+
+public class NullLogServiceTests
+{
+    [Fact]
+    public async Task LogError_DoesNothing()
+    {
+        var service = new NullLogService();
+
+        var task = service.LogError("err", new Exception());
+
+        await task;
+        Assert.True(task.IsCompleted);
+    }
+}

--- a/tests/Wrecept.Core.Tests/NullNumberingServiceTests.cs
+++ b/tests/Wrecept.Core.Tests/NullNumberingServiceTests.cs
@@ -1,0 +1,18 @@
+using System.Threading.Tasks;
+using Wrecept.Core.Services;
+using Xunit;
+
+namespace Wrecept.Core.Tests;
+
+public class NullNumberingServiceTests
+{
+    [Fact]
+    public async Task GetNextInvoiceNumberAsync_ReturnsEmpty()
+    {
+        var service = new NullNumberingService();
+
+        var result = await service.GetNextInvoiceNumberAsync();
+
+        Assert.Equal(string.Empty, result);
+    }
+}

--- a/tests/Wrecept.Core.Tests/NumberToWordsConverterTests.cs
+++ b/tests/Wrecept.Core.Tests/NumberToWordsConverterTests.cs
@@ -1,0 +1,16 @@
+using Wrecept.Core.Utilities;
+using Xunit;
+
+namespace Wrecept.Core.Tests;
+
+public class NumberToWordsConverterTests
+{
+    [Theory]
+    [InlineData(0, "nulla")]
+    [InlineData(-5, "mínusz öt")]
+    [InlineData(1000000, "egy millió")]
+    public void Convert_ReturnsExpected(long value, string expected)
+    {
+        Assert.Equal(expected, NumberToWordsConverter.Convert(value));
+    }
+}

--- a/tests/Wrecept.Core.Tests/PaymentMethodServiceTests.cs
+++ b/tests/Wrecept.Core.Tests/PaymentMethodServiceTests.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Wrecept.Core.Models;
+using Wrecept.Core.Repositories;
+using Wrecept.Core.Services;
+using Xunit;
+
+namespace Wrecept.Core.Tests;
+
+public class PaymentMethodServiceTests
+{
+    private class FakeRepo : IPaymentMethodRepository
+    {
+        public PaymentMethod? Added;
+        public PaymentMethod? Updated;
+        public Task<List<PaymentMethod>> GetAllAsync(CancellationToken ct = default) => Task.FromResult(new List<PaymentMethod>());
+        public Task<List<PaymentMethod>> GetActiveAsync(CancellationToken ct = default) => Task.FromResult(new List<PaymentMethod>());
+        public Task<Guid> AddAsync(PaymentMethod method, CancellationToken ct = default) { Added = method; return Task.FromResult(Guid.NewGuid()); }
+        public Task UpdateAsync(PaymentMethod method, CancellationToken ct = default) { Updated = method; return Task.CompletedTask; }
+    }
+
+    [Fact]
+    public async Task AddAsync_SetsTimestamps()
+    {
+        var repo = new FakeRepo();
+        var svc = new PaymentMethodService(repo);
+        var method = new PaymentMethod { Name = "m", CreatedAt = DateTime.MinValue, UpdatedAt = DateTime.MinValue };
+
+        await svc.AddAsync(method);
+
+        Assert.Equal(method, repo.Added);
+        Assert.NotEqual(DateTime.MinValue, repo.Added!.CreatedAt);
+        Assert.NotEqual(DateTime.MinValue, repo.Added!.UpdatedAt);
+    }
+
+    [Fact]
+    public async Task AddAsync_InvalidName_Throws()
+    {
+        var svc = new PaymentMethodService(new FakeRepo());
+        var m = new PaymentMethod { DueInDays = 1 };
+        await Assert.ThrowsAsync<ArgumentException>(() => svc.AddAsync(m));
+    }
+
+    [Fact]
+    public async Task AddAsync_NegativeDue_Throws()
+    {
+        var svc = new PaymentMethodService(new FakeRepo());
+        var m = new PaymentMethod { Name = "x", DueInDays = -1 };
+        await Assert.ThrowsAsync<ArgumentException>(() => svc.AddAsync(m));
+    }
+
+    [Fact]
+    public async Task UpdateAsync_SetsTimestamp()
+    {
+        var repo = new FakeRepo();
+        var svc = new PaymentMethodService(repo);
+        var m = new PaymentMethod { Id = Guid.NewGuid(), Name = "x", UpdatedAt = DateTime.MinValue };
+
+        await svc.UpdateAsync(m);
+
+        Assert.Equal(m, repo.Updated);
+        Assert.NotEqual(DateTime.MinValue, repo.Updated!.UpdatedAt);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_InvalidId_Throws()
+    {
+        var svc = new PaymentMethodService(new FakeRepo());
+        var m = new PaymentMethod { Id = Guid.Empty, Name = "x" };
+        await Assert.ThrowsAsync<ArgumentException>(() => svc.UpdateAsync(m));
+    }
+}

--- a/tests/Wrecept.Core.Tests/ProductGroupServiceTests.cs
+++ b/tests/Wrecept.Core.Tests/ProductGroupServiceTests.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Wrecept.Core.Models;
+using Wrecept.Core.Repositories;
+using Wrecept.Core.Services;
+using Xunit;
+
+namespace Wrecept.Core.Tests;
+
+public class ProductGroupServiceTests
+{
+    private class FakeRepo : IProductGroupRepository
+    {
+        public ProductGroup? Added;
+        public ProductGroup? Updated;
+        public Task<List<ProductGroup>> GetAllAsync(CancellationToken ct = default) => Task.FromResult(new List<ProductGroup>());
+        public Task<List<ProductGroup>> GetActiveAsync(CancellationToken ct = default) => Task.FromResult(new List<ProductGroup>());
+        public Task<Guid> AddAsync(ProductGroup group, CancellationToken ct = default) { Added = group; return Task.FromResult(Guid.NewGuid()); }
+        public Task UpdateAsync(ProductGroup group, CancellationToken ct = default) { Updated = group; return Task.CompletedTask; }
+    }
+
+    [Fact]
+    public async Task AddAsync_SetsTimestamps()
+    {
+        var repo = new FakeRepo();
+        var svc = new ProductGroupService(repo);
+        var group = new ProductGroup { Name = "g", CreatedAt = DateTime.MinValue, UpdatedAt = DateTime.MinValue };
+
+        await svc.AddAsync(group);
+
+        Assert.Equal(group, repo.Added);
+        Assert.NotEqual(DateTime.MinValue, repo.Added!.CreatedAt);
+        Assert.NotEqual(DateTime.MinValue, repo.Added!.UpdatedAt);
+    }
+
+    [Fact]
+    public async Task AddAsync_InvalidName_Throws()
+    {
+        var svc = new ProductGroupService(new FakeRepo());
+        await Assert.ThrowsAsync<ArgumentException>(() => svc.AddAsync(new ProductGroup()));
+    }
+
+    [Fact]
+    public async Task UpdateAsync_SetsTimestamp()
+    {
+        var repo = new FakeRepo();
+        var svc = new ProductGroupService(repo);
+        var group = new ProductGroup { Id = Guid.NewGuid(), Name = "g", UpdatedAt = DateTime.MinValue };
+
+        await svc.UpdateAsync(group);
+
+        Assert.Equal(group, repo.Updated);
+        Assert.NotEqual(DateTime.MinValue, repo.Updated!.UpdatedAt);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_InvalidId_Throws()
+    {
+        var svc = new ProductGroupService(new FakeRepo());
+        var group = new ProductGroup { Id = Guid.Empty, Name = "g" };
+        await Assert.ThrowsAsync<ArgumentException>(() => svc.UpdateAsync(group));
+    }
+}

--- a/tests/Wrecept.Core.Tests/ProductServiceTests.cs
+++ b/tests/Wrecept.Core.Tests/ProductServiceTests.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Wrecept.Core.Models;
+using Wrecept.Core.Repositories;
+using Wrecept.Core.Services;
+using Xunit;
+
+namespace Wrecept.Core.Tests;
+
+public class ProductServiceTests
+{
+    private class FakeRepo : IProductRepository
+    {
+        public Product? Added;
+        public Product? Updated;
+        public Task<List<Product>> GetAllAsync(CancellationToken ct = default) => Task.FromResult(new List<Product>());
+        public Task<List<Product>> GetActiveAsync(CancellationToken ct = default) => Task.FromResult(new List<Product>());
+        public Task<int> AddAsync(Product product, CancellationToken ct = default) { Added = product; return Task.FromResult(1); }
+        public Task UpdateAsync(Product product, CancellationToken ct = default) { Updated = product; return Task.CompletedTask; }
+    }
+
+    [Fact]
+    public async Task AddAsync_SetsTimestamps()
+    {
+        var repo = new FakeRepo();
+        var svc = new ProductService(repo);
+        var product = new Product { Name = "p", Net = 1m, Gross = 1m, CreatedAt = DateTime.MinValue, UpdatedAt = DateTime.MinValue };
+
+        await svc.AddAsync(product);
+
+        Assert.Equal(product, repo.Added);
+        Assert.NotEqual(DateTime.MinValue, repo.Added!.CreatedAt);
+        Assert.NotEqual(DateTime.MinValue, repo.Added!.UpdatedAt);
+    }
+
+    [Fact]
+    public async Task AddAsync_InvalidName_Throws()
+    {
+        var svc = new ProductService(new FakeRepo());
+        await Assert.ThrowsAsync<ArgumentException>(() => svc.AddAsync(new Product { Net = 1, Gross = 1 }));
+    }
+
+    [Fact]
+    public async Task AddAsync_NegativePrice_Throws()
+    {
+        var svc = new ProductService(new FakeRepo());
+        var p = new Product { Name = "x", Net = -1m, Gross = 1m };
+        await Assert.ThrowsAsync<ArgumentException>(() => svc.AddAsync(p));
+    }
+
+    [Fact]
+    public async Task UpdateAsync_SetsTimestamp()
+    {
+        var repo = new FakeRepo();
+        var svc = new ProductService(repo);
+        var p = new Product { Id = 1, Name = "p", Net = 1m, Gross = 1m, UpdatedAt = DateTime.MinValue };
+
+        await svc.UpdateAsync(p);
+
+        Assert.Equal(p, repo.Updated);
+        Assert.NotEqual(DateTime.MinValue, repo.Updated!.UpdatedAt);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_InvalidId_Throws()
+    {
+        var svc = new ProductService(new FakeRepo());
+        var p = new Product { Id = 0, Name = "p", Net = 1m, Gross = 1m };
+        await Assert.ThrowsAsync<ArgumentException>(() => svc.UpdateAsync(p));
+    }
+}

--- a/tests/Wrecept.Core.Tests/SimpleMathTests.cs
+++ b/tests/Wrecept.Core.Tests/SimpleMathTests.cs
@@ -1,0 +1,13 @@
+using Wrecept.Core.Utilities;
+using Xunit;
+
+namespace Wrecept.Core.Tests;
+
+public class SimpleMathTests
+{
+    [Fact]
+    public void Multiply_ReturnsProduct()
+    {
+        Assert.Equal(12, SimpleMath.Multiply(3, 4));
+    }
+}

--- a/tests/Wrecept.Core.Tests/SupplierServiceTests.cs
+++ b/tests/Wrecept.Core.Tests/SupplierServiceTests.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Wrecept.Core.Models;
+using Wrecept.Core.Repositories;
+using Wrecept.Core.Services;
+using Xunit;
+
+namespace Wrecept.Core.Tests;
+
+public class SupplierServiceTests
+{
+    private class FakeRepo : ISupplierRepository
+    {
+        public Supplier? Added;
+        public Supplier? Updated;
+        public Task<List<Supplier>> GetAllAsync(CancellationToken ct = default) => Task.FromResult(new List<Supplier>());
+        public Task<List<Supplier>> GetActiveAsync(CancellationToken ct = default) => Task.FromResult(new List<Supplier>());
+        public Task<int> AddAsync(Supplier supplier, CancellationToken ct = default) { Added = supplier; return Task.FromResult(1); }
+        public Task UpdateAsync(Supplier supplier, CancellationToken ct = default) { Updated = supplier; return Task.CompletedTask; }
+    }
+
+    [Fact]
+    public async Task AddAsync_SetsTimestamps()
+    {
+        var repo = new FakeRepo();
+        var svc = new SupplierService(repo);
+        var sup = new Supplier { Name = "s", CreatedAt = DateTime.MinValue, UpdatedAt = DateTime.MinValue };
+
+        await svc.AddAsync(sup);
+
+        Assert.Equal(sup, repo.Added);
+        Assert.NotEqual(DateTime.MinValue, repo.Added!.CreatedAt);
+        Assert.NotEqual(DateTime.MinValue, repo.Added!.UpdatedAt);
+    }
+
+    [Fact]
+    public async Task AddAsync_InvalidName_Throws()
+    {
+        var svc = new SupplierService(new FakeRepo());
+        await Assert.ThrowsAsync<ArgumentException>(() => svc.AddAsync(new Supplier()));
+    }
+
+    [Fact]
+    public async Task UpdateAsync_SetsTimestamp()
+    {
+        var repo = new FakeRepo();
+        var svc = new SupplierService(repo);
+        var sup = new Supplier { Id = 1, Name = "s", UpdatedAt = DateTime.MinValue };
+
+        await svc.UpdateAsync(sup);
+
+        Assert.Equal(sup, repo.Updated);
+        Assert.NotEqual(DateTime.MinValue, repo.Updated!.UpdatedAt);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_InvalidId_Throws()
+    {
+        var svc = new SupplierService(new FakeRepo());
+        var sup = new Supplier { Id = 0, Name = "s" };
+        await Assert.ThrowsAsync<ArgumentException>(() => svc.UpdateAsync(sup));
+    }
+}

--- a/tests/Wrecept.Core.Tests/TaxRateServiceTests.cs
+++ b/tests/Wrecept.Core.Tests/TaxRateServiceTests.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Wrecept.Core.Models;
+using Wrecept.Core.Repositories;
+using Wrecept.Core.Services;
+using Xunit;
+
+namespace Wrecept.Core.Tests;
+
+public class TaxRateServiceTests
+{
+    private class FakeRepo : ITaxRateRepository
+    {
+        public TaxRate? Added;
+        public TaxRate? Updated;
+        public Task<List<TaxRate>> GetAllAsync(CancellationToken ct = default) => Task.FromResult(new List<TaxRate>());
+        public Task<List<TaxRate>> GetActiveAsync(DateTime asOf, CancellationToken ct = default) => Task.FromResult(new List<TaxRate>());
+        public Task<Guid> AddAsync(TaxRate taxRate, CancellationToken ct = default) { Added = taxRate; return Task.FromResult(Guid.NewGuid()); }
+        public Task UpdateAsync(TaxRate taxRate, CancellationToken ct = default) { Updated = taxRate; return Task.CompletedTask; }
+    }
+
+    [Fact]
+    public async Task AddAsync_SetsTimestamps()
+    {
+        var repo = new FakeRepo();
+        var svc = new TaxRateService(repo);
+        var rate = new TaxRate { Name = "t", CreatedAt = DateTime.MinValue, UpdatedAt = DateTime.MinValue };
+
+        await svc.AddAsync(rate);
+
+        Assert.Equal(rate, repo.Added);
+        Assert.NotEqual(DateTime.MinValue, repo.Added!.CreatedAt);
+        Assert.NotEqual(DateTime.MinValue, repo.Added!.UpdatedAt);
+    }
+
+    [Fact]
+    public async Task AddAsync_InvalidName_Throws()
+    {
+        var svc = new TaxRateService(new FakeRepo());
+        await Assert.ThrowsAsync<ArgumentException>(() => svc.AddAsync(new TaxRate()));
+    }
+
+    [Fact]
+    public async Task UpdateAsync_SetsTimestamp()
+    {
+        var repo = new FakeRepo();
+        var svc = new TaxRateService(repo);
+        var rate = new TaxRate { Id = Guid.NewGuid(), Name = "t", UpdatedAt = DateTime.MinValue };
+
+        await svc.UpdateAsync(rate);
+
+        Assert.Equal(rate, repo.Updated);
+        Assert.NotEqual(DateTime.MinValue, repo.Updated!.UpdatedAt);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_InvalidId_Throws()
+    {
+        var svc = new TaxRateService(new FakeRepo());
+        var rate = new TaxRate { Id = Guid.Empty, Name = "t" };
+        await Assert.ThrowsAsync<ArgumentException>(() => svc.UpdateAsync(rate));
+    }
+}

--- a/tests/Wrecept.Core.Tests/UnitServiceTests.cs
+++ b/tests/Wrecept.Core.Tests/UnitServiceTests.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Wrecept.Core.Models;
+using Wrecept.Core.Repositories;
+using Wrecept.Core.Services;
+using Xunit;
+
+namespace Wrecept.Core.Tests;
+
+public class UnitServiceTests
+{
+    private class FakeRepo : IUnitRepository
+    {
+        public Unit? Added;
+        public Unit? Updated;
+        public Task<List<Unit>> GetAllAsync(CancellationToken ct = default) => Task.FromResult(new List<Unit>());
+        public Task<List<Unit>> GetActiveAsync(CancellationToken ct = default) => Task.FromResult(new List<Unit>());
+        public Task<Guid> AddAsync(Unit unit, CancellationToken ct = default) { Added = unit; return Task.FromResult(Guid.NewGuid()); }
+        public Task UpdateAsync(Unit unit, CancellationToken ct = default) { Updated = unit; return Task.CompletedTask; }
+    }
+
+    [Fact]
+    public async Task AddAsync_SetsTimestamps()
+    {
+        var repo = new FakeRepo();
+        var svc = new UnitService(repo);
+        var unit = new Unit { Name = "u", CreatedAt = DateTime.MinValue, UpdatedAt = DateTime.MinValue };
+
+        await svc.AddAsync(unit);
+
+        Assert.Equal(unit, repo.Added);
+        Assert.NotEqual(DateTime.MinValue, repo.Added!.CreatedAt);
+        Assert.NotEqual(DateTime.MinValue, repo.Added!.UpdatedAt);
+    }
+
+    [Fact]
+    public async Task AddAsync_InvalidName_Throws()
+    {
+        var svc = new UnitService(new FakeRepo());
+        await Assert.ThrowsAsync<ArgumentException>(() => svc.AddAsync(new Unit()));
+    }
+
+    [Fact]
+    public async Task UpdateAsync_SetsTimestamp()
+    {
+        var repo = new FakeRepo();
+        var svc = new UnitService(repo);
+        var unit = new Unit { Id = Guid.NewGuid(), Name = "u", UpdatedAt = DateTime.MinValue };
+
+        await svc.UpdateAsync(unit);
+
+        Assert.Equal(unit, repo.Updated);
+        Assert.NotEqual(DateTime.MinValue, repo.Updated!.UpdatedAt);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_InvalidId_Throws()
+    {
+        var svc = new UnitService(new FakeRepo());
+        var unit = new Unit { Id = Guid.Empty, Name = "u" };
+        await Assert.ThrowsAsync<ArgumentException>(() => svc.UpdateAsync(unit));
+    }
+}


### PR DESCRIPTION
## Summary
- add missing tests for NumberToWordsConverter, SimpleMath, InvoiceCalculator
- cover NullNumberingService and NullLogService
- add service layer tests for InvoiceService and basic entity services
- log progress

## Testing
- `dotnet test Wrecept.Core.Tests/Wrecept.Core.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_686b775390908322bcd767ff2149c898