### PR TITLE
Add startup flow tests and exclude migrations

### DIFF
--- a/Wrecept.Core.Tests/Wrecept.Core.Tests.csproj
+++ b/Wrecept.Core.Tests/Wrecept.Core.Tests.csproj
@@ -6,6 +6,9 @@
     <Nullable>enable</Nullable>
     <Threshold>100</Threshold>
   </PropertyGroup>
+  <PropertyGroup>
+    <ExcludeByFile>../Wrecept.Storage/Migrations/*</ExcludeByFile>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="xunit" Version="2.5.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0" />

--- a/docs/TEST_STRATEGY.md
+++ b/docs/TEST_STRATEGY.md
@@ -30,6 +30,8 @@ A Wrecept stabilitását több szinten biztosítjuk.
 * Kódfedettséget a `dotnet test --collect:"XPlat Code Coverage"` paranccsal mérünk.
   A CI szintén ezt használja, és a projektfájlokban szereplő `<Threshold>100</Threshold>`
   beállítás miatt bármilyen visszaesés hibát eredményez.
+* A kódfedettségi statisztikából kizárjuk a `Wrecept.Storage/Migrations` mappa osztályait
+  az `<ExcludeByFile>` projektbeállítással.
 
 *Megjegyzés: a `wrecept.db` néven szereplő adatbázis csak a migrációk tervezési szakaszában használatos.*
 

--- a/docs/progress/2025-07-07_11-38-43_test_agent.md
+++ b/docs/progress/2025-07-07_11-38-43_test_agent.md
@@ -1,0 +1,3 @@
+- Added AppStartupFlowTests covering successful startup and error logging.
+- Added SetupWindow and SeedOptionsWindow tests for command behavior.
+- Excluded EF Core migration files from coverage via ExcludeByFile and documented in TEST_STRATEGY.

--- a/tests/Wrecept.Storage.Tests/Wrecept.Storage.Tests.csproj
+++ b/tests/Wrecept.Storage.Tests/Wrecept.Storage.Tests.csproj
@@ -6,6 +6,9 @@
     <Nullable>enable</Nullable>
     <Threshold>100</Threshold>
   </PropertyGroup>
+  <PropertyGroup>
+    <ExcludeByFile>../Wrecept.Storage/Migrations/*</ExcludeByFile>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="xunit" Version="2.5.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0" />

--- a/tests/Wrecept.Tests/AppStartupFlowTests.cs
+++ b/tests/Wrecept.Tests/AppStartupFlowTests.cs
@@ -1,0 +1,121 @@
+using System;
+using System.IO;
+using System.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+using System.Threading.Tasks;
+using System.Windows;
+using Wrecept.Core.Entities;
+using Wrecept.Core.Services;
+using Wrecept.Wpf;
+using Wrecept.Wpf.ViewModels;
+using Wrecept.Wpf.Views;
+using Wrecept.Wpf.Services;
+using Xunit;
+
+namespace Wrecept.Tests;
+
+public class AppStartupFlowTests
+{
+    private static void EnsureApp()
+    {
+        if (Application.Current == null)
+            new Application();
+    }
+
+    private static void InvokeStartup(App app)
+    {
+        var m = typeof(App).GetMethod("OnStartup", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        m.Invoke(app, new object[] { new StartupEventArgs(Array.Empty<string>()) });
+    }
+
+    private static ServiceProvider BuildProvider(string dir, bool includeOptionsVm)
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<ILogService, NullLogService>();
+        services.AddSingleton(new AppStateService(Path.Combine(dir, "state.json")));
+        services.AddSingleton<StartupOrchestrator>();
+        services.AddTransient<ProgressViewModel>();
+        if (includeOptionsVm)
+            services.AddTransient<SeedOptionsViewModel>();
+        services.AddTransient<SeedOptionsWindow>();
+        services.AddTransient<StartupWindow>();
+        services.AddTransient<ScreenModeManager>(_ => new ScreenModeManager(new FakeSettingsService()));
+        services.AddTransient(sp => (StageView)FormatterServices.GetUninitializedObject(typeof(StageView)));
+        services.AddTransient<MainWindow>();
+        return services.BuildServiceProvider();
+    }
+
+    private class FakeSettingsService : ISettingsService
+    {
+        public Task<AppSettings> LoadAsync() => Task.FromResult(new AppSettings());
+        public Task SaveAsync(AppSettings settings) => Task.CompletedTask;
+    }
+
+    [StaFact]
+    public void OnStartup_Seeds_WhenDatabaseEmpty()
+    {
+        EnsureApp();
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(dir);
+        App.DbPath = Path.Combine(dir, "app.db");
+        App.UserInfoPath = Path.Combine(dir, "user.json");
+        App.SettingsPath = Path.Combine(dir, "settings.json");
+        App.StatePath = Path.Combine(dir, "state.json");
+        var provider = BuildProvider(dir, includeOptionsVm: true);
+        var optionsWindow = provider.GetRequiredService<SeedOptionsWindow>();
+        optionsWindow.Loaded += (_, _) =>
+        {
+            if (optionsWindow.DataContext is SeedOptionsViewModel vm)
+            {
+                vm.SupplierCount = 1;
+                vm.ProductCount = 1;
+                vm.InvoiceCount = 1;
+                vm.MinItemsPerInvoice = 1;
+                vm.MaxItemsPerInvoice = 1;
+            }
+            optionsWindow.DialogResult = true;
+        };
+        App.Services = provider;
+        var app = new App();
+
+        InvokeStartup(app);
+
+        Assert.True(File.Exists(App.DbPath));
+        Assert.IsType<MainWindow>(Application.Current!.MainWindow);
+    }
+
+    private class RecordingLog : ILogService
+    {
+        public bool Called;
+        public Task LogError(string message, Exception ex) { Called = true; return Task.CompletedTask; }
+    }
+
+    [StaFact]
+    public void OnStartup_LogsError_WhenServiceMissing()
+    {
+        EnsureApp();
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(dir);
+        App.DbPath = Path.Combine(dir, "app.db");
+        App.UserInfoPath = Path.Combine(dir, "user.json");
+        App.SettingsPath = Path.Combine(dir, "settings.json");
+        App.StatePath = Path.Combine(dir, "state.json");
+        var log = new RecordingLog();
+        var services = new ServiceCollection();
+        services.AddSingleton<ILogService>(log);
+        services.AddSingleton(new AppStateService(App.StatePath));
+        services.AddSingleton<StartupOrchestrator>();
+        services.AddTransient<ProgressViewModel>();
+        services.AddTransient<SeedOptionsWindow>();
+        services.AddTransient<StartupWindow>();
+        services.AddTransient(sp => (StageView)FormatterServices.GetUninitializedObject(typeof(StageView)));
+        services.AddTransient<ScreenModeManager>(_ => new ScreenModeManager(new FakeSettingsService()));
+        services.AddTransient<MainWindow>();
+        App.Services = services.BuildServiceProvider();
+        var app = new App();
+
+        InvokeStartup(app);
+
+        Assert.True(log.Called);
+    }
+}

--- a/tests/Wrecept.Tests/SetupAndSeedWindowTests.cs
+++ b/tests/Wrecept.Tests/SetupAndSeedWindowTests.cs
@@ -1,0 +1,63 @@
+using System.Windows;
+using Wrecept.Wpf.ViewModels;
+using Wrecept.Wpf.Views;
+using Xunit;
+
+namespace Wrecept.Tests;
+
+public class SetupAndSeedWindowTests
+{
+    private static void EnsureApp()
+    {
+        if (Application.Current == null)
+            new Application();
+    }
+
+    [StaFact]
+    public void SetupWindow_Ok_SetsDialogResultTrue()
+    {
+        EnsureApp();
+        var vm = new SetupViewModel("db", "cfg");
+        var win = new SetupWindow { DataContext = vm };
+
+        vm.OkCommand.Execute(win);
+
+        Assert.True(win.DialogResult);
+    }
+
+    [StaFact]
+    public void SetupWindow_Cancel_SetsDialogResultFalse()
+    {
+        EnsureApp();
+        var vm = new SetupViewModel("db", "cfg");
+        var win = new SetupWindow { DataContext = vm };
+
+        vm.CancelCommand.Execute(win);
+
+        Assert.False(win.DialogResult);
+    }
+
+    [StaFact]
+    public void SeedOptionsWindow_Ok_SetsDialogResultTrue()
+    {
+        EnsureApp();
+        var vm = new SeedOptionsViewModel();
+        var win = new SeedOptionsWindow { DataContext = vm };
+
+        vm.OkCommand.Execute(win);
+
+        Assert.True(win.DialogResult);
+    }
+
+    [StaFact]
+    public void SeedOptionsWindow_Cancel_SetsDialogResultFalse()
+    {
+        EnsureApp();
+        var vm = new SeedOptionsViewModel();
+        var win = new SeedOptionsWindow { DataContext = vm };
+
+        vm.CancelCommand.Execute(win);
+
+        Assert.False(win.DialogResult);
+    }
+}

--- a/tests/Wrecept.Tests/Wrecept.Tests.csproj
+++ b/tests/Wrecept.Tests/Wrecept.Tests.csproj
@@ -6,6 +6,9 @@
     <Nullable>enable</Nullable>
     <Threshold>100</Threshold>
   </PropertyGroup>
+  <PropertyGroup>
+    <ExcludeByFile>../Wrecept.Storage/Migrations/*</ExcludeByFile>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="xunit" Version="2.5.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0" />

--- a/tests/Wrecept.UiTests/Wrecept.UiTests.csproj
+++ b/tests/Wrecept.UiTests/Wrecept.UiTests.csproj
@@ -9,6 +9,9 @@
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
+  <PropertyGroup>
+    <ExcludeByFile>../Wrecept.Storage/Migrations/*</ExcludeByFile>
+  </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />


### PR DESCRIPTION
## Summary
- cover App.OnStartup happy path and error handling in new tests
- test SetupWindow and SeedOptionsWindow commands
- ignore EF Core migration files from coverage reports
- document coverage exclusion

## Testing
- `dotnet test --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bad0e9f488322bb18e5d1638171ae