### PR TITLE
Add setup flow injection and tests

### DIFF
--- a/Wrecept.Wpf/Services/ISetupFlow.cs
+++ b/Wrecept.Wpf/Services/ISetupFlow.cs
@@ -1,0 +1,11 @@
+using System.Threading.Tasks;
+using Wrecept.Core.Entities;
+
+namespace Wrecept.Wpf.Services;
+
+public record SetupData(string DatabasePath, string ConfigPath, UserInfo Info);
+
+public interface ISetupFlow
+{
+    Task<SetupData> RunAsync(string defaultDb, string defaultCfg);
+}

--- a/Wrecept.Wpf/Services/SetupFlow.cs
+++ b/Wrecept.Wpf/Services/SetupFlow.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Threading.Tasks;
+using System.Windows;
+using Wrecept.Core.Entities;
+using Wrecept.Wpf.ViewModels;
+using Wrecept.Wpf.Views;
+
+namespace Wrecept.Wpf.Services;
+
+public class SetupFlow : ISetupFlow
+{
+    public Task<SetupData> RunAsync(string defaultDb, string defaultCfg)
+    {
+        var vm = new SetupViewModel(defaultDb, defaultCfg);
+        var win = new SetupWindow { DataContext = vm };
+        if (win.ShowDialog() != true)
+        {
+            Application.Current.Shutdown();
+            Environment.Exit(0);
+        }
+
+        var infoVm = new UserInfoEditorViewModel();
+        var infoWin = new UserInfoWindow { DataContext = infoVm };
+        infoVm.OnOk = _ => { infoWin.DialogResult = true; infoWin.Close(); };
+        infoVm.OnCancel = () => { infoWin.DialogResult = false; infoWin.Close(); };
+        if (infoWin.ShowDialog() != true)
+        {
+            Application.Current.Shutdown();
+            Environment.Exit(0);
+        }
+
+        var info = new UserInfo
+        {
+            CompanyName = infoVm.CompanyName,
+            Address = infoVm.Address,
+            Phone = infoVm.Phone,
+            Email = infoVm.Email,
+            TaxNumber = infoVm.TaxNumber,
+            BankAccount = infoVm.BankAccount
+        };
+
+        return Task.FromResult(new SetupData(vm.DatabasePath, vm.ConfigPath, info));
+    }
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -81,6 +81,8 @@ Ha a második adatlekérdezés is hibát jelez, a részleteket az `ILogService` 
 
 Az alkalmazás betöltésekor a `StartupOrchestrator` fut le, amely két szintű előrehaladási értéket jelent az UI felé. A `ProgressViewModel` által kötött nézet két `ProgressBar`-on keresztül mutatja a globális és részfeladatok százalékos állását, így a felhasználó valós időben látja a migráció és a mintaadatok betöltésének állapotát.
 
+Az első indításkor a `LoadSettingsAsync` metódus a `ISetupFlow` szolgáltatás segítségével kéri be az adatbázis- és cégadatok elérési útvonalát. A `SetupFlow` alapértelmezett implementáció WPF dialógusokat használ, de tesztben könnyen helyettesíthető.
+
 Az `InvoiceEditorLayout` megnyitásakor hasonló ablak jelenik meg. A törzsadatok (fizetési módok, szállítók, ÁFA‑kulcsok, termékek, mértékegységek) betöltése lépésenként történik, a második sáv pedig az adott lista elemeinek betöltési arányát írja ki.
 
 ## Dialóguskezelés

--- a/docs/PROJECT_STRUCTURE.md
+++ b/docs/PROJECT_STRUCTURE.md
@@ -789,6 +789,20 @@ Minden fájl leírása az alábbi mezőket tartalmazza:
   - Responsibility: Funkcionális logika
   - Interaction: Repositories, ViewModels
   - Special Notes: -
+- **Wrecept.Wpf/Services/ISetupFlow.cs**
+  - Purpose: Üzleti szolgáltatás
+  - Layer: UI
+  - Type: C#
+  - Responsibility: Első indítás adatbekérés
+  - Interaction: ViewModels
+  - Special Notes: Mockolható
+- **Wrecept.Wpf/Services/SetupFlow.cs**
+  - Purpose: Üzleti szolgáltatás
+  - Layer: UI
+  - Type: C#
+  - Responsibility: Dialógusok megjelenítése
+  - Interaction: Views
+  - Special Notes: -
 - **Wrecept.Wpf/Services/NavigationService.cs**
   - Purpose: Üzleti szolgáltatás
   - Layer: UI

--- a/docs/progress/2025-07-07_11-57-26_test_agent.md
+++ b/docs/progress/2025-07-07_11-57-26_test_agent.md
@@ -1,0 +1,3 @@
+- Refactored LoadSettingsAsync to accept ISetupFlow and INotificationService.
+- Added tests for missing settings file with mock setup flow.
+- Covered NavigationService negative dialog branch and FileDialog path.

--- a/tests/Wrecept.Tests/AppLoadSettingsMissingTests.cs
+++ b/tests/Wrecept.Tests/AppLoadSettingsMissingTests.cs
@@ -4,26 +4,30 @@ using System.Reflection;
 using System.Threading.Tasks;
 using Wrecept.Wpf;
 using Wrecept.Core.Entities;
+using Wrecept.Core.Services;
+using Wrecept.Wpf.Services;
 using Xunit;
 
 namespace Wrecept.Tests;
 
 public class AppLoadSettingsMissingTests
 {
-    private static async Task<AppSettings> InvokeLoadAsync()
+    private static async Task<AppSettings> InvokeLoadAsync(INotificationService? n = null, ISetupFlow? f = null)
     {
         var m = typeof(App).GetMethod("LoadSettingsAsync", BindingFlags.NonPublic | BindingFlags.Static)!;
-        return await (Task<AppSettings>)m.Invoke(null, null)!;
+        return await (Task<AppSettings>)m.Invoke(null, new object?[] { n, f })!;
     }
 
-    [StaFact(Skip="Requires UI interaction")]
+    [StaFact]
     public async Task LoadSettingsAsync_CreatesDefaultWhenMissing()
     {
         var temp = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
         Environment.SetEnvironmentVariable("APPDATA", temp);
+        var flow = new DummyFlow();
+        var notif = new DummyNotif();
         try
         {
-            var settings = await InvokeLoadAsync();
+            var settings = await InvokeLoadAsync(notif, flow);
             Assert.NotEqual(string.Empty, settings.DatabasePath);
             Assert.NotEqual(string.Empty, settings.UserInfoPath);
             var logDir = Path.Combine(temp, "Wrecept", "logs");
@@ -35,5 +39,18 @@ public class AppLoadSettingsMissingTests
             Directory.Delete(temp, true);
             Environment.SetEnvironmentVariable("APPDATA", null);
         }
+    }
+
+    private class DummyFlow : ISetupFlow
+    {
+        public Task<SetupData> RunAsync(string db, string cfg)
+            => Task.FromResult(new SetupData(db, cfg, new UserInfo()));
+    }
+
+    private class DummyNotif : INotificationService
+    {
+        public void ShowError(string message) { }
+        public void ShowInfo(string message) { }
+        public bool Confirm(string message) => true;
     }
 }

--- a/tests/Wrecept.Tests/AppStartupTests.cs
+++ b/tests/Wrecept.Tests/AppStartupTests.cs
@@ -11,10 +11,10 @@ namespace Wrecept.Tests;
 
 public class AppStartupTests
 {
-    private static async Task<AppSettings> InvokeLoadAsync()
+    private static async Task<AppSettings> InvokeLoadAsync(INotificationService? n = null, ISetupFlow? f = null)
     {
         var method = typeof(App).GetMethod("LoadSettingsAsync", BindingFlags.NonPublic | BindingFlags.Static)!;
-        return await (Task<AppSettings>)method.Invoke(null, null)!;
+        return await (Task<AppSettings>)method.Invoke(null, new object?[] { n, f })!;
     }
 
     [StaFact]

--- a/tests/Wrecept.Tests/NavigationServiceTests.cs
+++ b/tests/Wrecept.Tests/NavigationServiceTests.cs
@@ -1,5 +1,6 @@
 using System.Windows;
 using Wrecept.Wpf.Services;
+using Wrecept.Core.Enums;
 using Xunit;
 
 namespace Wrecept.Tests;


### PR DESCRIPTION
## Summary
- refactor `App.LoadSettingsAsync` to accept `INotificationService` and `ISetupFlow`
- implement default `SetupFlow` for dialog-based startup
- document new interface in architecture and project structure docs
- add tests for missing settings, NavigationService branches, and injectible setup
- log progress

## Testing
- `dotnet test --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bb2808868832296e585ce3d77f18c