### PR TITLE
Ensure single-language docs

### DIFF
--- a/docs/DEV_SPECS.md
+++ b/docs/DEV_SPECS.md
@@ -39,7 +39,7 @@ The design must be:
 | Backups     | Manual + optional autosave-based copy            |
 | Permissions | No admin required. Writes to `%AppData%\Wrecept` |
 
-Az alkalmazás minden adatbázis-kapcsolat nyitásakor lefuttatja a `PRAGMA journal_mode=WAL` parancsot, így a naplózási mód mindig visszaáll WAL értékre.
+The application executes `PRAGMA journal_mode=WAL` every time it opens a database connection so the journaling mode always resets to WAL.
 
 ---
 
@@ -72,9 +72,7 @@ Az alkalmazás minden adatbázis-kapcsolat nyitásakor lefuttatja a `PRAGMA jour
 
 ## 🔍 View Utilities
 
-`VisualTreeExtensions.FindAncestor<T>` segít a vizuális fa bejárásában, ha a
-szükséges szülő vezérlőt XAML-ben szeretnénk elérni. Így a nézetekben nem kell
-kóddal keresni az ős elemeket, a logika tisztán a ViewModelben marad.
+`VisualTreeExtensions.FindAncestor<T>` helps traverse the visual tree when a parent control must be found from XAML. This keeps the search logic out of the views and inside the ViewModel layer.
 
 
 ---
@@ -112,8 +110,8 @@ kóddal keresni az ős elemeket, a logika tisztán a ViewModelben marad.
 ├── Themes\              # Application Themes
 └── version.txt          # Last known app version
 ```
-Fejlesztéskor a `wrecept.db` nevű adatbázis kizárólag a migrációk generálásához használatos.
-Ha az adatbázis elérési útja hiányzik, a program automatikusan a fenti `%AppData%/Wrecept/app.db` fájlt hozza létre.
+During development the `wrecept.db` database is used only for generating migrations.
+If the database path is missing the program automatically creates the `%AppData%/Wrecept/app.db` file.
 
 ---
 

--- a/docs/FEATURE_PLAN.md
+++ b/docs/FEATURE_PLAN.md
@@ -76,6 +76,6 @@ Automatically recalculate invoice totals when line items are added/removed.
 
 ---
 
-*2025-07-08:* Utolsó kódlefedettségi mérés 100% eredménnyel.*
+*2025-07-08:* Last code coverage run reported 100%.*
 
 *Maintained by `root_agent`. Update before major feature execution.*

--- a/docs/PROJECT_STRUCTURE.md
+++ b/docs/PROJECT_STRUCTURE.md
@@ -1,5 +1,5 @@
 ---
-title: "Project Structure"
+title: "Projektstruktúra"
 purpose: "Fájlok rétegenkénti szerepe és kapcsolatai"
 author: "docs_agent"
 date: "2025-07-05"
@@ -13,12 +13,12 @@ Ez a dokumentum fájlonként rögzíti a Wrecept megvalósításában szereplő 
 
 Minden fájl leírása az alábbi mezőket tartalmazza:
 
-- **Purpose** – a fájl célja
-- **Layer** – melyik réteghez tartozik
-- **Type** – kód, XAML, konfiguráció stb.
-- **Responsibility** – rövid feladatkör
-- **Interaction** – kapcsolódó komponensek
-- **Special Notes** – egyedi megjegyzések
+- **Cél** – a fájl célja
+- **Réteg** – melyik réteghez tartozik
+- **Típus** – kód, XAML, konfiguráció stb.
+- **Felelősség** – rövid feladatkör
+- **Kapcsolat** – kapcsolódó komponensek
+- **Megjegyzés** – egyedi megjegyzések
 - **Wrecept.Core/Entities/AppSettings.cs**
   - Purpose: Konfigurációs entitás
   - Layer: Core

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,7 +15,7 @@ date: "2025-06-27"
 
 ## 📦 Project Purpose
 
-Wrecept eredetileg Windowson futó WPF alkalmazásként indult. A multiplatform MAUI kitérő után ismét WPF-re építjük a felületet, megőrizve a Clipper + dBase IV rendszerek sebességét. A cél továbbra is a kiszámítható működés, akár áramszünet után is.
+Wrecept originally started as a Windows-only WPF application. After a brief MAUI detour we returned to WPF while keeping the speed of the Clipper + dBase IV systems. The goal remains predictable operation, even after a power outage.
 
 ---
 
@@ -38,18 +38,18 @@ Wrecept eredetileg Windowson futó WPF alkalmazásként indult. A multiplatform 
 
 * **No mouse. No clutter.**
 * All screens mimic DOS layouts — with color-coded panels and full-screen efficiency.
-* Menük nagy része még helykitöltő, de a termékek kezelése már működik.
+* Most of the menus are still placeholders, but product management already works.
 
 ---
 
 ## 📁 Folder Structure
 
 ```
-Wrecept.Core/          # Domain modellek és szolgáltatások
-Wrecept.Storage/       # EF Core adatkezelés és repositoryk
-Wrecept.Wpf/           # WPF UI projekt
-docs/                  # Dokumentációk
-tools/                 # Segédszkriptek
+Wrecept.Core/          # Domain models and services
+Wrecept.Storage/       # EF Core data access and repositories
+Wrecept.Wpf/           # WPF UI project
+docs/                  # Documentation
+tools/                 # Helper scripts
 CHANGELOG.md
 Wrecept.sln
 ```
@@ -69,24 +69,24 @@ Wrecept.sln
 1. Build out invoice editor UI (inspired by screenshot #3)
 2. Integrate fake data into product and supplier modules
 3. Discuss minimal database model based on real .dbf structure
-4. Kötelező induló tennivalók a [DEV_SPECS.md](DEV_SPECS.md) "Kick OFF" szakaszában
+4. Mandatory startup tasks can be found in the "Kick OFF" section of [DEV_SPECS.md](DEV_SPECS.md)
 
 ## ✅ Kick OFF
 
-A WPF projekt `Wrecept.Wpf` néven jött létre, és az alábbi alapelemeket tartalmazza:
+The WPF project was created as `Wrecept.Wpf` and contains the following basics:
 
-* `App.xaml` és `App.xaml.cs` – alkalmazásbeállítások
-* `MainWindow.xaml` – főablak
-* `App.xaml.cs` tartalmazza a DI és indítási logikát
-* A `MainWindow` betölti a `StageView` felületet
+* `App.xaml` and `App.xaml.cs` – application configuration
+* `MainWindow.xaml` – main window
+* `App.xaml.cs` holds DI and startup logic
+* `MainWindow` loads the `StageView` layout
 
-Ezek garantálják, hogy a program Windows környezetben azonnal futtatható legyen.
+These ensure the program runs immediately in a Windows environment.
 
 ---
 
 ## ✅ Running Tests
 
-A tesztek a következő paranccsal futtathatók:
+Tests can be run with the following command:
 
 ```bash
 dotnet test tests/Wrecept.Tests/Wrecept.Tests.csproj
@@ -99,7 +99,7 @@ dotnet test tests/Wrecept.Tests/Wrecept.Tests.csproj
 Original layout, logic and color schema: \[Egon’s legacy Clipper app]
 Reconstruction by: \[ChatGPT-Dev Agent – 2025 Edition]
 
-> "A színpad áll, a keverő bekészítve. Most jöhet a kábelezés."
+> "The stage is set, the mixer is ready. Time to wire things up."
 
 ---
 
@@ -107,16 +107,16 @@ Reconstruction by: \[ChatGPT-Dev Agent – 2025 Edition]
 
 ---
 
-## 📚 Dokumentációk
+## 📚 Documentation
 
-- [ARCHITECTURE.md](ARCHITECTURE.md) – Rétegek és adatútvonalak
-- [AGENTS.md](AGENTS.md) – Agent feladatkiosztás
-- [CODE_STANDARDS.md](CODE_STANDARDS.md) – Kódolási irányelvek
-- [DEV_SPECS.md](DEV_SPECS.md) – Fejlesztési specifikáció
-- [ERROR_HANDLING.md](ERROR_HANDLING.md) – Hibatűrés
-- [FAULT_PLAN.md](FAULT_PLAN.md) – Hibabefecskendezési terv
-- [TEST_STRATEGY.md](TEST_STRATEGY.md) – Tesztstratégia
-- [PROJECT_STRUCTURE.md](PROJECT_STRUCTURE.md) – Fájlszintű áttekintés
-- [../.git-branch-policy.md](../.git-branch-policy.md) – Git ágkezelési szabályzat
-- [manuals/developer_guide_hu.md](manuals/developer_guide_hu.md) – Fejlesztői útmutató
-- [manuals/user_manual_hu.md](manuals/user_manual_hu.md) – Felhasználói kézikönyv
+- [ARCHITECTURE.md](ARCHITECTURE.md) – Layers and data flow
+- [AGENTS.md](AGENTS.md) – Agent responsibilities
+- [CODE_STANDARDS.md](CODE_STANDARDS.md) – Coding guidelines
+- [DEV_SPECS.md](DEV_SPECS.md) – Development specification
+- [ERROR_HANDLING.md](ERROR_HANDLING.md) – Fault tolerance
+- [FAULT_PLAN.md](FAULT_PLAN.md) – Fault injection plan
+- [TEST_STRATEGY.md](TEST_STRATEGY.md) – Test strategy
+- [PROJECT_STRUCTURE.md](PROJECT_STRUCTURE.md) – File-level overview
+- [../.git-branch-policy.md](../.git-branch-policy.md) – Git branch policy
+- [manuals/developer_guide_hu.md](manuals/developer_guide_hu.md) – Developer guide (HU)
+- [manuals/user_manual_hu.md](manuals/user_manual_hu.md) – User manual (HU)

--- a/docs/TEST_MATRIX.md
+++ b/docs/TEST_MATRIX.md
@@ -1,18 +1,18 @@
 ---
-title: "Test Matrix"
-purpose: "Use-case coverage for reliability"
+title: "Tesztmátrix"
+purpose: "Használati esetek lefedettsége a megbízhatósághoz"
 author: "docs_agent"
 date: "2025-06-27"
 ---
 
-# 🧪 Test Matrix
+# 🧪 Tesztmátrix
 
 | Szituáció        | Elvárt viselkedés                                                                 |
 |------------------|----------------------------------------------------------------------------------|
-| UI lock          | Az alkalmazás újra fókuszálja az aktív elemet vagy visszaáll alapállapotba.       |
-| Network loss     | A lokális műveletek zavartalanul folytatódnak, figyelmeztető üzenet jelenik meg. |
-| Corrupted invoice| A betöltés megszakad, a hibát naplózzuk és a felhasználót tájékoztatjuk.          |
-| WPF build Windowson | Ha a .NET Desktop Runtime nincs telepítve, a build nem fut le; ezt naplózzuk. |
+| UI zárolás       | Az alkalmazás újra fókuszálja az aktív elemet vagy visszaáll alapállapotba.       |
+| Hálózati kiesés  | A lokális műveletek zavartalanul folytatódnak, figyelmeztető üzenet jelenik meg. |
+| Sérült számla    | A betöltés megszakad, a hibát naplózzuk és a felhasználót tájékoztatjuk.          |
+| WPF build Windows alatt | Ha a .NET Desktop Runtime nincs telepítve, a build nem fut le; ezt naplózzuk. |
 | StageView menü | Escape visszaadja a fókuszt az utolsó menüpontra. |
 | InvoiceEditor sor mentése | Új tétel rögzítését követően frissül a lista. |
 | Masteradat ablakok | A rács fókuszálható és Enter szerkesztést indít. |

--- a/docs/themes.md
+++ b/docs/themes.md
@@ -7,7 +7,7 @@ date: "2025-06-27"
 
 # 🎨 Retro téma áttekintés
 
-A Retro UI hangs on a 16 színű DOS-palettán. A XAML erőforrás szótár egységesíti a vezérlők megjelenését. A fő színek: háttér `#9b8b20`, mezők `#c7bb4f`, gombok `#0000aa` fehér felirattal és kiemelés `#000055`.
+A Retro felület 16 színű DOS-palettára épül. A XAML erőforrás szótár egységesíti a vezérlők megjelenését. A fő színek: háttér `#9b8b20`, mezők `#c7bb4f`, gombok `#0000aa` fehér felirattal és kiemelés `#000055`.
 
 2025 júliusától a `RetroTheme.xaml` két változatban érhető el: világos és sötét. A váltást a `ThemeManager.ApplyDarkTheme(bool)` hívással lehet vezérelni, ami a megfelelő `ResourceDictionary` betöltését végzi.
 
@@ -29,7 +29,7 @@ Betűméretek:
 
 DataGrid sorok fekete háttérrel és arany kiemeléssel jelennek meg a DOS-hatást erősítve. A mennyiségi vagy ár mezők címkéi piros színt kapnak, hogy gyorsabban felismerhetők legyenek.
 
-- The StatusBar uses `ControlBackgroundBrush` with subtle text to avoid distraction while conveying state.
+- A StatusBar a `ControlBackgroundBrush` színt használja visszafogott felirattal, hogy jelezze az állapotot anélkül, hogy elvonná a figyelmet.
 
 ## Screen Modes
 


### PR DESCRIPTION
## Summary
- rewrite README to keep only English content
- enforce English in FEATURE_PLAN and DEV_SPECS docs
- translate mixed lines in themes and test matrix
- adjust project structure metadata

## Testing
- `dotnet test --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c013230708322a1544a6b94e24168