### PR TITLE
Switch to AutoCompleteBox in invoice UI

### DIFF
--- a/Wrecept.Core/Models/PaymentMethod.cs
+++ b/Wrecept.Core/Models/PaymentMethod.cs
@@ -8,4 +8,6 @@ public class PaymentMethod
     public bool IsArchived { get; set; } = false;
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
     public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+
+    public override string ToString() => Name;
 }

--- a/Wrecept.Core/Models/TaxRate.cs
+++ b/Wrecept.Core/Models/TaxRate.cs
@@ -11,4 +11,6 @@ public class TaxRate
     public bool IsArchived { get; set; } = false;
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
     public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+
+    public override string ToString() => Name;
 }

--- a/Wrecept.Wpf/Views/Controls/EditLookup.xaml
+++ b/Wrecept.Wpf/Views/Controls/EditLookup.xaml
@@ -3,14 +3,11 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+            xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit"
             mc:Ignorable="d">
-    <ComboBox x:Name="Box"
-              ItemsSource="{Binding ItemsSource, RelativeSource={RelativeSource AncestorType=UserControl}}"
-              SelectedValuePath="{Binding SelectedValuePath, RelativeSource={RelativeSource AncestorType=UserControl}}"
-              DisplayMemberPath="{Binding DisplayMemberPath, RelativeSource={RelativeSource AncestorType=UserControl}}"
-              SelectedValue="{Binding SelectedValue, RelativeSource={RelativeSource AncestorType=UserControl}, Mode=TwoWay}"
-              IsEditable="True"
-              StaysOpenOnEdit="True"
-              IsTextSearchEnabled="False"
-              IsSynchronizedWithCurrentItem="True"/>
+    <xctk:AutoCompleteBox x:Name="Box"
+                          ItemsSource="{Binding ItemsSource, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                          ValueMemberPath="{Binding SelectedValuePath, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                          FilterMode="Contains"
+                          SelectedItem="{Binding SelectedValue, RelativeSource={RelativeSource AncestorType=UserControl}, Mode=TwoWay}" />
 </UserControl>

--- a/Wrecept.Wpf/Views/Controls/EditLookup.xaml.cs
+++ b/Wrecept.Wpf/Views/Controls/EditLookup.xaml.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Windows;
+using System.Collections;
 using System.Windows.Controls;
-using System.Windows.Data;
 using System.Windows.Input;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -10,7 +10,7 @@ namespace Wrecept.Wpf.Views.Controls;
 public partial class EditLookup : UserControl
 {
     public static readonly DependencyProperty ItemsSourceProperty = DependencyProperty.Register(
-        nameof(ItemsSource), typeof(object), typeof(EditLookup));
+        nameof(ItemsSource), typeof(IEnumerable), typeof(EditLookup));
 
     public static readonly DependencyProperty SelectedValueProperty = DependencyProperty.Register(
         nameof(SelectedValue), typeof(object), typeof(EditLookup),
@@ -28,7 +28,7 @@ public partial class EditLookup : UserControl
     public static readonly DependencyProperty CreateCommandParameterProperty = DependencyProperty.Register(
         nameof(CreateCommandParameter), typeof(object), typeof(EditLookup));
 
-    public object? ItemsSource
+    public IEnumerable? ItemsSource
     {
         get => GetValue(ItemsSourceProperty);
         set => SetValue(ItemsSourceProperty, value);
@@ -64,41 +64,9 @@ public partial class EditLookup : UserControl
         set => SetValue(CreateCommandProperty, value);
     }
 
-    private TextBox? _textBox;
-
     public EditLookup()
     {
         InitializeComponent();
-        Loaded += OnLoaded;
-    }
-
-    private void OnLoaded(object sender, RoutedEventArgs e)
-    {
-        _textBox = (TextBox)Box.Template.FindName("PART_EditableTextBox", Box);
-        if (_textBox != null)
-            _textBox.TextChanged += OnTextChanged;
-    }
-
-    private void OnTextChanged(object sender, TextChangedEventArgs e)
-    {
-        if (ItemsSource == null)
-            return;
-        var view = CollectionViewSource.GetDefaultView(ItemsSource);
-        var text = _textBox?.Text ?? string.Empty;
-        view.Filter = o => Matches(o, text);
-        Box.IsDropDownOpen = true;
-        view.Refresh();
-    }
-
-    private bool Matches(object? item, string text)
-    {
-        if (string.IsNullOrWhiteSpace(text))
-            return true;
-        if (item is null)
-            return false;
-        var prop = item.GetType().GetProperty(DisplayMemberPath ?? "Name");
-        var value = prop?.GetValue(item)?.ToString() ?? item.ToString();
-        return value != null && value.IndexOf(text, StringComparison.OrdinalIgnoreCase) >= 0;
     }
 
 }

--- a/Wrecept.Wpf/Views/InvoiceEditorLayout.xaml
+++ b/Wrecept.Wpf/Views/InvoiceEditorLayout.xaml
@@ -100,7 +100,6 @@
                             <Label Content="_Fizetési mód" Style="{StaticResource FormLabelStyle}" Target="{Binding ElementName=PaymentLookup}" />
                             <c:EditLookup x:Name="PaymentLookup" Width="220"
                                           ItemsSource="{Binding PaymentMethods}"
-                                          DisplayMemberPath="Name"
                                           SelectedValuePath="Id"
                                           SelectedValue="{Binding PaymentMethodId}"
                                           CreateCommand="{Binding ShowPaymentMethodCreatorCommand}"
@@ -159,7 +158,6 @@
                     <TextBox x:Name="EntryPrice" Grid.Column="3" Margin="4,0" Text="{Binding UnitPrice, Mode=TwoWay}" />
                     <c:EditLookup x:Name="EntryTax" Grid.Column="4" Tag="LastEntry"
                                   ItemsSource="{Binding DataContext.TaxRates, RelativeSource={RelativeSource AncestorType=UserControl}}"
-                                  DisplayMemberPath="Name"
                                   SelectedValuePath="Id"
                                   SelectedValue="{Binding TaxRateId, Mode=TwoWay}"
                                   CreateCommand="{Binding DataContext.ShowTaxRateCreatorCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"

--- a/Wrecept.Wpf/Views/InvoiceItemsGrid.xaml
+++ b/Wrecept.Wpf/Views/InvoiceItemsGrid.xaml
@@ -2,7 +2,8 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:c="clr-namespace:Wrecept.Wpf.Views.Controls"
-             xmlns:local="clr-namespace:Wrecept.Wpf.Converters">
+             xmlns:local="clr-namespace:Wrecept.Wpf.Converters"
+             xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit">
     <UserControl.Resources>
         <local:QuantityToStyleConverter x:Key="QuantityToStyleConverter" />
         <local:NegativeValueForegroundConverter x:Key="NegativeForegroundConverter" />
@@ -16,11 +17,10 @@
             <TextBlock Text="{Binding Product}" VerticalAlignment="Center" />
         </DataTemplate>
         <DataTemplate x:Key="ProductEditTemplate">
-            <ComboBox ItemsSource="{Binding DataContext.Products, RelativeSource={RelativeSource AncestorType=DataGrid}}"
-                      SelectedValuePath="Name"
-                      DisplayMemberPath="Name"
-                      SelectedValue="{Binding Product, Mode=TwoWay}" IsEditable="True"
-                      IsTextSearchEnabled="True" StaysOpenOnEdit="True" />
+            <xctk:AutoCompleteBox ItemsSource="{Binding DataContext.Products, RelativeSource={RelativeSource AncestorType=DataGrid}}"
+                                  ValueMemberPath="Name"
+                                  FilterMode="Contains"
+                                  SelectedItem="{Binding Product, Mode=TwoWay}" />
         </DataTemplate>
 
         <DataTemplate x:Key="QuantityDisplayTemplate">
@@ -36,9 +36,10 @@
             <TextBlock Text="{Binding UnitName}" />
         </DataTemplate>
         <DataTemplate x:Key="UnitEditTemplate">
-            <ComboBox ItemsSource="{Binding DataContext.Units, RelativeSource={RelativeSource AncestorType=DataGrid}}"
-                      SelectedValuePath="Id" DisplayMemberPath="Name"
-                      SelectedValue="{Binding UnitId, Mode=TwoWay}" />
+            <xctk:AutoCompleteBox ItemsSource="{Binding DataContext.Units, RelativeSource={RelativeSource AncestorType=DataGrid}}"
+                                  ValueMemberPath="Id"
+                                  FilterMode="Contains"
+                                  SelectedItem="{Binding UnitId, Mode=TwoWay}" />
         </DataTemplate>
 
         <DataTemplate x:Key="PriceDisplayTemplate">
@@ -52,9 +53,10 @@
             <TextBlock Text="{Binding TaxRateName}" />
         </DataTemplate>
         <DataTemplate x:Key="VatEditTemplate">
-            <ComboBox ItemsSource="{Binding DataContext.TaxRates, RelativeSource={RelativeSource AncestorType=DataGrid}}"
-                      SelectedValuePath="Id" DisplayMemberPath="Name"
-                      SelectedValue="{Binding TaxRateId, Mode=TwoWay}" />
+            <xctk:AutoCompleteBox ItemsSource="{Binding DataContext.TaxRates, RelativeSource={RelativeSource AncestorType=DataGrid}}"
+                                  ValueMemberPath="Id"
+                                  FilterMode="Contains"
+                                  SelectedItem="{Binding TaxRateId, Mode=TwoWay}" />
         </DataTemplate>
 
         <local:InvoiceLineTotalsConverter x:Key="NetConverter" Mode="Net" />

--- a/Wrecept.Wpf/Wrecept.Wpf.csproj
+++ b/Wrecept.Wpf/Wrecept.Wpf.csproj
@@ -12,6 +12,7 @@
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.0" />
     <PackageReference Include="QuestPDF" Version="2024.3.0" />
+    <PackageReference Include="Xceed.Wpf.Toolkit" Version="4.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/docs/RefactorPlan.md
+++ b/docs/RefactorPlan.md
@@ -42,13 +42,13 @@ Each step includes updates for:
 ### ViewModel Changes
 
 * Bind `IsGross` to a Toggle or Checkbox in the invoice editor.
-* Bind `PaymentMethodId` using a ComboBox of active payment methods.
+* Bind `PaymentMethodId` using an AutoCompleteBox of active payment methods.
 * Add `IsArchived` flag to support filtering/archive logic.
 
 ### View (XAML)
 
 * Add gross/net toggle.
-* Replace payment method TextBox with ComboBox.
+* Replace payment method TextBox with AutoCompleteBox.
 * Disable editing if `IsArchived` is true.
 
 ---
@@ -140,7 +140,7 @@ No changes beyond current `DueInDays`, `IsArchived`, etc.
 ### ViewModel & View
 
 * Make `DueInDays` editable.
-* Filter out archived values from Invoice editor ComboBox.
+* Filter out archived values from Invoice editor AutoCompleteBox.
 
 ---
 
@@ -167,7 +167,7 @@ Already conformant. Just ensure dropdown bindings and filtering work consistentl
 
 ## 🔁 Change Propagation Notes
 
-* Ensure all ComboBox elements bind to filtered observable collections (only non-archived items).
+* Ensure all AutoCompleteBox elements bind to filtered observable collections (only non-archived items).
 * All new IDs must be saved and loaded in ViewModel → Model mapping.
 * `InvoiceCalculator` must read `IsGross` and `TaxRate.Percentage` per item.
 * Negative `Quantity` must affect all totals.

--- a/docs/UI_FLOW.md
+++ b/docs/UI_FLOW.md
@@ -37,7 +37,7 @@ a kezdő elemüket regisztrálják.
 
 1. Számlaszám mező (keresés és létrehozás)
 
-A felső ComboBox időrendben mutatja a meglévő számlaszámokat.
+A felső AutoCompleteBox időrendben mutatja a meglévő számlaszámokat.
 
 Insert lenyomására vagy a lista tetejére lépve az `INumberingService` új számot ajánl fel egy kis megerősítő ablakban.
 

--- a/docs/progress/2025-07-07_20-54-32_ui_agent.md
+++ b/docs/progress/2025-07-07_20-54-32_ui_agent.md
@@ -1,0 +1,3 @@
+- Replaced ComboBox lookup fields with AutoCompleteBox across invoice views.
+- Updated EditLookup control to use Extended WPF Toolkit.
+- Adjusted InvoiceItemsGrid and tests accordingly.

--- a/tests/Wrecept.Tests/EditLookupTests.cs
+++ b/tests/Wrecept.Tests/EditLookupTests.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 using System.Reflection;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Data;
+using Xceed.Wpf.Toolkit;
 using Xunit;
 using Wrecept.Wpf.Views.Controls;
 
@@ -16,39 +16,12 @@ public class EditLookupTests
             new Application();
     }
 
-    private static void InvokeOnTextChanged(EditLookup lookup, TextBox box)
-    {
-        typeof(EditLookup).GetField("_textBox", BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(lookup, box);
-        var m = typeof(EditLookup).GetMethod("OnTextChanged", BindingFlags.Instance | BindingFlags.NonPublic)!;
-        m.Invoke(lookup, new object[] { box, new TextChangedEventArgs(TextBox.TextChangedEvent, UndoAction.None) });
-    }
-
-    [StaFact]
-    public void OnTextChanged_FiltersCollectionView()
+    [Fact]
+    public void AutoCompleteBox_HasContainsFilter()
     {
         EnsureApp();
-        var items = new[] { new { Name = "alma" }, new { Name = "barack" } };
-        var cvs = new CollectionViewSource { Source = items };
-        var lookup = new EditLookup { ItemsSource = cvs, DisplayMemberPath = "Name" };
-        var box = new TextBox { Text = "al" };
-
-        InvokeOnTextChanged(lookup, box);
-        var view = CollectionViewSource.GetDefaultView(cvs);
-        Assert.Single(view.Cast<object>());
-        Assert.True(((ComboBox)typeof(EditLookup).GetField("Box", BindingFlags.Instance | BindingFlags.NonPublic)!.GetValue(lookup)!).IsDropDownOpen);
-
-        box.Text = "zz";
-        InvokeOnTextChanged(lookup, box);
-        Assert.Empty(view.Cast<object>());
-    }
-
-    [Fact]
-    public void Matches_WorksCorrectly()
-    {
-        var lookup = new EditLookup { DisplayMemberPath = "Name" };
-        var m = typeof(EditLookup).GetMethod("Matches", BindingFlags.Instance | BindingFlags.NonPublic)!;
-        var item = new { Name = "korte" };
-        Assert.True((bool)m.Invoke(lookup, new object[] { item, "or" })!);
-        Assert.False((bool)m.Invoke(lookup, new object[] { item, "zz" })!);
+        var lookup = new EditLookup();
+        var box = (AutoCompleteBox)typeof(EditLookup).GetField("Box", BindingFlags.Instance | BindingFlags.NonPublic)!.GetValue(lookup)!;
+        Assert.Equal(AutoCompleteFilterMode.Contains, box.FilterMode);
     }
 }


### PR DESCRIPTION
## Summary
- add Extended WPF Toolkit
- update `EditLookup` to use `AutoCompleteBox`
- use the new control in invoice views
- override `ToString` for PaymentMethod and TaxRate
- refresh UI docs and refactor plan
- adjust unit tests

## Testing
- `dotnet test --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c3317d12c8322ada7adb6581c2a7c