### PR TITLE
Fix InvoiceLookupView XAML namespace

### DIFF
--- a/Wrecept.Wpf/Views/InvoiceLookupView.xaml
+++ b/Wrecept.Wpf/Views/InvoiceLookupView.xaml
@@ -1,8 +1,8 @@
 <UserControl x:Class="Wrecept.Wpf.Views.InvoiceLookupView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:prompt="clr-namespace:Wrecept.Wpf.Views.InlinePrompts"
-             xmlns:vm="clr-namespace:Wrecept.Wpf.ViewModels"
+            xmlns:prompt="clr-namespace:Wrecept.Wpf.Views.InlinePrompts;assembly=Wrecept.Wpf"
+             xmlns:vm="clr-namespace:Wrecept.Wpf.ViewModels;assembly=Wrecept.Wpf"
             >
     <UserControl.Resources>
         <DataTemplate DataType="{x:Type vm:InvoiceCreatePromptViewModel}">

--- a/docs/progress/2025-07-07_21-40-58_ui_agent.md
+++ b/docs/progress/2025-07-07_21-40-58_ui_agent.md
@@ -1,0 +1,1 @@
+- InvoiceLookupView.xaml namespace references updated with explicit assembly.


### PR DESCRIPTION
## Summary
- fix namespace in InvoiceLookupView.xaml so design-time compiler finds InvoiceCreatePromptView and ViewModel
- log progress

## Testing
- `dotnet build Wrecept.sln -c Release` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*
- `dotnet test Wrecept.sln --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c3e105f3c8322aa58fa5e1ad0cf4b