### PR TITLE
Replace leftover ComboBoxes with LookUpEdit

### DIFF
--- a/Wrecept.Wpf/Views/InlineCreators/ProductCreatorView.xaml
+++ b/Wrecept.Wpf/Views/InlineCreators/ProductCreatorView.xaml
@@ -2,7 +2,7 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="clr-namespace:Wrecept.Wpf.ViewModels"
-            >
+             xmlns:c="clr-namespace:Wrecept.Wpf.Views.Controls">
     <Border Background="#F5F5DC" Padding="4" Margin="0,4,0,0">
         <StackPanel>
             <TextBlock Text="Új termék" FontWeight="Bold" />
@@ -20,15 +20,27 @@
             </StackPanel>
             <StackPanel Orientation="Horizontal" Margin="0,4,0,0">
                 <TextBlock Text="Egység" Width="60" />
-                <ComboBox Width="120" ItemsSource="{Binding Units}" SelectedValuePath="Id" DisplayMemberPath="Name" SelectedValue="{Binding UnitId}" />
+                <c:LookUpEdit Width="120"
+                             ItemsSource="{Binding Units}"
+                             SelectedValuePath="Id"
+                             DisplayMemberPath="Name"
+                             SelectedValue="{Binding UnitId}" />
             </StackPanel>
             <StackPanel Orientation="Horizontal" Margin="0,4,0,0">
                 <TextBlock Text="Csoport" Width="60" />
-                <ComboBox Width="120" ItemsSource="{Binding ProductGroups}" SelectedValuePath="Id" DisplayMemberPath="Name" SelectedValue="{Binding ProductGroupId}" />
+                <c:LookUpEdit Width="120"
+                             ItemsSource="{Binding ProductGroups}"
+                             SelectedValuePath="Id"
+                             DisplayMemberPath="Name"
+                             SelectedValue="{Binding ProductGroupId}" />
             </StackPanel>
             <StackPanel Orientation="Horizontal" Margin="0,4,0,0">
                 <TextBlock Text="ÁFA" Width="60" />
-                <ComboBox Width="120" ItemsSource="{Binding TaxRates}" SelectedValuePath="Id" DisplayMemberPath="Name" SelectedValue="{Binding TaxRateId}" />
+                <c:LookUpEdit Width="120"
+                             ItemsSource="{Binding TaxRates}"
+                             SelectedValuePath="Id"
+                             DisplayMemberPath="Name"
+                             SelectedValue="{Binding TaxRateId}" />
             </StackPanel>
             <StackPanel Orientation="Horizontal" Margin="0,4,0,0">
                 <Button Content="OK" Command="{Binding ConfirmCommand}" Width="60" Margin="0,0,4,0" />

--- a/Wrecept.Wpf/Views/ProductMasterView.xaml
+++ b/Wrecept.Wpf/Views/ProductMasterView.xaml
@@ -4,6 +4,7 @@
                               xmlns:views="clr-namespace:Wrecept.Wpf.Views"
                               xmlns:viewsControls="clr-namespace:Wrecept.Wpf.Views.Controls"
                               xmlns:vm="clr-namespace:Wrecept.Wpf.ViewModels"
+                              xmlns:c="clr-namespace:Wrecept.Wpf.Views.Controls"
                               x:TypeArguments="vm:ProductMasterViewModel">
     <viewsControls:BaseMasterView.Columns>
         <DataGridTextColumn Header="Név" Binding="{Binding Name}" Width="*" />
@@ -28,11 +29,11 @@
                 </StackPanel>
                 <StackPanel Orientation="Horizontal" Margin="0,4,0,0">
                     <TextBlock Width="80" Text="ÁFA"/>
-                    <ComboBox Width="120"
-                              ItemsSource="{Binding DataContext.TaxRates, RelativeSource={RelativeSource AncestorType=UserControl}}"
-                              SelectedValuePath="Id"
-                              DisplayMemberPath="Name"
-                              SelectedValue="{Binding TaxRateId, Mode=TwoWay}" />
+                    <c:LookUpEdit Width="120"
+                                 ItemsSource="{Binding DataContext.TaxRates, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                 SelectedValuePath="Id"
+                                 DisplayMemberPath="Name"
+                                 SelectedValue="{Binding TaxRateId, Mode=TwoWay}" />
                 </StackPanel>
             </StackPanel>
         </DataTemplate>

--- a/docs/progress/2025-07-07_22-04-16_ui_agent.md
+++ b/docs/progress/2025-07-07_22-04-16_ui_agent.md
@@ -1,0 +1,1 @@
+- ProductCreatorView és ProductMasterView ComboBox vezérlői LookUpEditre cserélve az egységes AutoComplete viselkedésért.


### PR DESCRIPTION
## Summary
- unify product creator dropdowns using `LookUpEdit`
- replace tax rate selector in `ProductMasterView`
- log UI change

## Testing
- `dotnet test --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c4322ef80832299943f5e71bb6a48