### PR TITLE
Fix InvoiceCreatePromptViewModel resolution

### DIFF
--- a/Wrecept.Wpf/Views/InvoiceLookupView.xaml
+++ b/Wrecept.Wpf/Views/InvoiceLookupView.xaml
@@ -1,8 +1,8 @@
 <UserControl x:Class="Wrecept.Wpf.Views.InvoiceLookupView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-            xmlns:prompt="clr-namespace:Wrecept.Wpf.Views.InlinePrompts;assembly=Wrecept.Wpf"
-             xmlns:vm="clr-namespace:Wrecept.Wpf.ViewModels;assembly=Wrecept.Wpf"
+            xmlns:prompt="clr-namespace:Wrecept.Wpf.Views.InlinePrompts"
+             xmlns:vm="clr-namespace:Wrecept.Wpf.ViewModels"
             >
     <UserControl.Resources>
         <DataTemplate DataType="{x:Type vm:InvoiceCreatePromptViewModel}">

--- a/docs/progress/2025-07-07_22-27-05_ui_agent.md
+++ b/docs/progress/2025-07-07_22-27-05_ui_agent.md
@@ -1,0 +1,1 @@
+- Removed assembly qualification from InvoiceLookupView namespace imports to resolve MC3066 design error.


### PR DESCRIPTION
## Summary
- clean namespace declarations in `InvoiceLookupView`
- log fix in progress notes

## Testing
- `dotnet test --no-restore` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets missing)*

------
https://chatgpt.com/codex/tasks/task_e_686c48cffbac832292f249f21913d464