### PR TITLE
Add invoice lookup keyboard handler

### DIFF
--- a/Wrecept.Wpf/App.xaml.cs
+++ b/Wrecept.Wpf/App.xaml.cs
@@ -13,6 +13,7 @@ using Wrecept.Wpf.ViewModels;
 using Wrecept.Wpf.Views;
 using Wrecept.Wpf.Views.Controls;
 using Wrecept.Wpf.Services;
+using Wrecept.Core.Enums;
 using System.Text.Json;
 using CommunityToolkit.Mvvm.Input;
 using Wrecept.Core.Utilities;
@@ -173,6 +174,11 @@ public static IServiceProvider Provider => Services ?? throw new InvalidOperatio
 
             await EnsureServicesInitializedAsync();
             await Provider.GetRequiredService<AppStateService>().LoadAsync();
+
+            var km = Provider.GetRequiredService<KeyboardManager>();
+            var lookupVm = Provider.GetRequiredService<InvoiceLookupViewModel>();
+            var handler = new InvoiceLookupKeyboardHandler(lookupVm);
+            km.Register(AppInteractionState.BrowsingInvoices, handler);
 
             var orchestrator = Provider.GetRequiredService<StartupOrchestrator>();
             cts = new CancellationTokenSource();

--- a/Wrecept.Wpf/Services/InvoiceLookupKeyboardHandler.cs
+++ b/Wrecept.Wpf/Services/InvoiceLookupKeyboardHandler.cs
@@ -1,0 +1,50 @@
+using System.Windows.Controls;
+using System.Windows.Input;
+using Wrecept.Wpf.ViewModels;
+namespace Wrecept.Wpf.Services;
+
+public class InvoiceLookupKeyboardHandler : IKeyboardHandler
+{
+    private readonly InvoiceLookupViewModel _viewModel;
+
+    public InvoiceLookupKeyboardHandler(InvoiceLookupViewModel viewModel)
+    {
+        _viewModel = viewModel;
+    }
+
+    public bool HandleKey(KeyEventArgs e)
+    {
+        if (e.Key != Key.Insert && e.Key != Key.Up)
+            return false;
+
+        if (Keyboard.FocusedElement is not DependencyObject element)
+            return false;
+
+        var list = GetInvoiceList(element);
+        if (list is null)
+            return false;
+
+        if (list.Items.Count == 0 || list.SelectedIndex <= 0)
+        {
+            _ = _viewModel.PromptNewInvoiceAsync();
+            return true;
+        }
+
+        return false;
+    }
+
+    private static ListBox? GetInvoiceList(DependencyObject element)
+    {
+        if (element is ListBox list && list.Name == "InvoiceList")
+            return list;
+
+        if (element is ListBoxItem item)
+        {
+            var parent = ItemsControl.ItemsControlFromItemContainer(item) as ListBox;
+            if (parent?.Name == "InvoiceList")
+                return parent;
+        }
+
+        return null;
+    }
+}

--- a/Wrecept.Wpf/Views/InvoiceLookupView.xaml.cs
+++ b/Wrecept.Wpf/Views/InvoiceLookupView.xaml.cs
@@ -5,24 +5,28 @@ using Microsoft.Extensions.DependencyInjection;
 using Wrecept.Core.Services;
 using Wrecept.Wpf.ViewModels;
 using Wrecept.Wpf.Services;
+using Wrecept.Core.Enums;
 
 namespace Wrecept.Wpf.Views;
 
 public partial class InvoiceLookupView : UserControl
 {
     private readonly FocusManager _focus;
+    private readonly AppStateService _state;
 
     public InvoiceLookupView() : this(
         App.Provider.GetRequiredService<InvoiceLookupViewModel>(),
-        App.Provider.GetRequiredService<FocusManager>())
+        App.Provider.GetRequiredService<FocusManager>(),
+        App.Provider.GetRequiredService<AppStateService>())
     {
     }
 
-    public InvoiceLookupView(InvoiceLookupViewModel viewModel, FocusManager focus)
+    public InvoiceLookupView(InvoiceLookupViewModel viewModel, FocusManager focus, AppStateService state)
     {
         InitializeComponent();
         DataContext = viewModel;
         _focus = focus;
+        _state = state;
         Loaded += OnLoaded;
     }
 
@@ -32,6 +36,7 @@ public partial class InvoiceLookupView : UserControl
         {
             if (DataContext is InvoiceLookupViewModel vm)
                 await vm.LoadAsync();
+            _state.InteractionState = AppInteractionState.BrowsingInvoices;
             _focus.RequestFocus(InvoiceList);
         }
         catch (Exception ex)

--- a/docs/progress/2025-07-07_23-10-34_code_agent.md
+++ b/docs/progress/2025-07-07_23-10-34_code_agent.md
@@ -1,0 +1,4 @@
+- InvoiceLookupKeyboardHandler introduced for Insert/Up detection on invoice list.
+- Registered handler in App.OnStartup.
+- InvoiceLookupView sets BrowsingInvoices state on load.
+- dotnet build failed due to missing WindowsDesktop SDK.


### PR DESCRIPTION
## Summary
- add `InvoiceLookupKeyboardHandler` for Insert/Up handling
- register handler at startup
- set BrowsingInvoices state when `InvoiceLookupView` loads
- document progress

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*
- `dotnet test --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c523926f48322aa2cbf635d5aa690