### PR TITLE
Implement keyboard handler service

### DIFF
--- a/Wrecept.Wpf/App.xaml.cs
+++ b/Wrecept.Wpf/App.xaml.cs
@@ -138,6 +138,9 @@ public static IServiceProvider Provider => Services ?? throw new InvalidOperatio
         services.AddSingleton<ScreenModeManager>();
         services.AddSingleton<FocusManager>();
         services.AddSingleton<KeyboardManager>();
+        services.AddTransient<StageMenuKeyboardHandler>();
+        services.AddTransient<InvoiceEditorKeyboardHandler>();
+        services.AddTransient<MasterDataKeyboardHandler>();
         services.AddTransient<ProgressViewModel>();
         services.AddTransient<SeedOptionsViewModel>();
         services.AddTransient<SeedOptionsWindow>();
@@ -177,8 +180,17 @@ public static IServiceProvider Provider => Services ?? throw new InvalidOperatio
 
             var km = Provider.GetRequiredService<KeyboardManager>();
             var lookupVm = Provider.GetRequiredService<InvoiceLookupViewModel>();
-            var handler = new InvoiceLookupKeyboardHandler(lookupVm);
-            km.Register(AppInteractionState.BrowsingInvoices, handler);
+            var lookupHandler = new InvoiceLookupKeyboardHandler(lookupVm);
+            km.Register(AppInteractionState.BrowsingInvoices, lookupHandler);
+
+            var stageHandler = Provider.GetRequiredService<StageMenuKeyboardHandler>();
+            km.Register(AppInteractionState.MainMenu, stageHandler);
+
+            var editorHandler = Provider.GetRequiredService<InvoiceEditorKeyboardHandler>();
+            km.Register(AppInteractionState.EditingInvoice, editorHandler);
+
+            var masterHandler = Provider.GetRequiredService<MasterDataKeyboardHandler>();
+            km.Register(AppInteractionState.EditingMasterData, masterHandler);
 
             var orchestrator = Provider.GetRequiredService<StartupOrchestrator>();
             cts = new CancellationTokenSource();

--- a/Wrecept.Wpf/MainWindow.xaml.cs
+++ b/Wrecept.Wpf/MainWindow.xaml.cs
@@ -1,6 +1,7 @@
 using System.Windows;
 using Wrecept.Wpf.Views;
 using Wrecept.Wpf.Services;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Wrecept.Wpf;
 
@@ -10,6 +11,14 @@ public partial class MainWindow : Window
     {
         InitializeComponent();
         ContentHost.Content = stageView;
+        PreviewKeyDown += OnPreviewKeyDown;
         Loaded += async (_, _) => await screenModeManager.ApplySavedAsync(this);
+    }
+
+    private void OnPreviewKeyDown(object sender, System.Windows.Input.KeyEventArgs e)
+    {
+        var km = App.Provider.GetRequiredService<KeyboardManager>();
+        if (km.Process(e))
+            e.Handled = true;
     }
 }

--- a/Wrecept.Wpf/Services/InvoiceEditorKeyboardHandler.cs
+++ b/Wrecept.Wpf/Services/InvoiceEditorKeyboardHandler.cs
@@ -1,0 +1,35 @@
+using System.Windows.Input;
+using CommunityToolkit.Mvvm.Input;
+using Wrecept.Wpf.ViewModels;
+
+namespace Wrecept.Wpf.Services;
+
+public class InvoiceEditorKeyboardHandler : IKeyboardHandler
+{
+    private readonly InvoiceEditorViewModel _vm;
+
+    public InvoiceEditorKeyboardHandler(InvoiceEditorViewModel vm)
+    {
+        _vm = vm;
+    }
+
+    public bool HandleKey(KeyEventArgs e)
+    {
+        switch (e.Key)
+        {
+            case Key.Insert:
+                _vm.AddLineItemCommand.Execute(null);
+                return true;
+            case Key.Delete:
+                _vm.ShowArchivePromptCommand.Execute(null);
+                return true;
+            case Key.Enter:
+                _vm.SaveEditedItemCommand.Execute(null);
+                return true;
+            case Key.Escape:
+                _vm.CloseCommand.Execute(null);
+                return true;
+        }
+        return false;
+    }
+}

--- a/Wrecept.Wpf/Services/MasterDataKeyboardHandler.cs
+++ b/Wrecept.Wpf/Services/MasterDataKeyboardHandler.cs
@@ -1,0 +1,33 @@
+using System.Windows.Input;
+using CommunityToolkit.Mvvm.Input;
+using Wrecept.Wpf.ViewModels;
+
+namespace Wrecept.Wpf.Services;
+
+public class MasterDataKeyboardHandler : IKeyboardHandler
+{
+    private readonly IEditableMasterDataViewModel _vm;
+
+    public MasterDataKeyboardHandler(IEditableMasterDataViewModel vm)
+    {
+        _vm = vm;
+    }
+
+    public bool HandleKey(KeyEventArgs e)
+    {
+        switch (e.Key)
+        {
+            case Key.Insert:
+            case Key.Enter:
+                _vm.EditSelectedCommand.Execute(null);
+                return true;
+            case Key.Delete:
+                _vm.DeleteSelectedCommand.Execute(null);
+                return true;
+            case Key.Escape:
+                _vm.CloseDetailsCommand.Execute(null);
+                return true;
+        }
+        return false;
+    }
+}

--- a/Wrecept.Wpf/Services/StageMenuKeyboardHandler.cs
+++ b/Wrecept.Wpf/Services/StageMenuKeyboardHandler.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Windows.Input;
+using CommunityToolkit.Mvvm.Input;
+using Wrecept.Core.Enums;
+using Wrecept.Wpf.ViewModels;
+
+namespace Wrecept.Wpf.Services;
+
+public class StageMenuKeyboardHandler : IKeyboardHandler
+{
+    private readonly StageViewModel _stage;
+    private readonly StageMenuAction[] _actions = Enum.GetValues<StageMenuAction>();
+    private int _index;
+
+    public StageMenuKeyboardHandler(StageViewModel stage)
+    {
+        _stage = stage;
+    }
+
+    public bool HandleKey(KeyEventArgs e)
+    {
+        switch (e.Key)
+        {
+            case Key.Up:
+                _index = (_index - 1 + _actions.Length) % _actions.Length;
+                _stage.StatusBar.ActiveMenu = _actions[_index].ToString();
+                return true;
+            case Key.Down:
+                _index = (_index + 1) % _actions.Length;
+                _stage.StatusBar.ActiveMenu = _actions[_index].ToString();
+                return true;
+            case Key.Insert:
+            case Key.Enter:
+                var action = _actions[_index];
+                _stage.HandleMenuCommand.Execute(action);
+                return true;
+        }
+        return false;
+    }
+}

--- a/docs/UI_FLOW.md
+++ b/docs/UI_FLOW.md
@@ -23,6 +23,14 @@ számlafejléc mezőknél. A fókusz és a billentyűk útját központi
 `FocusManager` és `KeyboardManager` szolgáltatások rendezik, így a nézetek csak
 a kezdő elemüket regisztrálják.
 
+A billentyűk feldolgozását állapottól függő handlerek végzik:
+- **StageMenuKeyboardHandler** – a főmenüben Up/Down mozgatja a menüpontokat,
+  Insert vagy Enter aktiválja a kijelölt műveletet.
+- **InvoiceEditorKeyboardHandler** – számlaszerkesztéskor az Insert új sort hoz
+  létre, Delete archiválást kér, Enter menti a sort, Escape kilép a szerkesztésből.
+- **MasterDataKeyboardHandler** – törzsadat nézeteknél Insert/Enter szerkeszt,
+  Delete töröl, Escape bezárja a részleteket.
+
 - Fókuszkezdő pontok nézetenként:
   - **StageView** – a főmenüsor első eleme
   - **InvoiceLookupView** – `InvoiceList` `ListBox`

--- a/docs/manuals/developer_guide_hu.md
+++ b/docs/manuals/developer_guide_hu.md
@@ -35,6 +35,8 @@ Ez a dokumentum a projekt fejlesztéséhez szükséges alapvető lépéseket tar
 - A megoldás három fő projektet tartalmaz: `Wrecept.Core`, `Wrecept.Storage` és `Wrecept.Wpf`.
 - A nézetmodellek és szolgáltatások elrendezését a [PROJECT_STRUCTURE.md](../PROJECT_STRUCTURE.md) ismerteti.
 - A felhasználói felület billentyűs működését a [UI_FLOW.md](../UI_FLOW.md) dokumentum részletezi.
+- A billentyűparancsokat a `KeyboardManager` delegálja az egyes
+  `*KeyboardHandler` osztályoknak az alkalmazás állapotától függően.
 
 ## Karbantartási teendők
 

--- a/docs/progress/2025-07-08_00-39-34_code_agent.md
+++ b/docs/progress/2025-07-08_00-39-34_code_agent.md
@@ -1,0 +1,4 @@
+- Keyboard handlers refactored: added StageMenuKeyboardHandler, InvoiceEditorKeyboardHandler and MasterDataKeyboardHandler.
+- MainWindow now routes PreviewKeyDown events through KeyboardManager.
+- App registers handlers for MainMenu, EditingInvoice and EditingMasterData states.
+- Documentation updated with handler descriptions.


### PR DESCRIPTION
## Summary
- route MainWindow key events through KeyboardManager
- register StageMenuKeyboardHandler, InvoiceEditorKeyboardHandler and MasterDataKeyboardHandler
- hook handlers to App interaction states
- document new keyboard handling mechanism

## Testing
- `dotnet build Wrecept.sln -v minimal` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*
- `dotnet test tests/Wrecept.Tests/Wrecept.Tests.csproj -v minimal` *(fails: Project Wrecept.Wpf not compatible with net8.0)*

------
https://chatgpt.com/codex/tasks/task_e_686c622505e88322a6d9843fef6bcfb2