### PR TITLE
Implement CloseCommand in InvoiceEditor

### DIFF
--- a/Wrecept.Wpf/ViewModels/InvoiceEditorViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/InvoiceEditorViewModel.cs
@@ -573,6 +573,19 @@ private void UpdateSupplierId(string name)
             await _exporter.PrintAsync(invoice);
     }
 
+    [RelayCommand]
+    private void Close()
+    {
+        if (IsInLineFinalizationPrompt || SavePrompt != null)
+            return;
+
+        IsInLineFinalizationPrompt = true;
+        SavePrompt = new SaveLinePromptViewModel(
+            this,
+            "Végeztél a szerkesztéssel? (Enter=Mentés, Esc=Mégsem)",
+            finalize: true);
+    }
+
     public void EditLineFromSelection(InvoiceItemRowViewModel selected)
     {
         if (!IsEditable)

--- a/docs/progress/2025-07-08_00-49-25_code_agent.md
+++ b/docs/progress/2025-07-08_00-49-25_code_agent.md
@@ -1,0 +1,1 @@
+- CloseCommand implemented in InvoiceEditorViewModel to display finalization prompt.


### PR DESCRIPTION
## Summary
- add CloseCommand to InvoiceEditorViewModel
- log progress

## Testing
- `dotnet test --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c6989e6b88322b77f828160f8f4d2