### PR TITLE
Fix missing using in InvoiceLookupKeyboardHandler

### DIFF
--- a/Wrecept.Wpf/Services/InvoiceLookupKeyboardHandler.cs
+++ b/Wrecept.Wpf/Services/InvoiceLookupKeyboardHandler.cs
@@ -1,3 +1,4 @@
+using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using Wrecept.Wpf.ViewModels;

--- a/docs/progress/2025-07-08_01-04-11_code_agent.md
+++ b/docs/progress/2025-07-08_01-04-11_code_agent.md
@@ -1,0 +1,2 @@
+- InvoiceLookupKeyboardHandler build fix: added missing `System.Windows` using.
+- `dotnet test` executed, failed due to missing WindowsDesktop SDK.


### PR DESCRIPTION
## Summary
- fix compile error in `InvoiceLookupKeyboardHandler` by referencing `System.Windows`
- log the fix and test attempt

## Testing
- `dotnet test --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c6d8314a88322b1368e781c26f224