### PR TITLE
Fix WPF compile errors

### DIFF
--- a/Wrecept.Wpf/Services/InvoiceLookupKeyboardHandler.cs
+++ b/Wrecept.Wpf/Services/InvoiceLookupKeyboardHandler.cs
@@ -18,7 +18,7 @@ public class InvoiceLookupKeyboardHandler : IKeyboardHandler
         if (e.Key != Key.Insert && e.Key != Key.Up)
             return false;
 
-        if (Keyboard.FocusedElement is not DependencyObject element)
+        if (Keyboard.FocusedElement is not System.Windows.DependencyObject element)
             return false;
 
         var list = GetInvoiceList(element);
@@ -34,7 +34,7 @@ public class InvoiceLookupKeyboardHandler : IKeyboardHandler
         return false;
     }
 
-    private static ListBox? GetInvoiceList(DependencyObject element)
+    private static ListBox? GetInvoiceList(System.Windows.DependencyObject element)
     {
         if (element is ListBox list && list.Name == "InvoiceList")
             return list;

--- a/Wrecept.Wpf/ViewModels/InvoiceEditorViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/InvoiceEditorViewModel.cs
@@ -806,8 +806,9 @@ private void UpdateSupplierId(string name)
                 if (ok)
                 {
                     var newId = _draft.Id;
-                    for (int i = 0; i < _draft.Items.Count && i + 1 < Items.Count; i++)
-                        Items[i + 1].Id = _draft.Items[i].Id;
+                    var draftItems = _draft.Items.ToList();
+                    for (int i = 0; i < draftItems.Count && i + 1 < Items.Count; i++)
+                        Items[i + 1].Id = draftItems[i].Id;
                     InvoiceId = newId;
                     IsNew = false;
                     _draft = new Invoice();

--- a/docs/progress/2025-07-08_01-12-47_code_agent.md
+++ b/docs/progress/2025-07-08_01-12-47_code_agent.md
@@ -1,0 +1,2 @@
+- Fixed compile errors in InvoiceLookupKeyboardHandler and InvoiceEditorViewModel.
+- `DependencyObject` now fully qualified; `_draft.Items` enumerated as list.


### PR DESCRIPTION
## Summary
- reference DependencyObject with full namespace
- use enumerated list for invoice item ids
- log the build fixes

## Testing
- `dotnet test --no-build -nologo` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c6fe698dc832289f3712dfb9a8f91