### PR TITLE
Fix compile error due to invalid LookupBox attribute

### DIFF
--- a/Wrecept.Wpf/Views/InvoiceEditorLayout.xaml
+++ b/Wrecept.Wpf/Views/InvoiceEditorLayout.xaml
@@ -103,7 +103,7 @@
                                           SelectedValuePath="Id"
                                           SelectedValue="{Binding PaymentMethodId}"
                                           CreateCommand="{Binding ShowPaymentMethodCreatorCommand}"
-                                          CreateCommandParameter="{Binding RelativeSource={RelativeSource Self}}"
+                                          CommandParameter="{Binding RelativeSource={RelativeSource Self}}"
                                           IsEnabled="{Binding IsEditable}" />
                         </StackPanel>
 
@@ -161,7 +161,7 @@
                                   SelectedValuePath="Id"
                                   SelectedValue="{Binding TaxRateId, Mode=TwoWay}"
                                   CreateCommand="{Binding DataContext.ShowTaxRateCreatorCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
-                                  CreateCommandParameter="{Binding RelativeSource={RelativeSource Self}}" />
+                                  CommandParameter="{Binding RelativeSource={RelativeSource Self}}" />
                     <TextBox x:Name="EntryDesc" Grid.Column="5" Text="{Binding Description, Mode=TwoWay}" Margin="4,0"
                              />
                 </Grid>

--- a/docs/progress/2025-07-08_01-25-25_ui_agent.md
+++ b/docs/progress/2025-07-08_01-25-25_ui_agent.md
@@ -1,0 +1,2 @@
+- InvoiceEditorLayout XAML compile fix: replaced invalid `CreateCommandParameter` with `CommandParameter`.
+- `dotnet build` failed: WindowsDesktop SDK missing in container.


### PR DESCRIPTION
## Summary
- replace obsolete `CreateCommandParameter` attribute with `CommandParameter` in `InvoiceEditorLayout`
- log the fix in progress notes

## Testing
- `dotnet build Wrecept.sln -c Release` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c72da3e5c83229485de1f6b54e892