### PR TITLE
Fix DI for MasterDataKeyboardHandler

### DIFF
--- a/Wrecept.Wpf/Services/MasterDataKeyboardHandler.cs
+++ b/Wrecept.Wpf/Services/MasterDataKeyboardHandler.cs
@@ -6,11 +6,11 @@ namespace Wrecept.Wpf.Services;
 
 public class MasterDataKeyboardHandler : IKeyboardHandler
 {
-    private readonly IEditableMasterDataViewModel _vm;
+    private readonly StageViewModel _stage;
 
-    public MasterDataKeyboardHandler(IEditableMasterDataViewModel vm)
+    public MasterDataKeyboardHandler(StageViewModel stage)
     {
-        _vm = vm;
+        _stage = stage;
     }
 
     public bool HandleKey(KeyEventArgs e)
@@ -19,13 +19,16 @@ public class MasterDataKeyboardHandler : IKeyboardHandler
         {
             case Key.Insert:
             case Key.Enter:
-                _vm.EditSelectedCommand.Execute(null);
+                if (_stage.CurrentViewModel is IEditableMasterDataViewModel vmEdit)
+                    vmEdit.EditSelectedCommand.Execute(null);
                 return true;
             case Key.Delete:
-                _vm.DeleteSelectedCommand.Execute(null);
+                if (_stage.CurrentViewModel is IEditableMasterDataViewModel vmDel)
+                    vmDel.DeleteSelectedCommand.Execute(null);
                 return true;
             case Key.Escape:
-                _vm.CloseDetailsCommand.Execute(null);
+                if (_stage.CurrentViewModel is IEditableMasterDataViewModel vmClose)
+                    vmClose.CloseDetailsCommand.Execute(null);
                 return true;
         }
         return false;

--- a/docs/UI_FLOW.md
+++ b/docs/UI_FLOW.md
@@ -28,8 +28,9 @@ A billentyűk feldolgozását állapottól függő handlerek végzik:
   Insert vagy Enter aktiválja a kijelölt műveletet.
 - **InvoiceEditorKeyboardHandler** – számlaszerkesztéskor az Insert új sort hoz
   létre, Delete archiválást kér, Enter menti a sort, Escape kilép a szerkesztésből.
-- **MasterDataKeyboardHandler** – törzsadat nézeteknél Insert/Enter szerkeszt,
-  Delete töröl, Escape bezárja a részleteket.
+- **MasterDataKeyboardHandler** – a `StageViewModel.CurrentViewModel` értékét
+  `IEditableMasterDataViewModel`-ként kezeli. Insert/Enter a szerkesztést,
+  Delete a törlést, Escape a részletek bezárását indítja.
 
 - Fókuszkezdő pontok nézetenként:
   - **StageView** – a főmenüsor első eleme

--- a/docs/progress/2025-07-08_01-35-42_code_agent.md
+++ b/docs/progress/2025-07-08_01-35-42_code_agent.md
@@ -1,0 +1,2 @@
+- MasterDataKeyboardHandler now resolves commands from StageViewModel.CurrentViewModel.
+- Updated UI_FLOW.md with handler description.


### PR DESCRIPTION
## Summary
- use `StageViewModel` in `MasterDataKeyboardHandler` to reach the active master data VM
- document keyboard handler lookup
- log progress

## Testing
- `dotnet restore`
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*
- `dotnet test --no-build` *(fails: WindowsDesktop SDK missing)*

------
https://chatgpt.com/codex/tasks/task_e_686c74e76b04832296b93795073ea2fc