### PR TITLE
Fix Insert from invoice list not prompting new invoice

### DIFF
--- a/Wrecept.Wpf/Services/InvoiceEditorKeyboardHandler.cs
+++ b/Wrecept.Wpf/Services/InvoiceEditorKeyboardHandler.cs
@@ -1,3 +1,5 @@
+using System.Windows;
+using System.Windows.Controls;
 using System.Windows.Input;
 using CommunityToolkit.Mvvm.Input;
 using Wrecept.Wpf.ViewModels;
@@ -18,7 +20,15 @@ public class InvoiceEditorKeyboardHandler : IKeyboardHandler
         switch (e.Key)
         {
             case Key.Insert:
-                _vm.AddLineItemCommand.Execute(null);
+                if (Keyboard.FocusedElement is DependencyObject element &&
+                    GetInvoiceList(element) is not null)
+                {
+                    _ = _vm.Lookup.PromptNewInvoiceAsync();
+                }
+                else
+                {
+                    _vm.AddLineItemCommand.Execute(null);
+                }
                 return true;
             case Key.Delete:
                 _vm.ShowArchivePromptCommand.Execute(null);
@@ -31,5 +41,20 @@ public class InvoiceEditorKeyboardHandler : IKeyboardHandler
                 return true;
         }
         return false;
+    }
+
+    private static ListBox? GetInvoiceList(DependencyObject element)
+    {
+        if (element is ListBox list && list.Name == "InvoiceList")
+            return list;
+
+        if (element is ListBoxItem item)
+        {
+            var parent = ItemsControl.ItemsControlFromItemContainer(item) as ListBox;
+            if (parent?.Name == "InvoiceList")
+                return parent;
+        }
+
+        return null;
     }
 }

--- a/docs/progress/2025-07-08_02-15-50_code_agent.md
+++ b/docs/progress/2025-07-08_02-15-50_code_agent.md
@@ -1,0 +1,2 @@
+- InvoiceEditorKeyboardHandler now checks if focus is on InvoiceList.
+- Insert on the list triggers PromptNewInvoiceAsync instead of line insert.


### PR DESCRIPTION
## Summary
- check focused element in `InvoiceEditorKeyboardHandler`
- trigger `PromptNewInvoiceAsync` when InvoiceList has focus
- note change in progress log

## Testing
- `dotnet test --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets missing)*

------
https://chatgpt.com/codex/tasks/task_e_686c7cb765c48322962bebd15608fb74