### PR TITLE
Handle Return key in prompts

### DIFF
--- a/Wrecept.Wpf/Services/InvoiceEditorKeyboardHandler.cs
+++ b/Wrecept.Wpf/Services/InvoiceEditorKeyboardHandler.cs
@@ -34,6 +34,7 @@ public class InvoiceEditorKeyboardHandler : IKeyboardHandler
                 _vm.ShowArchivePromptCommand.Execute(null);
                 return true;
             case Key.Enter:
+            case Key.Return:
                 _vm.SaveEditedItemCommand.Execute(null);
                 return true;
             case Key.Escape:

--- a/Wrecept.Wpf/Services/MasterDataKeyboardHandler.cs
+++ b/Wrecept.Wpf/Services/MasterDataKeyboardHandler.cs
@@ -19,6 +19,7 @@ public class MasterDataKeyboardHandler : IKeyboardHandler
         {
             case Key.Insert:
             case Key.Enter:
+            case Key.Return:
                 if (_stage.CurrentViewModel is IEditableMasterDataViewModel vmEdit)
                     vmEdit.EditSelectedCommand.Execute(null);
                 return true;

--- a/Wrecept.Wpf/Services/StageMenuKeyboardHandler.cs
+++ b/Wrecept.Wpf/Services/StageMenuKeyboardHandler.cs
@@ -31,6 +31,7 @@ public class StageMenuKeyboardHandler : IKeyboardHandler
                 return true;
             case Key.Insert:
             case Key.Enter:
+            case Key.Return:
                 var action = _actions[_index];
                 _stage.HandleMenuCommand.Execute(action);
                 return true;

--- a/Wrecept.Wpf/Views/InlinePrompts/ArchivePromptView.xaml
+++ b/Wrecept.Wpf/Views/InlinePrompts/ArchivePromptView.xaml
@@ -4,6 +4,7 @@
              Loaded="OnLoaded">
     <UserControl.InputBindings>
         <KeyBinding Key="Enter" Command="{Binding ConfirmAsyncCommand}" />
+        <KeyBinding Key="Return" Command="{Binding ConfirmAsyncCommand}" />
         <KeyBinding Key="Escape" Command="{Binding CancelCommand}" />
     </UserControl.InputBindings>
     <Border Background="#F5F5DC" Padding="4" Margin="0,4,0,0">

--- a/Wrecept.Wpf/Views/InlinePrompts/DeleteItemPromptView.xaml
+++ b/Wrecept.Wpf/Views/InlinePrompts/DeleteItemPromptView.xaml
@@ -7,6 +7,7 @@
             IsEnabled="{Binding DataContext.IsEditable, RelativeSource={RelativeSource AncestorType=view:InvoiceEditorLayout}}">
     <UserControl.InputBindings>
         <KeyBinding Key="Enter" Command="{Binding ConfirmCommand}" />
+        <KeyBinding Key="Return" Command="{Binding ConfirmCommand}" />
         <KeyBinding Key="Escape" Command="{Binding CancelCommand}" />
     </UserControl.InputBindings>
     <Border Background="#F5F5DC" Padding="4" Margin="0,4,0,0">

--- a/Wrecept.Wpf/Views/InlinePrompts/InvoiceCreatePromptView.xaml
+++ b/Wrecept.Wpf/Views/InlinePrompts/InvoiceCreatePromptView.xaml
@@ -4,6 +4,7 @@
              Loaded="OnLoaded">
     <UserControl.InputBindings>
         <KeyBinding Key="Enter" Command="{Binding ConfirmAsyncCommand}" />
+        <KeyBinding Key="Return" Command="{Binding ConfirmAsyncCommand}" />
         <KeyBinding Key="Escape" Command="{Binding CancelCommand}" />
     </UserControl.InputBindings>
     <Border Background="#F5F5DC" Padding="4" Margin="0,4,0,0" HorizontalAlignment="Center">
@@ -11,6 +12,7 @@
             <TextBox x:Name="NumberBox" Width="120" Text="{Binding EditableNumber, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,4,0">
                 <TextBox.InputBindings>
                     <KeyBinding Key="Enter" Command="{Binding ConfirmAsyncCommand}" />
+                    <KeyBinding Key="Return" Command="{Binding ConfirmAsyncCommand}" />
                     <KeyBinding Key="Escape" Command="{Binding CancelCommand}" />
                 </TextBox.InputBindings>
             </TextBox>

--- a/Wrecept.Wpf/Views/InlinePrompts/SaveLinePromptView.xaml
+++ b/Wrecept.Wpf/Views/InlinePrompts/SaveLinePromptView.xaml
@@ -7,6 +7,7 @@
             IsEnabled="{Binding DataContext.IsEditable, RelativeSource={RelativeSource AncestorType=view:InvoiceEditorLayout}}">
     <UserControl.InputBindings>
         <KeyBinding Key="Enter" Command="{Binding ConfirmAsyncCommand}" />
+        <KeyBinding Key="Return" Command="{Binding ConfirmAsyncCommand}" />
         <KeyBinding Key="Escape" Command="{Binding CancelCommand}" />
     </UserControl.InputBindings>
     <Border Background="#F5F5DC" Padding="4" Margin="0,4,0,0">

--- a/docs/progress/2025-07-08_02-40-21_logic_agent.md
+++ b/docs/progress/2025-07-08_02-40-21_logic_agent.md
@@ -1,0 +1,2 @@
+- Fix prompt confirmations to accept both Return and numeric Enter.
+- Updated keyboard handlers for StageMenu, MasterData and InvoiceEditor.


### PR DESCRIPTION
## Summary
- accept both Return and numeric Enter for confirmation prompts
- route Return key in StageMenu, MasterData, and InvoiceEditor handlers
- log progress

## Testing
- `dotnet test --no-build` *(fails: WindowsDesktop SDK not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c80d7cd908322bc639fd9e6fbba81