### PR TITLE
Fix keyboard switch cases and update Appium tests

### DIFF
--- a/Wrecept.Wpf/Services/InvoiceEditorKeyboardHandler.cs
+++ b/Wrecept.Wpf/Services/InvoiceEditorKeyboardHandler.cs
@@ -33,8 +33,7 @@ public class InvoiceEditorKeyboardHandler : IKeyboardHandler
             case Key.Delete:
                 _vm.ShowArchivePromptCommand.Execute(null);
                 return true;
-            case Key.Enter:
-            case Key.Return:
+            case Key.Enter or Key.Return:
                 _vm.SaveEditedItemCommand.Execute(null);
                 return true;
             case Key.Escape:

--- a/Wrecept.Wpf/Services/MasterDataKeyboardHandler.cs
+++ b/Wrecept.Wpf/Services/MasterDataKeyboardHandler.cs
@@ -18,8 +18,7 @@ public class MasterDataKeyboardHandler : IKeyboardHandler
         switch (e.Key)
         {
             case Key.Insert:
-            case Key.Enter:
-            case Key.Return:
+            case Key.Enter or Key.Return:
                 if (_stage.CurrentViewModel is IEditableMasterDataViewModel vmEdit)
                     vmEdit.EditSelectedCommand.Execute(null);
                 return true;

--- a/Wrecept.Wpf/Services/StageMenuKeyboardHandler.cs
+++ b/Wrecept.Wpf/Services/StageMenuKeyboardHandler.cs
@@ -30,8 +30,7 @@ public class StageMenuKeyboardHandler : IKeyboardHandler
                 _stage.StatusBar.ActiveMenu = _actions[_index].ToString();
                 return true;
             case Key.Insert:
-            case Key.Enter:
-            case Key.Return:
+            case Key.Enter or Key.Return:
                 var action = _actions[_index];
                 _stage.HandleMenuCommand.Execute(action);
                 return true;

--- a/docs/progress/2025-07-08_07-56-46_logic_agent.md
+++ b/docs/progress/2025-07-08_07-56-46_logic_agent.md
@@ -1,0 +1,2 @@
+- Fix cs compile errors by merging Key.Enter and Key.Return cases.
+- Updated UI tests to use By.Name queries.

--- a/tests/Wrecept.UiTests/InvoiceEditorTests.cs
+++ b/tests/Wrecept.UiTests/InvoiceEditorTests.cs
@@ -36,9 +36,9 @@ public class InvoiceEditorTests
 
         var wait = new WebDriverWait(driver, TimeSpan.FromSeconds(5));
 
-        var options = driver.FindElementsByName("Mintaszámok");
+        var options = driver.FindElements(By.Name("Mintaszámok"));
         if (options.Count > 0)
-            options[0].FindElementByName("Mégse").Click();
+            options[0].FindElement(By.Name("Mégse")).Click();
 
         var list = wait.Until(d => ((WindowsDriver<WindowsElement>)d)
             .FindElementByAccessibilityId("InvoiceList"));
@@ -70,9 +70,9 @@ public class InvoiceEditorTests
 
         var wait = new WebDriverWait(driver, TimeSpan.FromSeconds(5));
 
-        var options = driver.FindElementsByName("Mintaszámok");
+        var options = driver.FindElements(By.Name("Mintaszámok"));
         if (options.Count > 0)
-            options[0].FindElementByName("Mégse").Click();
+            options[0].FindElement(By.Name("Mégse")).Click();
 
         var list = wait.Until(d => ((WindowsDriver<WindowsElement>)d)
             .FindElementByAccessibilityId("InvoiceList"));

--- a/tests/Wrecept.UiTests/MasterDataNavigationTests.cs
+++ b/tests/Wrecept.UiTests/MasterDataNavigationTests.cs
@@ -24,8 +24,8 @@ public class MasterDataNavigationTests
     {
         using var driver = LaunchApp();
 
-        driver.FindElementByName("Törzsek").Click();
-        driver.FindElementByName(item).Click();
+        driver.FindElement(By.Name("Törzsek")).Click();
+        driver.FindElement(By.Name(item)).Click();
 
         var wait = new WebDriverWait(driver, TimeSpan.FromSeconds(5));
         var grid = wait.Until(d => ((WindowsDriver<WindowsElement>)d)

--- a/tests/Wrecept.UiTests/MenuNavigationTests.cs
+++ b/tests/Wrecept.UiTests/MenuNavigationTests.cs
@@ -21,8 +21,8 @@ public class MenuNavigationTests
     {
         using var driver = LaunchApp();
 
-        driver.FindElementByName("Névjegy").Click();
-        driver.FindElementByName("A program felhasználójának adatai").Click();
+        driver.FindElement(By.Name("Névjegy")).Click();
+        driver.FindElement(By.Name("A program felhasználójának adatai")).Click();
 
         Assert.IsTrue(driver.PageSource.Contains("Program neve"));
         driver.Close();
@@ -33,8 +33,8 @@ public class MenuNavigationTests
     {
         using var driver = LaunchApp();
 
-        driver.FindElementByName("Vége").Click();
-        driver.FindElementByName("Kilépés").Click();
+        driver.FindElement(By.Name("Vége")).Click();
+        driver.FindElement(By.Name("Kilépés")).Click();
         Thread.Sleep(1000);
 
         Assert.ThrowsException<WebDriverException>(() => _ = driver.Title);

--- a/tests/Wrecept.UiTests/ScreenModeTests.cs
+++ b/tests/Wrecept.UiTests/ScreenModeTests.cs
@@ -19,15 +19,15 @@ public class ScreenModeTests
     {
         using var driver = LaunchApp();
 
-        driver.FindElementByName("Szerviz").Click();
-        driver.FindElementByName("Képernyő beállítása").Click();
+        driver.FindElement(By.Name("Szerviz")).Click();
+        driver.FindElement(By.Name("Képernyő beállítása")).Click();
 
         var wait = new WebDriverWait(driver, TimeSpan.FromSeconds(5));
         var window = wait.Until(d => ((WindowsDriver<WindowsElement>)d)
-            .FindElementByName("Képernyőbeállítás"));
-        window.FindElementByName("Mégse").Click();
+            .FindElement(By.Name("Képernyőbeállítás")));
+        window.FindElement(By.Name("Mégse")).Click();
 
-        Assert.ThrowsException<OpenQA.Selenium.WebDriverException>(() => driver.FindElementByName("Képernyőbeállítás"));
+        Assert.ThrowsException<OpenQA.Selenium.WebDriverException>(() => driver.FindElement(By.Name("Képernyőbeállítás")));
         driver.Close();
     }
 }

--- a/tests/Wrecept.UiTests/StartupWindowTests.cs
+++ b/tests/Wrecept.UiTests/StartupWindowTests.cs
@@ -36,11 +36,11 @@ public class StartupWindowTests
 
         var wait = new OpenQA.Selenium.Support.UI.WebDriverWait(driver, TimeSpan.FromSeconds(5));
         var optionsWindow = wait.Until(d => ((WindowsDriver<WindowsElement>)d)
-            .FindElementByName("Mintaszámok"));
-        optionsWindow.FindElementByName("Mégse").Click();
+            .FindElement(By.Name("Mintaszámok")));
+        optionsWindow.FindElement(By.Name("Mégse")).Click();
 
         var mainWindow = wait.Until(d => ((WindowsDriver<WindowsElement>)d)
-            .FindElementByName("Wrecept"));
+            .FindElement(By.Name("Wrecept")));
         Assert.IsNotNull(mainWindow);
         driver.Close();
     }
@@ -53,11 +53,11 @@ public class StartupWindowTests
 
         var wait = new OpenQA.Selenium.Support.UI.WebDriverWait(driver, TimeSpan.FromSeconds(5));
         var optionsWindow = wait.Until(d => ((WindowsDriver<WindowsElement>)d)
-            .FindElementByName("Mintaszámok"));
-        optionsWindow.FindElementByName("OK").Click();
+            .FindElement(By.Name("Mintaszámok")));
+        optionsWindow.FindElement(By.Name("OK")).Click();
 
         var startupWindow = wait.Until(d => ((WindowsDriver<WindowsElement>)d)
-            .FindElementByName("Indulás"));
+            .FindElement(By.Name("Indulás")));
         Assert.IsNotNull(startupWindow);
 
         driver.Close();
@@ -71,22 +71,22 @@ public class StartupWindowTests
 
         var wait = new WebDriverWait(driver, TimeSpan.FromSeconds(5));
         var setupWindow = wait.Until(d => ((WindowsDriver<WindowsElement>)d)
-            .FindElementByName("Első indítás"));
-        setupWindow.FindElementByName("OK").Click();
+            .FindElement(By.Name("Első indítás")));
+        setupWindow.FindElement(By.Name("OK")).Click();
 
         var editorWindow = wait.Until(d => ((WindowsDriver<WindowsElement>)d)
-            .FindElementByName("Tulajdonosi adatok"));
+            .FindElement(By.Name("Tulajdonosi adatok")));
         wait.Until(d => ((WindowsDriver<WindowsElement>)d)
-            .FindElementByAccessibilityId("CompanyNameBox")).SendKeys("Teszt Kft.");
-        driver.FindElementByAccessibilityId("AddressBox").SendKeys("Siklós, Fő utca 1.");
-        driver.FindElementByAccessibilityId("PhoneBox").SendKeys("1111");
-        driver.FindElementByAccessibilityId("EmailBox").SendKeys("teszt@example.hu");
-        driver.FindElementByAccessibilityId("TaxNumberBox").SendKeys("123");
-        driver.FindElementByAccessibilityId("BankAccountBox").SendKeys("111");
+            .FindElement(By.Id("CompanyNameBox"))).SendKeys("Teszt Kft.");
+        driver.FindElement(By.Id("AddressBox")).SendKeys("Siklós, Fő utca 1.");
+        driver.FindElement(By.Id("PhoneBox")).SendKeys("1111");
+        driver.FindElement(By.Id("EmailBox")).SendKeys("teszt@example.hu");
+        driver.FindElement(By.Id("TaxNumberBox")).SendKeys("123");
+        driver.FindElement(By.Id("BankAccountBox")).SendKeys("111");
         new Actions(driver).SendKeys(OpenQA.Selenium.Keys.Enter).Perform();
 
         wait.Until(d => ((WindowsDriver<WindowsElement>)d)
-            .FindElementByName("Wrecept"));
+            .FindElement(By.Name("Wrecept")));
         driver.Close();
     }
 
@@ -98,8 +98,8 @@ public class StartupWindowTests
 
         var wait = new WebDriverWait(driver, TimeSpan.FromSeconds(5));
         var setupWindow = wait.Until(d => ((WindowsDriver<WindowsElement>)d)
-            .FindElementByName("Első indítás"));
-        setupWindow.FindElementByName("Mégse").Click();
+            .FindElement(By.Name("Első indítás")));
+        setupWindow.FindElement(By.Name("Mégse")).Click();
 
         Assert.ThrowsException<WebDriverException>(() => _ = driver.Title);
     }
@@ -112,12 +112,12 @@ public class StartupWindowTests
 
         var wait = new WebDriverWait(driver, TimeSpan.FromSeconds(5));
         var setupWindow = wait.Until(d => ((WindowsDriver<WindowsElement>)d)
-            .FindElementByName("Első indítás"));
-        setupWindow.FindElementByName("OK").Click();
+            .FindElement(By.Name("Első indítás")));
+        setupWindow.FindElement(By.Name("OK")).Click();
 
         var editorWindow = wait.Until(d => ((WindowsDriver<WindowsElement>)d)
-            .FindElementByName("Tulajdonosi adatok"));
-        editorWindow.FindElementByName("Mégse").Click();
+            .FindElement(By.Name("Tulajdonosi adatok")));
+        editorWindow.FindElement(By.Name("Mégse")).Click();
 
         Assert.ThrowsException<WebDriverException>(() => _ = driver.Title);
     }

--- a/tests/Wrecept.UiTests/TestHelper.cs
+++ b/tests/Wrecept.UiTests/TestHelper.cs
@@ -107,12 +107,12 @@ internal static class TestHelper
     {
         foreach (var title in new[] { "Első indítás", "Megerősítés" })
         {
-            var dialogs = driver.FindElementsByName(title);
+            var dialogs = driver.FindElements(By.Name(title));
             if (dialogs.Count > 0)
             {
                 try
                 {
-                    dialogs[0].FindElementByName("Igen").Click();
+                    dialogs[0].FindElement(By.Name("Igen")).Click();
                 }
                 catch (WebDriverException)
                 {
@@ -144,16 +144,16 @@ internal static class TestHelper
     {
         if (driver.PageSource.Contains("Megerősítés"))
         {
-            var dialog = driver.FindElementByName("Megerősítés");
-            dialog.FindElementByName("Igen").Click();
+            var dialog = driver.FindElement(By.Name("Megerősítés"));
+            dialog.FindElement(By.Name("Igen")).Click();
         }
     }
 
     internal static void RunFirstLaunchSetup(WindowsDriver<WindowsElement> driver)
     {
         var wait = new WebDriverWait(driver, TimeSpan.FromSeconds(5));
-        var setupWindow = wait.Until(_ => driver.FindElementByName("Első indítás"));
-        setupWindow.FindElementByName("OK").Click();
+        var setupWindow = wait.Until(_ => driver.FindElement(By.Name("Első indítás")));
+        setupWindow.FindElement(By.Name("OK")).Click();
 
         var companyBox = WaitForElementById(driver, "CompanyNameBox");
         companyBox.SendKeys("Teszt Kft.");
@@ -163,7 +163,7 @@ internal static class TestHelper
         driver.FindElementByAccessibilityId("TaxNumberBox").SendKeys("1111");
         driver.FindElementByAccessibilityId("BankAccountBox").SendKeys("0000");
 
-        driver.FindElementByName("OK").Click();
+        driver.FindElement(By.Name("OK")).Click();
         HandleConfirmationDialog(driver);
     }
 


### PR DESCRIPTION
## Summary
- consolidate duplicate `Key.Return` switch labels using C# pattern matching
- replace `FindElementByName` usage with `FindElement(By.Name())` in UI tests
- log progress for logic_agent

## Testing
- `dotnet test --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ccdd726f48322a23536c22a71d592