### PR TITLE
Add DB indexes for faster queries

### DIFF
--- a/Wrecept.Storage/Data/AppDbContext.cs
+++ b/Wrecept.Storage/Data/AppDbContext.cs
@@ -30,5 +30,13 @@ public class AppDbContext : DbContext
             .HasIndex(u => new { u.Name, u.IsArchived });
         modelBuilder.Entity<Unit>()
             .HasIndex(u => new { u.Code, u.IsArchived });
+
+        modelBuilder.Entity<Invoice>()
+            .HasIndex(i => i.Date);
+        modelBuilder.Entity<Invoice>()
+            .HasIndex(i => i.SupplierId);
+
+        modelBuilder.Entity<Product>()
+            .HasIndex(p => p.Name);
     }
 }

--- a/Wrecept.Storage/Migrations/20250708123435_AddInvoiceAndProductIndexes.Designer.cs
+++ b/Wrecept.Storage/Migrations/20250708123435_AddInvoiceAndProductIndexes.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Wrecept.Storage.Data;
 
@@ -10,9 +11,11 @@ using Wrecept.Storage.Data;
 namespace Wrecept.Storage.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250708123435_AddInvoiceAndProductIndexes")]
+    partial class AddInvoiceAndProductIndexes
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "8.0.4");
@@ -53,11 +56,11 @@ namespace Wrecept.Storage.Migrations
 
                     b.HasKey("Id");
 
+                    b.HasIndex("Date");
+
                     b.HasIndex("PaymentMethodId");
 
                     b.HasIndex("SupplierId");
-
-                    b.HasIndex("Date");
 
                     b.ToTable("Invoices");
                 });
@@ -167,13 +170,13 @@ namespace Wrecept.Storage.Migrations
 
                     b.HasKey("Id");
 
+                    b.HasIndex("Name");
+
                     b.HasIndex("ProductGroupId");
 
                     b.HasIndex("TaxRateId");
 
                     b.HasIndex("UnitId");
-
-                    b.HasIndex("Name");
 
                     b.ToTable("Products");
                 });
@@ -236,7 +239,6 @@ namespace Wrecept.Storage.Migrations
                         .HasColumnType("TEXT");
 
                     b.Property<string>("Code")
-                        .IsRequired()
                         .HasColumnType("TEXT");
 
                     b.Property<DateTime>("CreatedAt")
@@ -277,7 +279,6 @@ namespace Wrecept.Storage.Migrations
                         .HasColumnType("TEXT");
 
                     b.Property<string>("Code")
-                        .IsRequired()
                         .HasColumnType("TEXT");
 
                     b.Property<DateTime>("CreatedAt")

--- a/Wrecept.Storage/Migrations/20250708123435_AddInvoiceAndProductIndexes.cs
+++ b/Wrecept.Storage/Migrations/20250708123435_AddInvoiceAndProductIndexes.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Wrecept.Storage.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddInvoiceAndProductIndexes : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "IX_Products_Name",
+                table: "Products",
+                column: "Name");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Invoices_Date",
+                table: "Invoices",
+                column: "Date");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Products_Name",
+                table: "Products");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Invoices_Date",
+                table: "Invoices");
+        }
+    }
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -47,6 +47,11 @@ Az `InvoiceService` kezeli a fejléc frissítését (`UpdateInvoiceHeaderAsync`)
 Az új `RemoveItemAsync` metódus lehetővé teszi egy meglévő tétel törlését adatbázisból.
 Az `IInvoiceExportService` felülete biztosít PDF mentést és nyomtatást, a `PdfInvoiceExporter` a WPF rétegben valósítja meg.
 
+Az `OnModelCreating` metódus indexeket készít a gyakran szűrt mezőkre:
+`Invoices.Date`, `Invoices.SupplierId` és `Products.Name`. A korábbi
+`TaxRate` és `Unit` indexekhez hasonlóan ezek is a lekérdezések gyorsítását
+segítik.
+
 Minden hibát az `ILogService` rögzít, amelyet a Storage réteg `LogService` implementációja valósít meg. A naplók a `%AppData%/Wrecept/logs` mappában napi bontású fájlokba kerülnek.
 Felhasználói üzenetekhez az `INotificationService` ad egységes felületet. WPF alatt a `MessageBoxNotificationService` jeleníti meg a dialógusokat, míg a tesztekben egy csonk "MockNotificationService" működik.
 Az alapvető cégadatokat a `UserInfoService` kezeli. Az adatok a `%AppData%/Wrecept/wrecept.json` fájlban tárolódnak, betöltésük az alkalmazás futása közben történik.

--- a/docs/progress/2025-07-08_12-35-48_docs_agent.md
+++ b/docs/progress/2025-07-08_12-35-48_docs_agent.md
@@ -1,0 +1,1 @@
+- Bővítettem az ARCHITECTURE.md dokumentációt az új adatbázis indexekkel.

--- a/docs/progress/2025-07-08_12-35-48_storage_agent.md
+++ b/docs/progress/2025-07-08_12-35-48_storage_agent.md
@@ -1,0 +1,2 @@
+- Indexeket adtam az Invoices.Date, Invoices.SupplierId és Products.Name mezőkre.
+- Létrehoztam EF Core migrációt `AddInvoiceAndProductIndexes` néven.


### PR DESCRIPTION
## Summary
- add indexes for invoice dates, supplier filter, and product names
- generate EF Core migration
- document the new indexes in `ARCHITECTURE.md`
- log progress for storage and docs agents

## Testing
- `dotnet test --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets missing)*

------
https://chatgpt.com/codex/tasks/task_e_686d0f1398b48322a66b96b20b1e4906