### PR TITLE
Improve invoice editor key handling

### DIFF
--- a/Wrecept.Wpf/App.xaml.cs
+++ b/Wrecept.Wpf/App.xaml.cs
@@ -189,6 +189,8 @@ public static IServiceProvider Provider => Services ?? throw new InvalidOperatio
 
             var editorHandler = Provider.GetRequiredService<InvoiceEditorKeyboardHandler>();
             km.Register(AppInteractionState.EditingInvoice, editorHandler);
+            km.Register(AppInteractionState.InlineCreatorActive, editorHandler);
+            km.Register(AppInteractionState.InlinePromptActive, editorHandler);
 
             var masterHandler = Provider.GetRequiredService<MasterDataKeyboardHandler>();
             km.Register(AppInteractionState.EditingMasterData, masterHandler);

--- a/Wrecept.Wpf/Services/InvoiceEditorKeyboardHandler.cs
+++ b/Wrecept.Wpf/Services/InvoiceEditorKeyboardHandler.cs
@@ -31,14 +31,26 @@ public class InvoiceEditorKeyboardHandler : IKeyboardHandler
                 }
                 return true;
             case Key.Delete:
-                _vm.ShowArchivePromptCommand.Execute(null);
-                return true;
+                if (Keyboard.FocusedElement is DependencyObject del && IsEntryOrGrid(del))
+                {
+                    _vm.ShowArchivePromptCommand.Execute(null);
+                    return true;
+                }
+                return false;
             case Key.Enter or Key.Return:
-                _vm.SaveEditedItemCommand.Execute(null);
-                return true;
+                if (Keyboard.FocusedElement is DependencyObject enter && IsEntryOrGrid(enter))
+                {
+                    _vm.SaveEditedItemCommand.Execute(null);
+                    return true;
+                }
+                return false;
             case Key.Escape:
-                _vm.CloseCommand.Execute(null);
-                return true;
+                if (Keyboard.FocusedElement is DependencyObject esc && IsEntryOrGrid(esc))
+                {
+                    _vm.CloseCommand.Execute(null);
+                    return true;
+                }
+                return false;
         }
         return false;
     }
@@ -56,5 +68,13 @@ public class InvoiceEditorKeyboardHandler : IKeyboardHandler
         }
 
         return null;
+    }
+
+    private static bool IsEntryOrGrid(DependencyObject element)
+    {
+        if (element is FrameworkElement fe && fe.Name.StartsWith("Entry"))
+            return true;
+
+        return element.FindAncestor<InvoiceItemsGrid>() != null;
     }
 }

--- a/docs/UI_FLOW.md
+++ b/docs/UI_FLOW.md
@@ -27,7 +27,9 @@ A billentyűk feldolgozását állapottól függő handlerek végzik:
 - **StageMenuKeyboardHandler** – a főmenüben Up/Down mozgatja a menüpontokat,
   Insert vagy Enter aktiválja a kijelölt műveletet.
 - **InvoiceEditorKeyboardHandler** – számlaszerkesztéskor az Insert új sort hoz
-  létre, Delete archiválást kér, Enter menti a sort, Escape kilép a szerkesztésből.
+  létre. A Delete/Enter/Escape billentyűk csak akkor hatnak, ha a fókusz a sorbeviteli
+  mezőkön vagy a terméktáblán áll; ilyenkor archiválást kérnek, sort mentenek,
+  illetve befejezik a szerkesztést.
 - **MasterDataKeyboardHandler** – a `StageViewModel.CurrentViewModel` értékét
   `IEditableMasterDataViewModel`-ként kezeli. Insert/Enter a szerkesztést,
   Delete a törlést, Escape a részletek bezárását indítja.

--- a/docs/manuals/developer_guide_hu.md
+++ b/docs/manuals/developer_guide_hu.md
@@ -37,6 +37,8 @@ Ez a dokumentum a projekt fejlesztéséhez szükséges alapvető lépéseket tar
 - A felhasználói felület billentyűs működését a [UI_FLOW.md](../UI_FLOW.md) dokumentum részletezi.
 - A billentyűparancsokat a `KeyboardManager` delegálja az egyes
   `*KeyboardHandler` osztályoknak az alkalmazás állapotától függően.
+  Az `InvoiceEditorKeyboardHandler` csak akkor reagál az Enter/Esc/Delete
+  billentyűkre, ha a fókusz a sorbeviteli mezőknél vagy a terméktáblán van.
 
 ## Karbantartási teendők
 

--- a/docs/progress/2025-07-08_16-40-21_logic_agent.md
+++ b/docs/progress/2025-07-08_16-40-21_logic_agent.md
@@ -1,0 +1,3 @@
+- Enter/Esc/Delete now require focus on line fields or item grid.
+- KeyboardManager registers InvoiceEditorKeyboardHandler for InlineCreatorActive and InlinePromptActive states.
+- Updated UI_FLOW and developer guide accordingly.


### PR DESCRIPTION
## Summary
- restrict Enter/Esc/Delete actions in `InvoiceEditorKeyboardHandler`
- register editor handler for inline creation/prompt states
- document updated keyboard logic
- log progress

## Testing
- `dotnet test --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d46c48b3883229068bad6e6f54c92