### PR TITLE
Implement database initializer service

### DIFF
--- a/Wrecept.Core/Services/IDatabaseInitializer.cs
+++ b/Wrecept.Core/Services/IDatabaseInitializer.cs
@@ -1,0 +1,6 @@
+namespace Wrecept.Core.Services;
+
+public interface IDatabaseInitializer
+{
+    Task InitializeAsync(CancellationToken ct = default);
+}

--- a/Wrecept.Storage/ServiceCollectionExtensions.cs
+++ b/Wrecept.Storage/ServiceCollectionExtensions.cs
@@ -48,12 +48,6 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<INumberingService>(_ => new NumberingService(numberPath));
         services.AddScoped<IBackupService>(_ => new FileBackupService(dbPath, userInfoPath, settingsPath));
         services.AddScoped<IDbHealthService, DbHealthService>();
-
-        using var provider = services.BuildServiceProvider();
-        var factory = provider.GetRequiredService<IDbContextFactory<AppDbContext>>();
-        var logger = provider.GetRequiredService<ILogService>();
-        await using var ctx = factory.CreateDbContext();
-        await DbInitializer.EnsureCreatedAndMigratedAsync(ctx, logger);
-        await ctx.Database.ExecuteSqlRawAsync("PRAGMA journal_mode=WAL");
+        services.AddSingleton<IDatabaseInitializer, DatabaseInitializer>();
     }
 }

--- a/Wrecept.Storage/Services/DatabaseInitializer.cs
+++ b/Wrecept.Storage/Services/DatabaseInitializer.cs
@@ -1,0 +1,24 @@
+using Microsoft.EntityFrameworkCore;
+using Wrecept.Core.Services;
+using Wrecept.Storage.Data;
+
+namespace Wrecept.Storage.Services;
+
+public class DatabaseInitializer : IDatabaseInitializer
+{
+    private readonly IDbContextFactory<AppDbContext> _factory;
+    private readonly ILogService _log;
+
+    public DatabaseInitializer(IDbContextFactory<AppDbContext> factory, ILogService log)
+    {
+        _factory = factory;
+        _log = log;
+    }
+
+    public async Task InitializeAsync(CancellationToken ct = default)
+    {
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        await DbInitializer.EnsureCreatedAndMigratedAsync(ctx, _log, ct);
+        await ctx.Database.ExecuteSqlRawAsync("PRAGMA journal_mode=WAL", ct);
+    }
+}

--- a/Wrecept.Wpf/App.xaml.cs
+++ b/Wrecept.Wpf/App.xaml.cs
@@ -177,6 +177,7 @@ public static IServiceProvider Provider => Services ?? throw new InvalidOperatio
             ShutdownMode = ShutdownMode.OnExplicitShutdown;
 
             await EnsureServicesInitializedAsync();
+            await Provider.GetRequiredService<IDatabaseInitializer>().InitializeAsync();
             await Provider.GetRequiredService<AppStateService>().LoadAsync();
 
             var km = Provider.GetRequiredService<KeyboardManager>();

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -70,12 +70,11 @@ A különböző mesteradat nézeteket kiszolgáló ViewModel-ek mind az `Editabl
 
 Minden domain modell tartalmaz `CreatedAt` és `UpdatedAt` mezőket. Ezeket a service réteg inicializálja, így naplózható az adat módosításának ideje.
 
- Az alkalmazás indításakor a `DbInitializer` a `Database.Migrate()` hívással
- hozza létre vagy frissíti az adatbázist. A migráció futása automatikusan
- létrehozza az `__EFMigrationsHistory` táblát is, így külön
- `EnsureCreated()` hívásra nincs szükség.
-  Az `AddStorageAsync` kiterjesztés ehhez `IDbContextFactory`-t használ,
-  így a migráció egy külön kontextuson történik és azonnal eldobásra kerül.
+ Az alkalmazás indításakor a `DatabaseInitializer` szolgáltatás fut le. Ez a
+ `DbInitializer` statikus osztályt hívja a sémamigrációk végrehajtásához, majd
+ `PRAGMA journal_mode=WAL` utasítással aktiválja a naplózási módot. A
+ migrációkhoz `IDbContextFactory` használatos, így a munkakontextus azonnal
+ eldobásra kerül.
 Az indítás során a `DataSeeder` ellenőrzi, hogy az adatbázis teljesen üres‑e.
 Ha igen, a felhasználó egy párbeszédablakban megadhatja,
 hány szállító, termék, számla és tétel generálódjon.

--- a/docs/BUILD_RUNTIME_NOTES.md
+++ b/docs/BUILD_RUNTIME_NOTES.md
@@ -28,11 +28,9 @@ Ez a jegyzet a fejlesztés során tapasztalt fordítási és futásidejű probl�
 4. Teszteléskor győződjünk meg róla, hogy a szükséges SDK-k és NuGet csomagok telepítve vannak.
 5. Sémafrissítés után futtassuk le az EF Core migrációkat (`Database.Migrate()`),
    különben futásidőben "no such column" hibát kaphatunk.
-6. Indításkor a `DbInitializer` egyszerűen `Database.Migrate()` hívást végez,
-   amely létrehozza és frissíti az adatbázist. A migrációk futtatása közben
-   automatikusan létrejön az `__EFMigrationsHistory` tábla is.
-   Ha az adatbázis üres, a felhasználó megerősítheti, hogy Bogus segítségével generált mintaadatok kerüljenek be.
-7. Az `AddStorageAsync` kiterjesztés migrációhoz `IDbContextFactory`‑t használ, így a munkakontextus az inicializálás végén eldobásra kerül.
+6. Indításkor a `DatabaseInitializer` végzi a sémamigrációt és a `PRAGMA journal_mode=WAL` parancs futtatását. A folyamat `IDbContextFactory` segítségével külön kontextusban zajlik.
+    Ha az adatbázis üres, a felhasználó megerősítheti, hogy Bogus segítségével generált mintaadatok kerüljenek be.
+7. Az `AddStorageAsync` kiterjesztés már csak a szolgáltatásokat regisztrálja, migrációt nem indít.
 8. Ha a második adatlekérdezés is `SqliteException`-t dob, a `DataSeeder` a `logs/startup.log` fájlba ír és `Failed` állapotot jelez.
 9. Új modell bevezetésekor, ha valamely tábla hiányzik, a `DataSeeder` ismét migrációt futtat és naplózza a hibát.
 10. A `SetupWindow` bezárása után az alkalmazás alapértelmezett `OnLastWindowClose` módja miatt azonnal leállt,

--- a/docs/ERROR_HANDLING.md
+++ b/docs/ERROR_HANDLING.md
@@ -30,14 +30,14 @@ Ez a dokumentum összefoglalja a hibakezelési stratégiát. Cél, hogy az alkal
 
 1. **Adatbázis fájl hiánya vagy hiányzó elérési út** – Ha az adatbázis helye nincs megadva vagy az `app.db` nem található, a Storage réteg a `%AppData%/Wrecept/app.db` fájlt hozza létre, majd figyelmeztető üzenetet jelenítünk meg.
 2. **Üres adatbázis** – Ha egyetlen táblában sincs adat, minta rekordokat szúrunk be és figyelmeztetjük a felhasználót.
-3. **Sémahibák indításkor** – A `DbInitializer` közvetlenül `Database.Migrate()` hívást végez, amely a hiányzó táblákat és az `__EFMigrationsHistory` naplót is létrehozza. A `DataSeeder` külön kontextust használ, így a DI-ből kapott példány nem marad használatban.
+3. **Sémahibák indításkor** – A `DatabaseInitializer` a `DbInitializer` segítségével futtatja a migrációkat és `PRAGMA journal_mode=WAL` parancsot ad ki. A `DataSeeder` külön kontextust használ, így a DI-ből kapott példány nem marad használatban.
 4. **Sérült konfigurációs fájl** – A `settings.json` olvasásakor `JsonException` vagy `IOException` esetén hibaüzenetet írunk a naplóba és alapértelmezett beállításokkal folytatjuk.
 5. **Sérült állapotfájl** – A `state.json` nem olvasható vagy hiányos, ekkor figyelmeztetés nélkül alapértelmezett nézetre és számlára állunk vissza.
 6. **Sérült import fájl** – Hibás formátumú vagy hiányzó adatfájl betöltésekor megszakítjuk a folyamatot, naplózzuk a fájl nevét és a kiváltó hibát, és lehetőséget adunk új fájl kiválasztására.
 7. **Hálózati kimaradás** – Külső frissítések letöltése közben kapcsolatvesztés esetén újrapróbálkozunk, majd offline módra váltunk, miközben a felhasználót tájékoztatjuk.
 8. **Sikertelen adatbázis írás** – Ha a fájl zárolt vagy elfogy a tárhely, hibaüzenetet jelenítünk meg, a műveletet naplózzuk, majd biztonsági mentés után újrapróbáljuk.
 9. **Indítási hiba** – Ha a `DataSeeder` másodszori próbálkozásra is `SqliteException`-t kap, a részleteket az `ILogService` naplózza a `logs` mappába, majd hibaüzenetet jelenítünk meg.
-10. **Egyéb inicializációs hiba** – A `DbInitializer` általános kivételt is naplóz. Ha a második migrációs kísérlet sikertelen, a program leáll.
+10. **Egyéb inicializációs hiba** – A `DatabaseInitializer` általános kivételt is naplóz. Ha a migráció sikertelen, a program leáll.
 11. **Hiányzó tábla új modell után** – A `DataSeeder` felismeri a `no such table` hibát, ismét migrációt futtat és naplózza az eseményt.
 
 *Megjegyzés: a `wrecept.db` fájlt kizárólag fejlesztés közbeni migrációkhoz használjuk.*

--- a/docs/PROJECT_STRUCTURE.md
+++ b/docs/PROJECT_STRUCTURE.md
@@ -257,6 +257,13 @@ Minden fájl leírása az alábbi mezőket tartalmazza:
   - Responsibility: Funkcionális logika
   - Interaction: Repositories, ViewModels
   - Special Notes: -
+- **Wrecept.Core/Services/IDatabaseInitializer.cs**
+  - Purpose: Üzleti szolgáltatás
+  - Layer: Core
+  - Type: C#
+  - Responsibility: Adatbázis migrálása indításkor
+  - Interaction: Storage
+  - Special Notes: -
 - **Wrecept.Core/Services/InvoiceCalculator.cs**
   - Purpose: Üzleti szolgáltatás
   - Layer: Core
@@ -529,6 +536,13 @@ Minden fájl leírása az alábbi mezőket tartalmazza:
   - Type: C#
   - Responsibility: Funkcionális logika
   - Interaction: Repositories, ViewModels
+  - Special Notes: -
+- **Wrecept.Storage/Services/DatabaseInitializer.cs**
+  - Purpose: Üzleti szolgáltatás
+  - Layer: Storage
+  - Type: C#
+  - Responsibility: Adatbázis migrálás és PRAGMA futtatás
+  - Interaction: DbContext
   - Special Notes: -
 - **Wrecept.Storage/Wrecept.Storage.csproj**
   - Purpose: Projektfájl

--- a/docs/progress/2025-07-08_19-43-38_code_agent.md
+++ b/docs/progress/2025-07-08_19-43-38_code_agent.md
@@ -1,0 +1,1 @@
+- App.OnStartup invokes IDatabaseInitializer after building the service provider.

--- a/docs/progress/2025-07-08_19-43-38_docs_agent.md
+++ b/docs/progress/2025-07-08_19-43-38_docs_agent.md
@@ -1,0 +1,1 @@
+- Documentation updated for DatabaseInitializer role and AddStorageAsync change.

--- a/docs/progress/2025-07-08_19-43-38_storage_agent.md
+++ b/docs/progress/2025-07-08_19-43-38_storage_agent.md
@@ -1,0 +1,2 @@
+- Moved DbInitializer call from AddStorageAsync to new DatabaseInitializer service.
+- AddStorageAsync now only registers services; migrations run at startup.

--- a/tests/Wrecept.Tests/AddStorageRegistrationTests.cs
+++ b/tests/Wrecept.Tests/AddStorageRegistrationTests.cs
@@ -42,6 +42,7 @@ public class AddStorageRegistrationTests
             typeof(INumberingService),
             typeof(IBackupService),
             typeof(IDbHealthService),
+            typeof(IDatabaseInitializer),
             typeof(WalPragmaInterceptor)
         };
 

--- a/tests/Wrecept.Tests/WalPragmaTests.cs
+++ b/tests/Wrecept.Tests/WalPragmaTests.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Wrecept.Storage;
 using Wrecept.Storage.Data;
 using Wrecept.Core.Repositories;
+using Wrecept.Core.Services;
 using Xunit;
 using System;
 using System.IO;
@@ -21,6 +22,8 @@ public class WalPragmaTests
         var services = new ServiceCollection();
         await services.AddStorageAsync(dbPath, userPath, settingsPath);
         using var provider = services.BuildServiceProvider();
+        var init = provider.GetRequiredService<IDatabaseInitializer>();
+        await init.InitializeAsync();
         var factory = provider.GetRequiredService<IDbContextFactory<AppDbContext>>();
         await using var ctx = await factory.CreateDbContextAsync();
         await ctx.Database.OpenConnectionAsync();
@@ -41,6 +44,8 @@ public class WalPragmaTests
         var services = new ServiceCollection();
         await services.AddStorageAsync(string.Empty, userPath, settingsPath);
         using var provider = services.BuildServiceProvider();
+        var init = provider.GetRequiredService<IDatabaseInitializer>();
+        await init.InitializeAsync();
 
         var interceptor = provider.GetRequiredService<WalPragmaInterceptor>();
         var repo = provider.GetRequiredService<IInvoiceRepository>();


### PR DESCRIPTION
## Summary
- remove temporary service provider from `AddStorageAsync`
- add `IDatabaseInitializer` and `DatabaseInitializer`
- call initializer in `App.OnStartup`
- adjust tests for new initializer
- document startup changes

## Testing
- `dotnet test --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d7349a004832286f531bbf5ca10a9