### PR TITLE
Introduce basic plugin infrastructure

### DIFF
--- a/Wrecept.Core/CoreModule.cs
+++ b/Wrecept.Core/CoreModule.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Wrecept.Plugins.Abstractions;
+
+namespace Wrecept.Core;
+
+public class CoreModule : IPlugin
+{
+    public Task ConfigureServicesAsync(IServiceCollection services, IDictionary<string, object>? context = null)
+    {
+        services.AddCore();
+        return Task.CompletedTask;
+    }
+}

--- a/Wrecept.Core/Wrecept.Core.csproj
+++ b/Wrecept.Core/Wrecept.Core.csproj
@@ -9,5 +9,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\refactor\Wrecept.Plugins.Abstractions\Wrecept.Plugins.Abstractions.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/Wrecept.Storage/StorageModule.cs
+++ b/Wrecept.Storage/StorageModule.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Wrecept.Plugins.Abstractions;
+
+namespace Wrecept.Storage;
+
+public class StorageModule : IPlugin
+{
+    public async Task ConfigureServicesAsync(IServiceCollection services, IDictionary<string, object>? context = null)
+    {
+        var dbPath = context?[("DbPath")] as string ?? string.Empty;
+        var userInfoPath = context?[("UserInfoPath")] as string ?? string.Empty;
+        var settingsPath = context?[("SettingsPath")] as string ?? string.Empty;
+        await services.AddStorageAsync(dbPath, userInfoPath, settingsPath);
+    }
+}

--- a/Wrecept.Storage/Wrecept.Storage.csproj
+++ b/Wrecept.Storage/Wrecept.Storage.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Wrecept.Core\Wrecept.Core.csproj" />
+    <ProjectReference Include="..\refactor\Wrecept.Plugins.Abstractions\Wrecept.Plugins.Abstractions.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Wrecept.Wpf/WpfModule.cs
+++ b/Wrecept.Wpf/WpfModule.cs
@@ -15,9 +15,9 @@ public class WpfModule : IPlugin
 {
     public async Task ConfigureServicesAsync(IServiceCollection services, IDictionary<string, object>? context = null)
     {
-        var dbPath = context?[("DbPath")] as string ?? string.Empty;
-        var userInfoPath = context?[("UserInfoPath")] as string ?? string.Empty;
-        var settingsPath = context?[("SettingsPath")] as string ?? string.Empty;
+        var dbPath = context?["DbPath"] as string ?? string.Empty;
+        var userInfoPath = context?["UserInfoPath"] as string ?? string.Empty;
+        var settingsPath = context?["SettingsPath"] as string ?? string.Empty;
 
         services.AddCore();
         await services.AddStorageAsync(dbPath, userInfoPath, settingsPath);

--- a/Wrecept.Wpf/WpfModule.cs
+++ b/Wrecept.Wpf/WpfModule.cs
@@ -1,0 +1,71 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Wrecept.Plugins.Abstractions;
+using Wrecept.Core;
+using Wrecept.Storage;
+using Wrecept.Wpf.ViewModels;
+using Wrecept.Wpf.Views;
+using Wrecept.Wpf.Services;
+using Wrecept.Core.Services;
+
+namespace Wrecept.Wpf;
+
+public class WpfModule : IPlugin
+{
+    public async Task ConfigureServicesAsync(IServiceCollection services, IDictionary<string, object>? context = null)
+    {
+        var dbPath = context?[("DbPath")] as string ?? string.Empty;
+        var userInfoPath = context?[("UserInfoPath")] as string ?? string.Empty;
+        var settingsPath = context?[("SettingsPath")] as string ?? string.Empty;
+
+        services.AddCore();
+        await services.AddStorageAsync(dbPath, userInfoPath, settingsPath);
+
+        services.AddSingleton<StageViewModel>();
+        services.AddSingleton<InvoiceEditorViewModel>();
+        services.AddSingleton<InvoiceLookupViewModel>();
+        services.AddTransient<ProductMasterViewModel>();
+        services.AddTransient<ProductGroupMasterViewModel>();
+        services.AddTransient<SupplierMasterViewModel>();
+        services.AddTransient<TaxRateMasterViewModel>();
+        services.AddTransient<PaymentMethodMasterViewModel>();
+        services.AddTransient<UnitMasterViewModel>();
+        services.AddTransient<UserInfoViewModel>();
+        services.AddTransient<UserInfoEditorViewModel>();
+        services.AddTransient<ScreenModeViewModel>();
+        services.AddTransient<AboutViewModel>();
+        services.AddTransient<PlaceholderViewModel>();
+        services.AddSingleton<StatusBarViewModel>();
+        services.AddSingleton<AppStateService>(_ => new AppStateService(settingsPath.Replace("settings.json", "state.json")));
+        services.AddSingleton<INotificationService, MessageBoxNotificationService>();
+        services.AddTransient<IInvoiceExportService, PdfInvoiceExporter>();
+        services.AddSingleton<ScreenModeManager>();
+        services.AddSingleton<FocusManager>();
+        services.AddSingleton<KeyboardManager>();
+        services.AddTransient<StageMenuHandler>();
+        services.AddTransient<StageMenuKeyboardHandler>();
+        services.AddTransient<InvoiceEditorKeyboardHandler>();
+        services.AddTransient<MasterDataKeyboardHandler>();
+        services.AddTransient<ProgressViewModel>();
+        services.AddTransient<SeedOptionsViewModel>();
+        services.AddTransient<SeedOptionsWindow>();
+        services.AddTransient<StartupWindow>();
+        services.AddTransient<ScreenModeWindow>();
+        services.AddTransient<StartupOrchestrator>();
+        services.AddTransient<StageView>();
+        services.AddTransient<InvoiceLookupView>();
+        services.AddTransient<ProductMasterView>();
+        services.AddTransient<ProductGroupMasterView>();
+        services.AddTransient<SupplierMasterView>();
+        services.AddTransient<TaxRateMasterView>();
+        services.AddTransient<PaymentMethodMasterView>();
+        services.AddTransient<UnitMasterView>();
+        services.AddTransient<UserInfoView>();
+        services.AddTransient<UserInfoWindow>();
+        services.AddTransient<AboutView>();
+        services.AddTransient<PlaceholderView>();
+        services.AddTransient<Views.Controls.StatusBar>();
+        services.AddSingleton<MainWindow>();
+    }
+}

--- a/Wrecept.Wpf/Wrecept.Wpf.csproj
+++ b/Wrecept.Wpf/Wrecept.Wpf.csproj
@@ -21,6 +21,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Wrecept.Core\Wrecept.Core.csproj" />
     <ProjectReference Include="..\Wrecept.Storage\Wrecept.Storage.csproj" />
+    <ProjectReference Include="..\refactor\Wrecept.Plugins.Abstractions\Wrecept.Plugins.Abstractions.csproj" />
   </ItemGroup>
 
 </Project>

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,0 +1,37 @@
+# Plug-in architektúra
+
+Ez a dokumentum bemutatja, hogyan bővíthető a Wrecept moduláris plug-inekkel.
+
+## IPlugin interfész
+
+A `refactor/Wrecept.Plugins.Abstractions` projekt tartalmazza az `IPlugin` interfészt és a `PluginLoader` segédosztályt.
+
+```csharp
+public interface IPlugin
+{
+    Task ConfigureServicesAsync(IServiceCollection services, IDictionary<string, object>? context = null);
+}
+```
+
+A `PluginLoader.LoadPluginsAsync` metódus betölti a megadott mappában található DLL-eket, megkeresi az `IPlugin` implementációkat, majd meghívja azok `ConfigureServicesAsync` metódusát.
+
+## Saját modulok
+
+Minden projekt létrehozhat egy modulosztályt, amely implementálja az `IPlugin` interfészt és regisztrálja a szükséges szolgáltatásokat. Például a `Wrecept.Wpf` projekt a `WpfModule` osztályt tartalmazza.
+
+A host alkalmazás az indításkor betölti a plug-ineket:
+
+```csharp
+var context = new Dictionary<string, object>
+{
+    ["DbPath"] = settings.DatabasePath,
+    ["UserInfoPath"] = settings.UserInfoPath,
+    ["SettingsPath"] = SettingsPath
+};
+
+var module = new WpfModule();
+await module.ConfigureServicesAsync(services, context);
+await PluginLoader.LoadPluginsAsync(services, Path.Combine(AppContext.BaseDirectory, "plugins"), context);
+```
+
+Minden külső plug-int a `plugins` mappába kell másolni. A betöltés sorrendje nincs garantálva.

--- a/docs/progress/2025-07-08_20-21-56_code_agent.md
+++ b/docs/progress/2025-07-08_20-21-56_code_agent.md
@@ -1,0 +1,4 @@
+- Létrehoztam a Wrecept.Refactor.sln solutiont és benne a Wrecept.Plugins.Abstractions projektet.
+- Implementáltam az IPlugin interfészt és a PluginLoader osztályt.
+- A Core, Storage és Wpf projektek modul osztályt kaptak, melyek a plug-in felületen keresztül regisztrálnak.
+- Az App.ConfigureServicesAsync most a modulokat és a plugins mappát tölti be.

--- a/docs/progress/2025-07-08_20-21-56_docs_agent.md
+++ b/docs/progress/2025-07-08_20-21-56_docs_agent.md
@@ -1,0 +1,1 @@
+- Új plugins.md dokumentum ismerteti az IPlugin interfészt és a betöltési mechanizmust.

--- a/refactor/Wrecept.Plugins.Abstractions/IPlugin.cs
+++ b/refactor/Wrecept.Plugins.Abstractions/IPlugin.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Wrecept.Plugins.Abstractions;
+
+public interface IPlugin
+{
+    Task ConfigureServicesAsync(IServiceCollection services, IDictionary<string, object>? context = null);
+}

--- a/refactor/Wrecept.Plugins.Abstractions/PluginLoader.cs
+++ b/refactor/Wrecept.Plugins.Abstractions/PluginLoader.cs
@@ -33,7 +33,7 @@ public static class PluginLoader
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"Failed to load plugin {dll}: {ex.Message}");
+                logger.LogError(ex, $"Failed to load plugin {dll}");
             }
         }
     }

--- a/refactor/Wrecept.Plugins.Abstractions/PluginLoader.cs
+++ b/refactor/Wrecept.Plugins.Abstractions/PluginLoader.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Wrecept.Plugins.Abstractions;
+
+public static class PluginLoader
+{
+    public static async Task LoadPluginsAsync(IServiceCollection services, string pluginsPath, IDictionary<string, object>? context = null)
+    {
+        if (!Directory.Exists(pluginsPath))
+            return;
+
+        foreach (var dll in Directory.GetFiles(pluginsPath, "*.dll"))
+        {
+            try
+            {
+                var assembly = Assembly.LoadFrom(dll);
+                var pluginTypes = assembly.GetTypes()
+                    .Where(t => typeof(IPlugin).IsAssignableFrom(t) && !t.IsAbstract && !t.IsInterface);
+
+                foreach (var type in pluginTypes)
+                {
+                    if (Activator.CreateInstance(type) is IPlugin plugin)
+                    {
+                        await plugin.ConfigureServicesAsync(services, context);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Failed to load plugin {dll}: {ex.Message}");
+            }
+        }
+    }
+}

--- a/refactor/Wrecept.Plugins.Abstractions/Wrecept.Plugins.Abstractions.csproj
+++ b/refactor/Wrecept.Plugins.Abstractions/Wrecept.Plugins.Abstractions.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/refactor/Wrecept.Refactor.sln
+++ b/refactor/Wrecept.Refactor.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Wrecept.Plugins.Abstractions", "Wrecept.Plugins.Abstractions\Wrecept.Plugins.Abstractions.csproj", "{45BFC7AA-B60D-4103-AF8F-CA3E50B3098A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Wrecept.Core", "..\Wrecept.Core\Wrecept.Core.csproj", "{5A9BE415-2283-48BB-8B93-FF432CE88558}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Wrecept.Storage", "..\Wrecept.Storage\Wrecept.Storage.csproj", "{CCA4BD76-C221-45ED-A961-EE250FA4550F}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{45BFC7AA-B60D-4103-AF8F-CA3E50B3098A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{45BFC7AA-B60D-4103-AF8F-CA3E50B3098A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{45BFC7AA-B60D-4103-AF8F-CA3E50B3098A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{45BFC7AA-B60D-4103-AF8F-CA3E50B3098A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5A9BE415-2283-48BB-8B93-FF432CE88558}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5A9BE415-2283-48BB-8B93-FF432CE88558}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5A9BE415-2283-48BB-8B93-FF432CE88558}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5A9BE415-2283-48BB-8B93-FF432CE88558}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CCA4BD76-C221-45ED-A961-EE250FA4550F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CCA4BD76-C221-45ED-A961-EE250FA4550F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CCA4BD76-C221-45ED-A961-EE250FA4550F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CCA4BD76-C221-45ED-A961-EE250FA4550F}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
## Summary
- add new `Wrecept.Refactor.sln` with `Wrecept.Plugins.Abstractions` project
- define `IPlugin` interface and `PluginLoader`
- implement plugin modules for Core, Storage and WPF
- load plugins from `plugins` folder on startup
- document plugin mechanism in `docs/plugins.md`

## Testing
- `dotnet test tests/Wrecept.Tests/Wrecept.Tests.csproj -c Release` *(fails: Project Wrecept.Wpf is not compatible with net8.0)*

------
https://chatgpt.com/codex/tasks/task_e_686d7c9fbfc483229d8b7aec5ce717de