### PR TITLE
Fix plugin abstractions project build

### DIFF
--- a/docs/progress/2025-07-08_21-04-12_code_agent.md
+++ b/docs/progress/2025-07-08_21-04-12_code_agent.md
@@ -1,0 +1,1 @@
+- Fix build errors in Wrecept.Plugins.Abstractions by referencing Microsoft.Extensions.DependencyInjection.Abstractions and using Console for error messages.

--- a/refactor/Wrecept.Plugins.Abstractions/PluginLoader.cs
+++ b/refactor/Wrecept.Plugins.Abstractions/PluginLoader.cs
@@ -33,7 +33,7 @@ public static class PluginLoader
             }
             catch (Exception ex)
             {
-                logger.LogError(ex, $"Failed to load plugin {dll}");
+                Console.Error.WriteLine($"Failed to load plugin {dll}: {ex}");
             }
         }
     }

--- a/refactor/Wrecept.Plugins.Abstractions/Wrecept.Plugins.Abstractions.csproj
+++ b/refactor/Wrecept.Plugins.Abstractions/Wrecept.Plugins.Abstractions.csproj
@@ -6,4 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
## Summary
- add missing dependency on Microsoft.Extensions.DependencyInjection.Abstractions
- simplify PluginLoader error handling

## Testing
- `dotnet test --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d873762948322b6efb67b844beeed