### PR TITLE
Implement Serilog logging

### DIFF
--- a/Wrecept.Storage/ServiceCollectionExtensions.cs
+++ b/Wrecept.Storage/ServiceCollectionExtensions.cs
@@ -39,7 +39,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IProductGroupRepository, ProductGroupRepository>();
         services.AddScoped<ITaxRateRepository, TaxRateRepository>();
         services.AddScoped<IUnitRepository, UnitRepository>();
-        services.AddSingleton<ILogService, LogService>();
+        services.AddSingleton<ILogService, SerilogLogService>();
         services.AddSingleton<IUserInfoService>(_ => new UserInfoService(userInfoPath));
         services.AddSingleton<ISettingsService>(_ => new SettingsService(settingsPath));
         var sessionPath = Path.Combine(Path.GetDirectoryName(settingsPath)!, "session.json");

--- a/Wrecept.Storage/Services/SerilogLogService.cs
+++ b/Wrecept.Storage/Services/SerilogLogService.cs
@@ -1,0 +1,43 @@
+using System;
+using System.IO;
+using Serilog;
+using Serilog.Formatting.Json;
+using Wrecept.Core.Services;
+
+namespace Wrecept.Storage.Services;
+
+public class SerilogLogService : ILogService
+{
+    private readonly ILogger _logger;
+
+    public SerilogLogService()
+    {
+        var appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+        var logDir = Path.Combine(appData, "Wrecept", "logs");
+        try
+        {
+            Directory.CreateDirectory(logDir);
+            var path = Path.Combine(logDir, "log-.json");
+            _logger = new LoggerConfiguration()
+                .WriteTo.File(new JsonFormatter(), path,
+                    rollingInterval: RollingInterval.Day,
+                    fileSizeLimitBytes: 5_000_000,
+                    rollOnFileSizeLimit: true,
+                    retainedFileCountLimit: 5,
+                    shared: true)
+                .CreateLogger();
+        }
+        catch
+        {
+            _logger = new LoggerConfiguration()
+                .WriteTo.Console()
+                .CreateLogger();
+        }
+    }
+
+    public Task LogError(string message, Exception ex)
+    {
+        _logger.Error(ex, message);
+        return Task.CompletedTask;
+    }
+}

--- a/Wrecept.Storage/Wrecept.Storage.csproj
+++ b/Wrecept.Storage/Wrecept.Storage.csproj
@@ -13,6 +13,8 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Bogus" Version="35.0.1" />
+    <PackageReference Include="Serilog" Version="3.1.1" />
+    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Wrecept.Wpf/App.xaml.cs
+++ b/Wrecept.Wpf/App.xaml.cs
@@ -68,7 +68,7 @@ public static IServiceProvider Provider => Services ?? throw new InvalidOperatio
             }
             catch (Exception ex) when (ex is IOException || ex is JsonException)
             {
-                var logger = new Wrecept.Storage.Services.LogService();
+                var logger = new Wrecept.Storage.Services.SerilogLogService();
                 await logger.LogError("LoadSettings", ex);
             }
         }
@@ -104,7 +104,7 @@ public static IServiceProvider Provider => Services ?? throw new InvalidOperatio
         }
         catch (Exception ex) when (ex is IOException || ex is JsonException)
         {
-            var logger = new Wrecept.Storage.Services.LogService();
+            var logger = new Wrecept.Storage.Services.SerilogLogService();
             await logger.LogError("SaveSettings", ex);
         }
         return settings;
@@ -222,7 +222,7 @@ public static IServiceProvider Provider => Services ?? throw new InvalidOperatio
         {
             ILogService log = Services != null
                 ? Provider.GetRequiredService<ILogService>()
-                : new Wrecept.Storage.Services.LogService();
+                : new Wrecept.Storage.Services.SerilogLogService();
             await log.LogError("App.OnStartup", ex);
             MessageBox.Show(
                 "Váratlan hiba indításkor. Részletek a logs/startup.log fájlban.",

--- a/docs/ERROR_HANDLING.md
+++ b/docs/ERROR_HANDLING.md
@@ -23,7 +23,8 @@ Ez a dokumentum összefoglalja a hibakezelési stratégiát. Cél, hogy az alkal
 ## Naplózás
 
 * A `ILogService` a `%AppData%/Wrecept/logs` könyvtárba ír naplóbejegyzéseket.
-* A Storage réteg hibáit a `LogService` rögzíti napi bontású fájlokba.
+* A Storage réteg hibáit a `SerilogLogService` rögzíti gördülő JSON fájlokba
+  (5 × 5 MB).
 * Kritikus hiba esetén a felhasználó dönthet a folytatásról vagy kilépésről.
 
 ## Konkrét példák

--- a/tests/Wrecept.Storage.Tests/LogServiceTests.cs
+++ b/tests/Wrecept.Storage.Tests/LogServiceTests.cs
@@ -19,7 +19,7 @@ public class LogServiceTests
         Console.SetError(sw);
         try
         {
-            var svc = new LogService();
+            var svc = new SerilogLogService();
             await svc.LogError("err", new InvalidOperationException());
             var logDir = Path.Combine(tempHome, "Wrecept", "logs");
             Assert.False(Directory.Exists(logDir));
@@ -29,6 +29,37 @@ public class LogServiceTests
         {
             Console.SetError(oldErr);
             Environment.SetEnvironmentVariable("APPDATA", oldAppData);
+        }
+    }
+
+    [Fact]
+    public async Task LogError_WritesFile()
+    {
+        var tempHome = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(tempHome);
+        var oldAppData = Environment.GetEnvironmentVariable("APPDATA");
+        Environment.SetEnvironmentVariable("APPDATA", tempHome);
+
+        try
+        {
+            var svc = new SerilogLogService();
+            await svc.LogError("test", new InvalidOperationException());
+
+            var logDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+                "Wrecept", "logs");
+            Assert.True(Directory.Exists(logDir));
+            var files = Directory.GetFiles(logDir);
+            Assert.NotEmpty(files);
+            var content = await File.ReadAllTextAsync(files[0]);
+            Assert.Contains("test", content);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("APPDATA", oldAppData);
+            if (Directory.Exists(tempHome))
+            {
+                Directory.Delete(tempHome, recursive: true);
+            }
         }
     }
 }

--- a/tests/Wrecept.Storage.Tests/SettingsSessionLogServiceTests.cs
+++ b/tests/Wrecept.Storage.Tests/SettingsSessionLogServiceTests.cs
@@ -88,7 +88,7 @@ public class SettingsSessionLogServiceTests
 
         try
         {
-            var svc = new LogService();
+            var svc = new SerilogLogService();
             await svc.LogError("test", new InvalidOperationException());
 
             var logDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),


### PR DESCRIPTION
## Summary
- add Serilog packages
- implement `SerilogLogService`
- register new log service in DI and startup
- update error handling docs
- extend log service tests for file creation

## Testing
- `dotnet test tests/Wrecept.Storage.Tests/Wrecept.Storage.Tests.csproj -v q` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873fc59d85083228aa97a6c167076e1