### PR TITLE
Implement ChangeLog and DB recovery

### DIFF
--- a/Wrecept.Core/Models/ChangeLog.cs
+++ b/Wrecept.Core/Models/ChangeLog.cs
@@ -1,0 +1,12 @@
+namespace Wrecept.Core.Models;
+
+public class ChangeLog
+{
+    public int Id { get; set; }
+    public string Entity { get; set; } = string.Empty;
+    public string EntityId { get; set; } = string.Empty;
+    public string Operation { get; set; } = string.Empty;
+    public string Data { get; set; } = string.Empty;
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+}
+

--- a/Wrecept.Core/Services/IDatabaseRecoveryService.cs
+++ b/Wrecept.Core/Services/IDatabaseRecoveryService.cs
@@ -1,0 +1,7 @@
+namespace Wrecept.Core.Services;
+
+public interface IDatabaseRecoveryService
+{
+    Task CheckAndRecoverAsync(CancellationToken ct = default);
+}
+

--- a/Wrecept.Storage/Data/AppDbContext.cs
+++ b/Wrecept.Storage/Data/AppDbContext.cs
@@ -13,6 +13,7 @@ public class AppDbContext : DbContext
     public DbSet<TaxRate> TaxRates => Set<TaxRate>();
     public DbSet<PaymentMethod> PaymentMethods => Set<PaymentMethod>();
     public DbSet<Unit> Units => Set<Unit>();
+    public DbSet<ChangeLog> ChangeLogs => Set<ChangeLog>();
 
     public AppDbContext(DbContextOptions<AppDbContext> options)
         : base(options)

--- a/Wrecept.Storage/Migrations/20250709120000_AddChangeLog.cs
+++ b/Wrecept.Storage/Migrations/20250709120000_AddChangeLog.cs
@@ -1,0 +1,40 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Wrecept.Storage.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddChangeLog : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ChangeLogs",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    Entity = table.Column<string>(type: "TEXT", nullable: false),
+                    EntityId = table.Column<string>(type: "TEXT", nullable: false),
+                    Operation = table.Column<string>(type: "TEXT", nullable: false),
+                    Data = table.Column<string>(type: "TEXT", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ChangeLogs", x => x.Id);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ChangeLogs");
+        }
+    }
+}
+

--- a/Wrecept.Storage/Migrations/AppDbContextModelSnapshot.cs
+++ b/Wrecept.Storage/Migrations/AppDbContextModelSnapshot.cs
@@ -302,6 +302,36 @@ namespace Wrecept.Storage.Migrations
                     b.ToTable("Units");
                 });
 
+            modelBuilder.Entity("Wrecept.Core.Models.ChangeLog", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("INTEGER");
+
+                    b.Property<DateTime>("CreatedAt")
+                        .HasColumnType("TEXT");
+
+                    b.Property<string>("Data")
+                        .IsRequired()
+                        .HasColumnType("TEXT");
+
+                    b.Property<string>("Entity")
+                        .IsRequired()
+                        .HasColumnType("TEXT");
+
+                    b.Property<string>("EntityId")
+                        .IsRequired()
+                        .HasColumnType("TEXT");
+
+                    b.Property<string>("Operation")
+                        .IsRequired()
+                        .HasColumnType("TEXT");
+
+                    b.HasKey("Id");
+
+                    b.ToTable("ChangeLogs");
+                });
+
             modelBuilder.Entity("Wrecept.Core.Models.Invoice", b =>
                 {
                     b.HasOne("Wrecept.Core.Models.PaymentMethod", "PaymentMethod")

--- a/Wrecept.Storage/Repositories/ProductRepository.cs
+++ b/Wrecept.Storage/Repositories/ProductRepository.cs
@@ -2,6 +2,7 @@ using Microsoft.EntityFrameworkCore;
 using Wrecept.Core.Models;
 using Wrecept.Core.Repositories;
 using Wrecept.Storage.Data;
+using System.Text.Json;
 
 namespace Wrecept.Storage.Repositories;
 
@@ -14,6 +15,18 @@ public class ProductRepository : IProductRepository
         _db = db;
     }
 
+    private void Log(string id, string op, object data)
+    {
+        _db.ChangeLogs.Add(new ChangeLog
+        {
+            Entity = nameof(Product),
+            EntityId = id,
+            Operation = op,
+            Data = JsonSerializer.Serialize(data),
+            CreatedAt = DateTime.UtcNow
+        });
+    }
+
     public Task<List<Product>> GetAllAsync(CancellationToken ct = default)
         => _db.Products.AsNoTracking().ToListAsync(ct);
 
@@ -24,12 +37,16 @@ public class ProductRepository : IProductRepository
     {
         _db.Products.Add(product);
         await _db.SaveChangesAsync(ct);
+        Log(product.Id.ToString(), "Insert", product);
+        await _db.SaveChangesAsync(ct);
         return product.Id;
     }
 
     public async Task UpdateAsync(Product product, CancellationToken ct = default)
     {
         _db.Products.Update(product);
+        await _db.SaveChangesAsync(ct);
+        Log(product.Id.ToString(), "Update", product);
         await _db.SaveChangesAsync(ct);
     }
 }

--- a/Wrecept.Storage/Repositories/SupplierRepository.cs
+++ b/Wrecept.Storage/Repositories/SupplierRepository.cs
@@ -2,6 +2,7 @@ using Microsoft.EntityFrameworkCore;
 using Wrecept.Core.Models;
 using Wrecept.Core.Repositories;
 using Wrecept.Storage.Data;
+using System.Text.Json;
 
 namespace Wrecept.Storage.Repositories;
 
@@ -14,6 +15,18 @@ public class SupplierRepository : ISupplierRepository
         _db = db;
     }
 
+    private void Log(string id, string op, object data)
+    {
+        _db.ChangeLogs.Add(new ChangeLog
+        {
+            Entity = nameof(Supplier),
+            EntityId = id,
+            Operation = op,
+            Data = JsonSerializer.Serialize(data),
+            CreatedAt = DateTime.UtcNow
+        });
+    }
+
     public Task<List<Supplier>> GetAllAsync(CancellationToken ct = default)
         => _db.Suppliers.AsNoTracking().ToListAsync(ct);
 
@@ -24,12 +37,16 @@ public class SupplierRepository : ISupplierRepository
     {
         _db.Suppliers.Add(supplier);
         await _db.SaveChangesAsync(ct);
+        Log(supplier.Id.ToString(), "Insert", supplier);
+        await _db.SaveChangesAsync(ct);
         return supplier.Id;
     }
 
     public async Task UpdateAsync(Supplier supplier, CancellationToken ct = default)
     {
         _db.Suppliers.Update(supplier);
+        await _db.SaveChangesAsync(ct);
+        Log(supplier.Id.ToString(), "Update", supplier);
         await _db.SaveChangesAsync(ct);
     }
 }

--- a/Wrecept.Storage/Repositories/TaxRateRepository.cs
+++ b/Wrecept.Storage/Repositories/TaxRateRepository.cs
@@ -2,6 +2,7 @@ using Microsoft.EntityFrameworkCore;
 using Wrecept.Core.Models;
 using Wrecept.Core.Repositories;
 using Wrecept.Storage.Data;
+using System.Text.Json;
 
 namespace Wrecept.Storage.Repositories;
 
@@ -12,6 +13,18 @@ public class TaxRateRepository : ITaxRateRepository
     public TaxRateRepository(AppDbContext db)
     {
         _db = db;
+    }
+
+    private void Log(string id, string op, object data)
+    {
+        _db.ChangeLogs.Add(new ChangeLog
+        {
+            Entity = nameof(TaxRate),
+            EntityId = id,
+            Operation = op,
+            Data = JsonSerializer.Serialize(data),
+            CreatedAt = DateTime.UtcNow
+        });
     }
 
     public Task<List<TaxRate>> GetAllAsync(CancellationToken ct = default)
@@ -27,12 +40,16 @@ public class TaxRateRepository : ITaxRateRepository
     {
         _db.Add(taxRate);
         await _db.SaveChangesAsync(ct);
+        Log(taxRate.Id.ToString(), "Insert", taxRate);
+        await _db.SaveChangesAsync(ct);
         return taxRate.Id;
     }
 
     public async Task UpdateAsync(TaxRate taxRate, CancellationToken ct = default)
     {
         _db.Update(taxRate);
+        await _db.SaveChangesAsync(ct);
+        Log(taxRate.Id.ToString(), "Update", taxRate);
         await _db.SaveChangesAsync(ct);
     }
 }

--- a/Wrecept.Storage/ServiceCollectionExtensions.cs
+++ b/Wrecept.Storage/ServiceCollectionExtensions.cs
@@ -48,6 +48,8 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<INumberingService>(_ => new NumberingService(numberPath));
         services.AddScoped<IBackupService>(_ => new FileBackupService(dbPath, userInfoPath, settingsPath));
         services.AddScoped<IDbHealthService, DbHealthService>();
+        services.AddSingleton<IDatabaseRecoveryService>(sp =>
+            new DatabaseRecoveryService(dbPath, sp.GetRequiredService<IDbContextFactory<AppDbContext>>(), sp.GetRequiredService<ILogService>()));
         services.AddSingleton<IDatabaseInitializer, DatabaseInitializer>();
     }
 }

--- a/Wrecept.Storage/Services/DatabaseInitializer.cs
+++ b/Wrecept.Storage/Services/DatabaseInitializer.cs
@@ -8,11 +8,13 @@ public class DatabaseInitializer : IDatabaseInitializer
 {
     private readonly IDbContextFactory<AppDbContext> _factory;
     private readonly ILogService _log;
+    private readonly IDatabaseRecoveryService _recovery;
 
-    public DatabaseInitializer(IDbContextFactory<AppDbContext> factory, ILogService log)
+    public DatabaseInitializer(IDbContextFactory<AppDbContext> factory, ILogService log, IDatabaseRecoveryService recovery)
     {
         _factory = factory;
         _log = log;
+        _recovery = recovery;
     }
 
     public async Task InitializeAsync(CancellationToken ct = default)
@@ -20,5 +22,6 @@ public class DatabaseInitializer : IDatabaseInitializer
         await using var ctx = await _factory.CreateDbContextAsync(ct);
         await DbInitializer.EnsureCreatedAndMigratedAsync(ctx, _log, ct);
         await ctx.Database.ExecuteSqlRawAsync("PRAGMA journal_mode=WAL", ct);
+        await _recovery.CheckAndRecoverAsync(ct);
     }
 }

--- a/Wrecept.Storage/Services/DatabaseRecoveryService.cs
+++ b/Wrecept.Storage/Services/DatabaseRecoveryService.cs
@@ -1,0 +1,94 @@
+using System;
+using System.IO;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Wrecept.Core.Models;
+using Wrecept.Core.Services;
+using Wrecept.Storage.Data;
+
+namespace Wrecept.Storage.Services;
+
+public class DatabaseRecoveryService : IDatabaseRecoveryService
+{
+    private readonly string _dbPath;
+    private readonly IDbContextFactory<AppDbContext> _factory;
+    private readonly ILogService _log;
+
+    public DatabaseRecoveryService(string dbPath, IDbContextFactory<AppDbContext> factory, ILogService log)
+    {
+        _dbPath = dbPath;
+        _factory = factory;
+        _log = log;
+    }
+
+    public async Task CheckAndRecoverAsync(CancellationToken ct = default)
+    {
+        await using var db = await _factory.CreateDbContextAsync(ct);
+        await db.Database.OpenConnectionAsync(ct);
+        await using var cmd = db.Database.GetDbConnection().CreateCommand();
+        cmd.CommandText = "PRAGMA integrity_check;";
+        var result = (string?)await cmd.ExecuteScalarAsync(ct);
+        await db.Database.CloseConnectionAsync();
+        if (result == "ok")
+            return;
+
+        await _log.LogError("DbRecovery", new Exception(result ?? "unknown"));
+        var backupDir = Path.Combine(Path.GetDirectoryName(_dbPath)!, "backup");
+        Directory.CreateDirectory(backupDir);
+        var backupPath = Path.Combine(backupDir, $"corrupt_{DateTime.UtcNow:yyyyMMdd}.db");
+        File.Copy(_dbPath, backupPath, true);
+
+        // read changelog from corrupt db
+        var opts = new DbContextOptionsBuilder<AppDbContext>()
+            .UseSqlite($"Data Source={backupPath}")
+            .Options;
+        await using var corruptCtx = new AppDbContext(opts);
+        List<ChangeLog> logs = await corruptCtx.ChangeLogs.AsNoTracking().OrderBy(c => c.Id).ToListAsync(ct);
+
+        File.Delete(_dbPath);
+        await using var recreate = await _factory.CreateDbContextAsync(ct);
+        await DbInitializer.EnsureCreatedAndMigratedAsync(recreate, _log, ct);
+
+        foreach (var logEntry in logs)
+        {
+            await ApplyLogAsync(recreate, logEntry, ct);
+        }
+        await recreate.SaveChangesAsync(ct);
+    }
+
+    private static async Task ApplyLogAsync(AppDbContext db, ChangeLog log, CancellationToken ct)
+    {
+        var type = Type.GetType($"Wrecept.Core.Models.{log.Entity}");
+        if (type == null)
+            return;
+        if (log.Operation.Equals("Insert", StringComparison.OrdinalIgnoreCase))
+        {
+            var obj = JsonSerializer.Deserialize(log.Data, type);
+            if (obj != null)
+                db.Add(obj);
+        }
+        else if (log.Operation.Equals("Update", StringComparison.OrdinalIgnoreCase))
+        {
+            var obj = JsonSerializer.Deserialize(log.Data, type);
+            if (obj != null)
+                db.Update(obj);
+        }
+        else if (log.Operation.Equals("Delete", StringComparison.OrdinalIgnoreCase))
+        {
+            object? key = ParseKey(log.EntityId);
+            var existing = key != null ? await db.FindAsync(type, new object?[] { key }, ct) : null;
+            if (existing != null)
+                db.Remove(existing);
+        }
+    }
+
+    private static object? ParseKey(string id)
+    {
+        if (Guid.TryParse(id, out var g))
+            return g;
+        if (int.TryParse(id, out var i))
+            return i;
+        return null;
+    }
+}
+

--- a/Wrecept.Wpf/StartupOrchestrator.cs
+++ b/Wrecept.Wpf/StartupOrchestrator.cs
@@ -10,10 +10,12 @@ namespace Wrecept.Wpf;
 public class StartupOrchestrator
 {
     private readonly ILogService _log;
+    private readonly IDatabaseRecoveryService _recovery;
 
-    public StartupOrchestrator(ILogService log)
+    public StartupOrchestrator(ILogService log, IDatabaseRecoveryService recovery)
     {
         _log = log;
+        _recovery = recovery;
     }
 
     public Task<bool> DatabaseEmptyAsync(CancellationToken ct)
@@ -29,6 +31,7 @@ public class StartupOrchestrator
         int maxItems,
         bool slow)
     {
+        await _recovery.CheckAndRecoverAsync(ct);
         progress.Report(new ProgressReport { GlobalPercent = 10, Message = "Mintaszámlák létrehozása..." });
         var status = await Task.Run(
             () => DataSeeder.SeedSampleDataAsync(

--- a/docs/ERROR_HANDLING.md
+++ b/docs/ERROR_HANDLING.md
@@ -40,6 +40,7 @@ Ez a dokumentum összefoglalja a hibakezelési stratégiát. Cél, hogy az alkal
 9. **Indítási hiba** – Ha a `DataSeeder` másodszori próbálkozásra is `SqliteException`-t kap, a részleteket az `ILogService` naplózza a `logs` mappába, majd hibaüzenetet jelenítünk meg.
 10. **Egyéb inicializációs hiba** – A `DatabaseInitializer` általános kivételt is naplóz. Ha a migráció sikertelen, a program leáll.
 11. **Hiányzó tábla új modell után** – A `DataSeeder` felismeri a `no such table` hibát, ismét migrációt futtat és naplózza az eseményt.
+12. **Sérült adatbázis fájl** – A `DatabaseRecoveryService` futtatja a `PRAGMA integrity_check` parancsot. Hiba esetén az `app.db` a `backup/corrupt_YYYYMMDD.db` néven elmentésre kerül, a séma újraépül és a `ChangeLog` alapján állítjuk vissza az adatokat.
 
 *Megjegyzés: a `wrecept.db` fájlt kizárólag fejlesztés közbeni migrációkhoz használjuk.*
 

--- a/docs/FAULT_PLAN.md
+++ b/docs/FAULT_PLAN.md
@@ -15,7 +15,8 @@ Ez a dokumentum meghatározza, hogyan vizsgáljuk az alkalmazás hibával szembe
 2. **Hiányzó vagy sérült konfigurációs fájl** – Indításkor ellenőrizzük, hogy a beállítások olvashatók-e; hiba esetén alapértelmezett értékeket töltünk.
 3. **Nem várt kivétel a ViewModelben** – Ellenőrizzük, hogy az Error Handling terv szerint logol-e és jelzi-e a hibát a felhasználónak.
 4. **Sérült adatbázis szerkezet** – Az `IDbHealthService` `PRAGMA integrity_check` futtatásával vizsgálja a táblák épségét. Hibát a LogService naplóz.
-5. **Áramszünet utáni helyreállítás** – A SessionService eltárolja az utoljára szerkesztett számla azonosítóját. A *Szerviz > Áramszünet után* menüpont visszatölti ezt az állapotot.
+5. **Fájl szintű korrupció** – A `DatabaseRecoveryService` a sérült `app.db` állományt átmásolja a `backup` mappába, majd újraépíti az adatbázist és a `ChangeLog` segítségével visszatölti a rekordokat.
+6. **Áramszünet utáni helyreállítás** – A SessionService eltárolja az utoljára szerkesztett számla azonosítóját. A *Szerviz > Áramszünet után* menüpont visszatölti ezt az állapotot.
 
 ## Cél
 

--- a/tests/Wrecept.Storage.Tests/DatabaseRecoveryServiceTests.cs
+++ b/tests/Wrecept.Storage.Tests/DatabaseRecoveryServiceTests.cs
@@ -1,0 +1,92 @@
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Wrecept.Core.Models;
+using Wrecept.Core.Services;
+using Wrecept.Storage.Data;
+using Wrecept.Storage.Repositories;
+using Wrecept.Storage.Services;
+using Xunit;
+
+namespace Wrecept.Storage.Tests;
+
+public class DatabaseRecoveryServiceTests
+{
+    private class DummyLogService : ILogService
+    {
+        public Task LogError(string message, Exception ex) => Task.CompletedTask;
+    }
+
+    private class TestFactory : IDbContextFactory<AppDbContext>
+    {
+        private readonly DbContextOptions<AppDbContext> _opts;
+        public TestFactory(string db)
+        {
+            _opts = new DbContextOptionsBuilder<AppDbContext>()
+                .UseSqlite($"Data Source={db}")
+                .Options;
+        }
+        public AppDbContext CreateDbContext() => new AppDbContext(_opts);
+        public Task<AppDbContext> CreateDbContextAsync(CancellationToken ct = default)
+            => Task.FromResult(new AppDbContext(_opts));
+    }
+
+    private static async Task InitializeAsync(string db)
+    {
+        var opts = new DbContextOptionsBuilder<AppDbContext>()
+            .UseSqlite($"Data Source={db}")
+            .Options;
+        await using var ctx = new AppDbContext(opts);
+        await DbInitializer.EnsureCreatedAndMigratedAsync(ctx, new DummyLogService());
+    }
+
+    [Fact]
+    public async Task CheckAndRecoverAsync_NoAction_WhenIntegrityOk()
+    {
+        var db = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".db");
+        await InitializeAsync(db);
+        await using var ctx = new AppDbContext(new DbContextOptionsBuilder<AppDbContext>().UseSqlite($"Data Source={db}").Options);
+        var repo = new SupplierRepository(ctx);
+        await repo.AddAsync(new Supplier { Name = "Test" });
+        var factory = new TestFactory(db);
+        var svc = new DatabaseRecoveryService(db, factory, new DummyLogService());
+
+        await svc.CheckAndRecoverAsync();
+
+        Assert.True(File.Exists(db));
+        var backupDir = Path.Combine(Path.GetDirectoryName(db)!, "backup");
+        Assert.False(Directory.Exists(backupDir));
+    }
+
+    [Fact]
+    public async Task CheckAndRecoverAsync_RestoresData()
+    {
+        var db = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".db");
+        await InitializeAsync(db);
+        await using (var ctx = new AppDbContext(new DbContextOptionsBuilder<AppDbContext>().UseSqlite($"Data Source={db}").Options))
+        {
+            var repo = new SupplierRepository(ctx);
+            await repo.AddAsync(new Supplier { Name = "Demo" });
+        }
+
+        // corrupt file
+        using (var fs = new FileStream(db, FileMode.Open, FileAccess.Write))
+        {
+            fs.Seek(0, SeekOrigin.Begin);
+            fs.WriteByte(0);
+        }
+
+        var factory = new TestFactory(db);
+        var svc = new DatabaseRecoveryService(db, factory, new DummyLogService());
+
+        await svc.CheckAndRecoverAsync();
+
+        var backupDir = Path.Combine(Path.GetDirectoryName(db)!, "backup");
+        Assert.True(File.Exists(Path.Combine(backupDir, $"corrupt_{DateTime.UtcNow:yyyyMMdd}.db")));
+
+        await using var verify = new AppDbContext(new DbContextOptionsBuilder<AppDbContext>().UseSqlite($"Data Source={db}").Options);
+        Assert.True(await verify.Suppliers.AnyAsync());
+    }
+}
+


### PR DESCRIPTION
## Summary
- track entity modifications via `ChangeLog`
- implement `DatabaseRecoveryService` for corruption recovery
- integrate recovery checks in database initializer and startup orchestrator
- document recovery flow
- add failing integration tests for recovery cases

## Testing
- `dotnet test --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop missing)*

------
https://chatgpt.com/codex/tasks/task_e_6873fe9a5a748322af7792f28585cda6