### PR TITLE
Add supplier-aware invoice numbering

### DIFF
--- a/Wrecept.Core.Tests/Services/NumberingServiceTests.cs
+++ b/Wrecept.Core.Tests/Services/NumberingServiceTests.cs
@@ -1,47 +1,64 @@
-using System;
-using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
+using Wrecept.Core.Repositories;
 using Wrecept.Storage.Services;
 using Xunit;
 
 namespace Wrecept.Core.Tests.Services;
 
-public class NumberingServiceTests : IDisposable
+public class NumberingServiceTests
 {
-    private readonly string _file;
-
-    public NumberingServiceTests()
+    private sealed class FakeInvoiceRepository : IInvoiceRepository
     {
-        _file = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".txt");
+        public string? Latest;
+        public int Supplier;
+        public Task<int> AddAsync(Wrecept.Core.Models.Invoice invoice, CancellationToken ct = default) => Task.FromResult(0);
+        public Task<int> AddItemAsync(Wrecept.Core.Models.InvoiceItem item, CancellationToken ct = default) => Task.FromResult(0);
+        public Task RemoveItemAsync(int id, CancellationToken ct = default) => Task.CompletedTask;
+        public Task UpdateHeaderAsync(int id, string number, DateOnly date, DateOnly dueDate, int supplierId, Guid paymentMethodId, bool isGross, CancellationToken ct = default) => Task.CompletedTask;
+        public Task SetArchivedAsync(int id, bool isArchived, CancellationToken ct = default) => Task.CompletedTask;
+        public Task<Wrecept.Core.Models.Invoice?> GetAsync(int id, CancellationToken ct = default) => Task.FromResult<Wrecept.Core.Models.Invoice?>(null);
+        public Task<List<Wrecept.Core.Models.Invoice>> GetRecentAsync(int count, CancellationToken ct = default) => Task.FromResult(new List<Wrecept.Core.Models.Invoice>());
+        public Task<LastUsageData?> GetLastUsageDataAsync(int supplierId, int productId, CancellationToken ct = default) => Task.FromResult<LastUsageData?>(null);
+        public Task<Dictionary<int, LastUsageData>> GetLastUsageDataBatchAsync(int supplierId, IEnumerable<int> productIds, CancellationToken ct = default) => Task.FromResult(new Dictionary<int, LastUsageData>());
+        public Task<string?> GetLatestInvoiceNumberBySupplierAsync(int supplierId, CancellationToken ct = default)
+        {
+            Supplier = supplierId;
+            return Task.FromResult(Latest);
+        }
     }
 
     [Fact]
-    public async Task GeneratesSequentialNumbers()
+    public async Task GeneratesSequentialNumber_FromLatest()
     {
-        var svc = new NumberingService(_file);
-        var first = await svc.GetNextInvoiceNumberAsync();
-        var second = await svc.GetNextInvoiceNumberAsync();
+        var repo = new FakeInvoiceRepository { Latest = "INV5" };
+        var svc = new NumberingService(repo);
 
-        Assert.Equal("INV1", first);
-        Assert.Equal("INV2", second);
+        var next = await svc.GetNextInvoiceNumberAsync(1);
+
+        Assert.Equal("INV6", next);
+        Assert.Equal(1, repo.Supplier);
     }
 
     [Fact]
-    public async Task ReturnsInv1_WhenFileCorrupted()
+    public async Task ReturnsInv1_WhenNoPrevious()
     {
-        await File.WriteAllTextAsync(_file, "abc");
-        var svc = new NumberingService(_file);
+        var repo = new FakeInvoiceRepository { Latest = null };
+        var svc = new NumberingService(repo);
 
-        var result = await svc.GetNextInvoiceNumberAsync();
+        var next = await svc.GetNextInvoiceNumberAsync(2);
 
-        Assert.Equal("INV1", result);
-        var text = await File.ReadAllTextAsync(_file);
-        Assert.Equal("1", text);
+        Assert.Equal("INV1", next);
     }
 
-    public void Dispose()
+    [Fact]
+    public async Task KeepsPrefixAndSuffix()
     {
-        if (File.Exists(_file))
-            File.Delete(_file);
+        var repo = new FakeInvoiceRepository { Latest = "ABC-001/2024" };
+        var svc = new NumberingService(repo);
+
+        var next = await svc.GetNextInvoiceNumberAsync(3);
+
+        Assert.Equal("ABC-002/2024", next);
     }
 }

--- a/Wrecept.Core/Repositories/IInvoiceRepository.cs
+++ b/Wrecept.Core/Repositories/IInvoiceRepository.cs
@@ -13,6 +13,8 @@ public interface IInvoiceRepository
     Task<Invoice?> GetAsync(int id, CancellationToken ct = default);
     Task<List<Invoice>> GetRecentAsync(int count, CancellationToken ct = default);
 
+    Task<string?> GetLatestInvoiceNumberBySupplierAsync(int supplierId, CancellationToken ct = default);
+
     Task<LastUsageData?> GetLastUsageDataAsync(int supplierId, int productId, CancellationToken ct = default);
 
     Task<Dictionary<int, LastUsageData>> GetLastUsageDataBatchAsync(int supplierId, IEnumerable<int> productIds, CancellationToken ct = default);

--- a/Wrecept.Core/Services/INumberingService.cs
+++ b/Wrecept.Core/Services/INumberingService.cs
@@ -5,5 +5,5 @@ namespace Wrecept.Core.Services;
 
 public interface INumberingService
 {
-    Task<string> GetNextInvoiceNumberAsync(CancellationToken ct = default);
+    Task<string> GetNextInvoiceNumberAsync(int supplierId, CancellationToken ct = default);
 }

--- a/Wrecept.Core/Services/NullNumberingService.cs
+++ b/Wrecept.Core/Services/NullNumberingService.cs
@@ -4,6 +4,6 @@ namespace Wrecept.Core.Services;
 
 public class NullNumberingService : INumberingService
 {
-    public Task<string> GetNextInvoiceNumberAsync(CancellationToken ct = default)
+    public Task<string> GetNextInvoiceNumberAsync(int supplierId, CancellationToken ct = default)
         => Task.FromResult(string.Empty);
 }

--- a/Wrecept.Storage/Repositories/InvoiceRepository.cs
+++ b/Wrecept.Storage/Repositories/InvoiceRepository.cs
@@ -106,6 +106,14 @@ public class InvoiceRepository : IInvoiceRepository
             .Take(count)
             .ToListAsync(ct);
 
+    public Task<string?> GetLatestInvoiceNumberBySupplierAsync(int supplierId, CancellationToken ct = default)
+        => _db.Invoices.AsNoTracking()
+            .Where(i => i.SupplierId == supplierId)
+            .OrderByDescending(i => i.Date)
+            .ThenByDescending(i => i.Id)
+            .Select(i => i.Number)
+            .FirstOrDefaultAsync(ct);
+
     public async Task<LastUsageData?> GetLastUsageDataAsync(int supplierId, int productId, CancellationToken ct = default)
     {
         return await _db.InvoiceItems.AsNoTracking()

--- a/Wrecept.Storage/ServiceCollectionExtensions.cs
+++ b/Wrecept.Storage/ServiceCollectionExtensions.cs
@@ -44,8 +44,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<ISettingsService>(_ => new SettingsService(settingsPath));
         var sessionPath = Path.Combine(Path.GetDirectoryName(settingsPath)!, "session.json");
         services.AddSingleton<ISessionService>(_ => new SessionService(sessionPath));
-        var numberPath = Path.Combine(Path.GetDirectoryName(settingsPath)!, "invoice_sequence.txt");
-        services.AddSingleton<INumberingService>(_ => new NumberingService(numberPath));
+        services.AddSingleton<INumberingService, NumberingService>();
         services.AddScoped<IBackupService>(_ => new FileBackupService(dbPath, userInfoPath, settingsPath));
         services.AddScoped<IDbHealthService, DbHealthService>();
         services.AddSingleton<IDatabaseRecoveryService>(sp =>

--- a/Wrecept.Storage/Services/NumberingService.cs
+++ b/Wrecept.Storage/Services/NumberingService.cs
@@ -1,40 +1,47 @@
-using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Wrecept.Core.Services;
+using Wrecept.Core.Repositories;
 
 namespace Wrecept.Storage.Services;
 
 public class NumberingService : INumberingService
 {
-    private readonly string _path;
-    private readonly SemaphoreSlim _mutex = new(1, 1);
+    private readonly IInvoiceRepository _invoices;
 
-    public NumberingService(string path)
+    public NumberingService(IInvoiceRepository invoices)
     {
-        _path = path;
+        _invoices = invoices;
     }
 
-    public async Task<string> GetNextInvoiceNumberAsync(CancellationToken ct = default)
+    public async Task<string> GetNextInvoiceNumberAsync(int supplierId, CancellationToken ct = default)
     {
-        await _mutex.WaitAsync(ct);
-        try
+        if (supplierId <= 0)
+            return "INV1";
+
+        var last = await _invoices.GetLatestInvoiceNumberBySupplierAsync(supplierId, ct);
+        if (!string.IsNullOrWhiteSpace(last))
         {
-            int current = 0;
-            if (File.Exists(_path))
+            int end = last.Length - 1;
+            while (end >= 0 && !char.IsDigit(last[end])) end--;
+            int digitEnd = end;
+            while (end >= 0 && char.IsDigit(last[end])) end--;
+
+            if (digitEnd >= 0)
             {
-                var text = await File.ReadAllTextAsync(_path, ct);
-                if (int.TryParse(text, out var value))
-                    current = value;
+                var prefix = last.Substring(0, end + 1);
+                var digits = last.Substring(end + 1, digitEnd - end);
+                var suffix = last.Substring(digitEnd + 1);
+
+                if (int.TryParse(digits, out var num))
+                {
+                    var next = (num + 1).ToString().PadLeft(digits.Length, '0');
+                    return prefix + next + suffix;
+                }
             }
-            var next = current + 1;
-            Directory.CreateDirectory(Path.GetDirectoryName(_path)!);
-            await File.WriteAllTextAsync(_path, next.ToString(), ct);
-            return $"INV{next}";
         }
-        finally
-        {
-            _mutex.Release();
-        }
+
+        return "INV1";
     }
 }

--- a/Wrecept.Wpf/ViewModels/InvoiceLookupViewModel.cs
+++ b/Wrecept.Wpf/ViewModels/InvoiceLookupViewModel.cs
@@ -15,6 +15,7 @@ public partial class InvoiceLookupItem : ObservableObject
     public string Number { get; set; } = string.Empty;
     public DateOnly Date { get; set; }
     public string Supplier { get; set; } = string.Empty;
+    public int SupplierId { get; set; }
 }
 
 public partial class InvoiceLookupViewModel : ObservableObject
@@ -39,7 +40,8 @@ public partial class InvoiceLookupViewModel : ObservableObject
     [RelayCommand]
     private async Task CreateNewInvoiceAsync()
     {
-        var number = await _numbering.GetNextInvoiceNumberAsync();
+        var supplierId = SelectedInvoice?.SupplierId ?? 0;
+        var number = await _numbering.GetNextInvoiceNumberAsync(supplierId);
         await CreateInvoiceAsync(number);
     }
 
@@ -55,13 +57,14 @@ public partial class InvoiceLookupViewModel : ObservableObject
         Invoices.Clear();
         foreach (var inv in items)
         {
-            Invoices.Add(new InvoiceLookupItem
-            {
-                Id = inv.Id,
-                Number = inv.Number,
-                Date = inv.Date,
-                Supplier = inv.Supplier?.Name ?? string.Empty
-            });
+                Invoices.Add(new InvoiceLookupItem
+                {
+                    Id = inv.Id,
+                    Number = inv.Number,
+                    Date = inv.Date,
+                    Supplier = inv.Supplier?.Name ?? string.Empty,
+                    SupplierId = inv.SupplierId
+                });
         }
 
         if (Invoices.Count > 0)

--- a/tests/Wrecept.Core.Tests/NullNumberingServiceTests.cs
+++ b/tests/Wrecept.Core.Tests/NullNumberingServiceTests.cs
@@ -11,7 +11,7 @@ public class NullNumberingServiceTests
     {
         var service = new NullNumberingService();
 
-        var result = await service.GetNextInvoiceNumberAsync();
+        var result = await service.GetNextInvoiceNumberAsync(1);
 
         Assert.Equal(string.Empty, result);
     }

--- a/tests/Wrecept.Tests/InvoiceEditorLayoutTests.cs
+++ b/tests/Wrecept.Tests/InvoiceEditorLayoutTests.cs
@@ -98,8 +98,9 @@ public class InvoiceEditorLayoutTests
         EnsureApp();
         var svc = new CountingService();
         var invoice = new DummyInvoiceService();
-        var lookup = new InvoiceLookupViewModel(invoice, new FakeNumberingService());
-        var vm = new InvoiceEditorViewModel(svc, svc, svc, svc, svc, svc, invoice, new DummyLogService(), new DummyNotificationService(), new DummySessionService(), new AppStateService(System.IO.Path.GetTempFileName()), lookup);
+        var numberSvc = new FakeNumberingService();
+        var lookup = new InvoiceLookupViewModel(invoice, numberSvc);
+        var vm = new InvoiceEditorViewModel(svc, svc, svc, svc, svc, svc, invoice, new DummyLogService(), new DummyNotificationService(), new DummySessionService(), new AppStateService(System.IO.Path.GetTempFileName()), lookup, numberSvc);
         var layout = new InvoiceEditorLayout(vm);
 
         layout.RaiseEvent(new RoutedEventArgs(FrameworkElement.LoadedEvent));

--- a/tests/viewmodels/ArchivePromptViewModelTests.cs
+++ b/tests/viewmodels/ArchivePromptViewModelTests.cs
@@ -66,9 +66,10 @@ public class ArchivePromptViewModelTests
 
     private static InvoiceEditorViewModel CreateEditor(FakeInvoiceService invoice)
     {
-        var lookup = new InvoiceLookupViewModel(invoice, new FakeNumberingService());
+        var numberSvc = new FakeNumberingService();
+        var lookup = new InvoiceLookupViewModel(invoice, numberSvc);
         var state = new AppStateService(Path.GetTempFileName());
-        return new InvoiceEditorViewModel(new DummyService<object>(), new DummyService<object>(), new DummyService<object>(), new FakeProductService(), new DummyService<object>(), new DummyService<object>(), invoice, new DummyLogService(), new DummyNotificationService(), state, lookup);
+        return new InvoiceEditorViewModel(new DummyService<object>(), new DummyService<object>(), new DummyService<object>(), new FakeProductService(), new DummyService<object>(), new DummyService<object>(), invoice, new DummyLogService(), new DummyNotificationService(), state, lookup, numberSvc);
     }
 
     [Fact]

--- a/tests/viewmodels/DeleteItemPromptViewModelTests.cs
+++ b/tests/viewmodels/DeleteItemPromptViewModelTests.cs
@@ -62,9 +62,10 @@ public class DeleteItemPromptViewModelTests
     private static InvoiceEditorViewModel CreateEditor()
     {
         var invoice = new FakeInvoiceService();
-        var lookup = new InvoiceLookupViewModel(invoice, new FakeNumberingService());
+        var numberSvc = new FakeNumberingService();
+        var lookup = new InvoiceLookupViewModel(invoice, numberSvc);
         var state = new AppStateService(Path.GetTempFileName());
-        return new InvoiceEditorViewModel(new DummyService<object>(), new DummyService<object>(), new DummyService<object>(), new FakeProductService(), new DummyService<object>(), new DummyService<object>(), invoice, new DummyLogService(), new DummyNotificationService(), state, lookup);
+        return new InvoiceEditorViewModel(new DummyService<object>(), new DummyService<object>(), new DummyService<object>(), new FakeProductService(), new DummyService<object>(), new DummyService<object>(), invoice, new DummyLogService(), new DummyNotificationService(), state, lookup, numberSvc);
     }
 
     [Fact]

--- a/tests/viewmodels/EditableItemViewModelTests.cs
+++ b/tests/viewmodels/EditableItemViewModelTests.cs
@@ -6,10 +6,11 @@ namespace Wrecept.Tests.ViewModels;
 
 public class EditableItemViewModelTests
 {
+    private static T CreateUninitialized<T>() => (T)System.Runtime.Serialization.FormatterServices.GetUninitializedObject(typeof(T));
     [Fact]
     public void ExistingItem_CopiesProperties()
     {
-        var parent = new InvoiceEditorViewModel();
+        var parent = CreateUninitialized<InvoiceEditorViewModel>();
         var source = new InvoiceItemRowViewModel(parent)
         {
             Product = "P",

--- a/tests/viewmodels/InvoiceEditorViewModelTests.cs
+++ b/tests/viewmodels/InvoiceEditorViewModelTests.cs
@@ -115,7 +115,7 @@ public class InvoiceEditorViewModelTests
     private class FakeNumberingService : INumberingService
     {
         private int _counter;
-        public Task<string> GetNextInvoiceNumberAsync(System.Threading.CancellationToken ct = default)
+        public Task<string> GetNextInvoiceNumberAsync(int supplierId, System.Threading.CancellationToken ct = default)
         {
             _counter++;
             return Task.FromResult($"INV{_counter}");
@@ -154,9 +154,10 @@ public class InvoiceEditorViewModelTests
         var groups = new DummyService<object>();
         var log = new DummyLogService();
         var notify = new DummyNotificationService();
-        var lookup = new InvoiceLookupViewModel(invoiceSvc, new FakeNumberingService());
+        var num = new FakeNumberingService();
+        var lookup = new InvoiceLookupViewModel(invoiceSvc, num);
         var state = new AppStateService(Path.GetTempFileName());
-        var vm = new InvoiceEditorViewModel(payment, tax, supplier, productSvc, unit, groups, invoiceSvc, log, notify, state, lookup);
+        var vm = new InvoiceEditorViewModel(payment, tax, supplier, productSvc, unit, groups, invoiceSvc, log, notify, state, lookup, num);
 
         var row = vm.Items[0];
         row.Product = "Test";
@@ -182,9 +183,10 @@ public class InvoiceEditorViewModelTests
         var unit = new DummyService<object>();
         var log = new DummyLogService();
         var notify = new DummyNotificationService();
-        var lookup = new InvoiceLookupViewModel(invoiceSvc, new FakeNumberingService());
+        var num = new FakeNumberingService();
+        var lookup = new InvoiceLookupViewModel(invoiceSvc, num);
         var state = new AppStateService(Path.GetTempFileName());
-        var vm = new InvoiceEditorViewModel(payment, tax, supplier, productSvc, unit, groups, invoiceSvc, log, notify, state, lookup);
+        var vm = new InvoiceEditorViewModel(payment, tax, supplier, productSvc, unit, groups, invoiceSvc, log, notify, state, lookup, num);
 
         var row = vm.Items[0];
         row.Product = "Test";
@@ -209,9 +211,10 @@ public class InvoiceEditorViewModelTests
         var dummy = new DummyService<object>();
         var log = new DummyLogService();
         var notify = new DummyNotificationService();
-        var lookup = new InvoiceLookupViewModel(invoiceSvc, new FakeNumberingService());
+        var num = new FakeNumberingService();
+        var lookup = new InvoiceLookupViewModel(invoiceSvc, num);
         var state = new AppStateService(Path.GetTempFileName());
-        var vm = new InvoiceEditorViewModel(dummy, dummy, dummy, productSvc, dummy, dummy, invoiceSvc, log, notify, state, lookup)
+        var vm = new InvoiceEditorViewModel(dummy, dummy, dummy, productSvc, dummy, dummy, invoiceSvc, log, notify, state, lookup, num)
         {
             IsArchived = true
         };
@@ -237,9 +240,10 @@ public class InvoiceEditorViewModelTests
         var dummy = new DummyService<object>();
         var log = new DummyLogService();
         var notify = new DummyNotificationService();
-        var lookup = new InvoiceLookupViewModel(invoiceSvc, new FakeNumberingService());
+        var num = new FakeNumberingService();
+        var lookup = new InvoiceLookupViewModel(invoiceSvc, num);
         var state = new AppStateService(Path.GetTempFileName());
-        var vm = new InvoiceEditorViewModel(dummy, dummy, dummy, productSvc, dummy, dummy, invoiceSvc, log, notify, state, lookup);
+        var vm = new InvoiceEditorViewModel(dummy, dummy, dummy, productSvc, dummy, dummy, invoiceSvc, log, notify, state, lookup, num);
 
         var row = vm.Items[0];
         var creator = new ProductCreatorViewModel(vm, row, productSvc)
@@ -263,9 +267,10 @@ public class InvoiceEditorViewModelTests
         var dummy = new DummyService<object>();
         var log = new DummyLogService();
         var notify = new DummyNotificationService();
-        var lookup = new InvoiceLookupViewModel(invoiceSvc, new FakeNumberingService());
+        var num = new FakeNumberingService();
+        var lookup = new InvoiceLookupViewModel(invoiceSvc, num);
         var state = new AppStateService(Path.GetTempFileName());
-        var vm = new InvoiceEditorViewModel(dummy, dummy, dummy, productSvc, dummy, dummy, invoiceSvc, log, notify, state, lookup)
+        var vm = new InvoiceEditorViewModel(dummy, dummy, dummy, productSvc, dummy, dummy, invoiceSvc, log, notify, state, lookup, num)
         {
             IsNew = false,
             InvoiceId = 1
@@ -296,9 +301,10 @@ public class InvoiceEditorViewModelTests
         var dummy = new DummyService<object>();
         var log = new DummyLogService();
         var notify = new DummyNotificationService();
-        var lookup = new InvoiceLookupViewModel(invoiceSvc, new FakeNumberingService());
+        var num = new FakeNumberingService();
+        var lookup = new InvoiceLookupViewModel(invoiceSvc, num);
         var state = new AppStateService(Path.GetTempFileName());
-        var vm = new InvoiceEditorViewModel(dummy, dummy, dummy, productSvc, dummy, dummy, invoiceSvc, log, notify, state, lookup)
+        var vm = new InvoiceEditorViewModel(dummy, dummy, dummy, productSvc, dummy, dummy, invoiceSvc, log, notify, state, lookup, num)
         {
             IsNew = false,
             InvoiceId = 1,
@@ -328,9 +334,10 @@ public class InvoiceEditorViewModelTests
         var productSvc = new FakeProductService();
         var log = new DummyLogService();
         var notify = new DummyNotificationService();
-        var lookup = new InvoiceLookupViewModel(invoiceSvc, new FakeNumberingService());
+        var num = new FakeNumberingService();
+        var lookup = new InvoiceLookupViewModel(invoiceSvc, num);
         var state = new AppStateService(Path.GetTempFileName());
-        var vm = new InvoiceEditorViewModel(dummy, dummy, dummy, productSvc, dummy, dummy, invoiceSvc, log, notify, state, lookup);
+        var vm = new InvoiceEditorViewModel(dummy, dummy, dummy, productSvc, dummy, dummy, invoiceSvc, log, notify, state, lookup, num);
 
         lookup.Invoices.Add(new InvoiceLookupItem { Id = 1, Number = "A1", Date = DateOnly.FromDateTime(DateTime.Today) });
         lookup.SelectedInvoice = lookup.Invoices[0];
@@ -343,9 +350,10 @@ public class InvoiceEditorViewModelTests
     public void InlineCreator_SetsInteractionState()
     {
         var invoiceSvc = new FakeInvoiceService();
-        var lookup = new InvoiceLookupViewModel(invoiceSvc, new FakeNumberingService());
+        var num = new FakeNumberingService();
+        var lookup = new InvoiceLookupViewModel(invoiceSvc, num);
         var state = new AppStateService(Path.GetTempFileName());
-        var vm = new InvoiceEditorViewModel(new DummyService<object>(), new DummyService<object>(), new DummyService<object>(), new FakeProductService(), new DummyService<object>(), new DummyService<object>(), invoiceSvc, new DummyLogService(), new DummyNotificationService(), state, lookup);
+        var vm = new InvoiceEditorViewModel(new DummyService<object>(), new DummyService<object>(), new DummyService<object>(), new FakeProductService(), new DummyService<object>(), new DummyService<object>(), invoiceSvc, new DummyLogService(), new DummyNotificationService(), state, lookup, num);
 
         vm.InlineCreator = new ProductCreatorViewModel(vm, vm.Items[0], new FakeProductService());
         Assert.Equal(AppInteractionState.InlineCreatorActive, state.InteractionState);
@@ -390,10 +398,11 @@ public class InvoiceEditorViewModelTests
         };
         invoiceSvc.Invoices.Add(invoice);
 
-        var lookup = new InvoiceLookupViewModel(invoiceSvc, new FakeNumberingService());
+        var num = new FakeNumberingService();
+        var lookup = new InvoiceLookupViewModel(invoiceSvc, num);
         await lookup.LoadAsync();
         var state = new AppStateService(Path.GetTempFileName());
-        var vm = new InvoiceEditorViewModel(new DummyService<object>(), new DummyService<object>(), new DummyService<object>(), new FakeProductService(), new DummyService<object>(), new DummyService<object>(), invoiceSvc, new DummyLogService(), new DummyNotificationService(), state, lookup);
+        var vm = new InvoiceEditorViewModel(new DummyService<object>(), new DummyService<object>(), new DummyService<object>(), new FakeProductService(), new DummyService<object>(), new DummyService<object>(), invoiceSvc, new DummyLogService(), new DummyNotificationService(), state, lookup, num);
 
         lookup.SelectedInvoice = lookup.Invoices[0];
 

--- a/tests/viewmodels/InvoiceLookupViewModelTests.cs
+++ b/tests/viewmodels/InvoiceLookupViewModelTests.cs
@@ -37,7 +37,7 @@ public class InvoiceLookupViewModelTests
     private class FakeNumberingService : INumberingService
     {
         private int _counter;
-        public Task<string> GetNextInvoiceNumberAsync(System.Threading.CancellationToken ct = default)
+        public Task<string> GetNextInvoiceNumberAsync(int supplierId, System.Threading.CancellationToken ct = default)
         {
             _counter++;
             return Task.FromResult($"INV{_counter}");

--- a/tests/viewmodels/SaveLinePromptViewModelTests.cs
+++ b/tests/viewmodels/SaveLinePromptViewModelTests.cs
@@ -78,7 +78,7 @@ public class SaveLinePromptViewModelTests
         var numberSvc = new FakeNumberingService();
         var lookup = new InvoiceLookupViewModel(invoice, numberSvc);
         var state = new AppStateService(Path.GetTempFileName());
-        return new InvoiceEditorViewModel(new DummyService<object>(), new DummyService<object>(), new DummyService<object>(), products, new DummyService<object>(), new DummyService<object>(), invoice, new DummyLogService(), new DummyNotificationService(), state, lookup);
+        return new InvoiceEditorViewModel(new DummyService<object>(), new DummyService<object>(), new DummyService<object>(), products, new DummyService<object>(), new DummyService<object>(), invoice, new DummyLogService(), new DummyNotificationService(), state, lookup, numberSvc);
     }
 
     [Fact]

--- a/tests/viewmodels/StageViewModelTests.cs
+++ b/tests/viewmodels/StageViewModelTests.cs
@@ -52,7 +52,7 @@ public class StageViewModelTests
             LastView = last,
             CurrentInvoiceId = null
         };
-        var invoice = new InvoiceEditorViewModel(); // Replace with proper instantiation logic.
+        var invoice = CreateUninitialized<InvoiceEditorViewModel>();
         var product = new ProductMasterViewModel(new FakeProductService(), new FakeTaxRateService());
         var group = new ProductGroupMasterViewModel(new FakeProductGroupService());
         var supplier = new SupplierMasterViewModel(new FakeSupplierService());
@@ -136,7 +136,7 @@ public class StageViewModelTests
     {
         var state = new AppStateService(Path.GetTempFileName());
         NavigationService.State = state;
-        var invoice = new InvoiceEditorViewModel();
+        var invoice = CreateUninitialized<InvoiceEditorViewModel>();
         var product = new ProductMasterViewModel(new FakeProductService(), new FakeTaxRateService(), state);
         var group = new ProductGroupMasterViewModel(new FakeProductGroupService(), state);
         var supplier = new SupplierMasterViewModel(new FakeSupplierService(), state);
@@ -163,7 +163,7 @@ public class StageViewModelTests
     {
         var state = new AppStateService(Path.GetTempFileName());
         NavigationService.State = state;
-        var invoice = new InvoiceEditorViewModel();
+        var invoice = CreateUninitialized<InvoiceEditorViewModel>();
         var changes = new List<AppInteractionState>();
         state.InteractionStateChanged += s => changes.Add(s);
         var product = new ProductMasterViewModel(new FakeProductService(), new FakeTaxRateService(), state);

--- a/tests/viewmodels/TotalsViewModelTests.cs
+++ b/tests/viewmodels/TotalsViewModelTests.cs
@@ -14,7 +14,7 @@ public class TotalsViewModelTests
         var vm = new TotalsViewModel();
         var rows = new ObservableCollection<InvoiceItemRowViewModel>
         {
-            new(new InvoiceEditorViewModel(null!, null!, null!, null!, null!, null!, null!, null!, null!, null!, null!, null!))
+            new(new InvoiceEditorViewModel(null!, null!, null!, null!, null!, null!, null!, null!, null!, null!, null!, null!, null!))
             {
                 Quantity = 2,
                 UnitPrice = 100,


### PR DESCRIPTION
## Summary
- extend `INumberingService` with supplierId parameter
- implement per-supplier numbering in `NumberingService`
- add repository API to query latest invoice number
- include numbering service when loading invoices in the UI
- adapt view models and unit tests

## Testing
- `dotnet test --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_687402c787c0832299ea9749123d5f90