### PR TITLE
Fix framework mismatch for Storage project

### DIFF
--- a/Wrecept.Storage/Wrecept.Storage.csproj
+++ b/Wrecept.Storage/Wrecept.Storage.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>


### PR DESCRIPTION
## Summary
- target `net8.0-windows` in `Wrecept.Storage`

## Testing
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_68740d7a9b688322be5a341da9ee3d0b