### PR TITLE
Add skeleton MAUI projects

### DIFF
--- a/InvoiceApp.Core/InvoiceApp.Core.csproj
+++ b/InvoiceApp.Core/InvoiceApp.Core.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\refactor\Wrecept.Plugins.Abstractions\Wrecept.Plugins.Abstractions.csproj" />
+  </ItemGroup>
+</Project>

--- a/InvoiceApp.Core/Placeholder.cs
+++ b/InvoiceApp.Core/Placeholder.cs
@@ -1,0 +1,2 @@
+namespace InvoiceApp.Core;
+public class Placeholder {}

--- a/InvoiceApp.Core/README.md
+++ b/InvoiceApp.Core/README.md
@@ -1,0 +1,3 @@
+# InvoiceApp.Core
+
+Shared domain models and service interfaces for the upcoming MAUI version.

--- a/InvoiceApp.Data/InvoiceApp.Data.csproj
+++ b/InvoiceApp.Data/InvoiceApp.Data.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.4">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Bogus" Version="35.0.1" />
+    <PackageReference Include="Serilog" Version="3.1.1" />
+    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\InvoiceApp.Core\InvoiceApp.Core.csproj" />
+    <ProjectReference Include="..\refactor\Wrecept.Plugins.Abstractions\Wrecept.Plugins.Abstractions.csproj" />
+  </ItemGroup>
+</Project>

--- a/InvoiceApp.Data/Placeholder.cs
+++ b/InvoiceApp.Data/Placeholder.cs
@@ -1,0 +1,2 @@
+namespace InvoiceApp.Data;
+public class Placeholder {}

--- a/InvoiceApp.Data/README.md
+++ b/InvoiceApp.Data/README.md
@@ -1,0 +1,3 @@
+# InvoiceApp.Data
+
+Entity Framework Core DbContext and repositories for the MAUI edition.

--- a/InvoiceApp.MAUI/InvoiceApp.MAUI.csproj
+++ b/InvoiceApp.MAUI/InvoiceApp.MAUI.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>net8.0-windows10.0.19041.0</TargetFrameworks>
+    <Nullable>enable</Nullable>
+    <UseMaui>true</UseMaui>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\InvoiceApp.Core\InvoiceApp.Core.csproj" />
+    <ProjectReference Include="..\InvoiceApp.Data\InvoiceApp.Data.csproj" />
+    <ProjectReference Include="..\refactor\Wrecept.Plugins.Abstractions\Wrecept.Plugins.Abstractions.csproj" />
+  </ItemGroup>
+</Project>

--- a/InvoiceApp.MAUI/Program.cs
+++ b/InvoiceApp.MAUI/Program.cs
@@ -1,0 +1,20 @@
+using Microsoft.Maui;
+using Microsoft.Maui.Hosting;
+namespace InvoiceApp.MAUI;
+public class Program : MauiApplication
+{
+    public Program() : base()
+    {
+    }
+    protected override MauiApp CreateMauiApp() => MauiProgram.CreateMauiApp();
+    static void Main(string[] args) => new Program().Run(args);
+}
+
+public static class MauiProgram
+{
+    public static MauiApp CreateMauiApp()
+    {
+        var builder = MauiApp.CreateBuilder();
+        return builder.Build();
+    }
+}

--- a/InvoiceApp.MAUI/README.md
+++ b/InvoiceApp.MAUI/README.md
@@ -1,0 +1,3 @@
+# InvoiceApp.MAUI
+
+.NET MAUI user interface with MVVM and startup logic.

--- a/README.md
+++ b/README.md
@@ -2,5 +2,7 @@
 
 Offline-first WPF invoicing tool built with C# (.NET 8) and MVVM architecture. The project is being prepared for a cross-platform .NET MAUI version.
 See [docs/README.md](docs/README.md) or the Hungarian version
+
+Placeholder MAUI projects (InvoiceApp.Core, InvoiceApp.Data, InvoiceApp.MAUI) have been added for the upcoming port.
 [docs/README_hu.md](docs/README_hu.md) for full documentation. The user manual
 is available under [docs/manuals/user_manual_hu.md](docs/manuals/user_manual_hu.md).

--- a/Wrecept.sln
+++ b/Wrecept.sln
@@ -11,6 +11,12 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Wrecept.Wpf", "Wrecept.Wpf\
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Wrecept.UiTests", "tests\Wrecept.UiTests\Wrecept.UiTests.csproj", "{774CE749-12EB-4FF3-9C18-9F94C695176C}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "InvoiceApp.Core", "InvoiceApp.Core\InvoiceApp.Core.csproj", "{87717039-6AE8-450C-A0B9-1F07115DE1B3}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "InvoiceApp.Data", "InvoiceApp.Data\InvoiceApp.Data.csproj", "{8E133574-F17F-45A7-A40B-1E157B5FF168}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "InvoiceApp.MAUI", "InvoiceApp.MAUI\InvoiceApp.MAUI.csproj", "{1463BE2E-1707-4491-9BEE-34220E47AF7F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -32,6 +38,18 @@ Global
 		{774CE749-12EB-4FF3-9C18-9F94C695176C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{774CE749-12EB-4FF3-9C18-9F94C695176C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{774CE749-12EB-4FF3-9C18-9F94C695176C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{87717039-6AE8-450C-A0B9-1F07115DE1B3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{87717039-6AE8-450C-A0B9-1F07115DE1B3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{87717039-6AE8-450C-A0B9-1F07115DE1B3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{87717039-6AE8-450C-A0B9-1F07115DE1B3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8E133574-F17F-45A7-A40B-1E157B5FF168}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8E133574-F17F-45A7-A40B-1E157B5FF168}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8E133574-F17F-45A7-A40B-1E157B5FF168}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8E133574-F17F-45A7-A40B-1E157B5FF168}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1463BE2E-1707-4491-9BEE-34220E47AF7F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1463BE2E-1707-4491-9BEE-34220E47AF7F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1463BE2E-1707-4491-9BEE-34220E47AF7F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1463BE2E-1707-4491-9BEE-34220E47AF7F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/docs/MAUI_PORT_PREP.md
+++ b/docs/MAUI_PORT_PREP.md
@@ -38,3 +38,4 @@ To align with the MAUI architecture, the projects will be renamed:
 
 The namespaces will follow the new project names (e.g. `InvoiceApp.Core.Models`).
 
+Initial placeholder projects have been created under InvoiceApp.Core, InvoiceApp.Data and InvoiceApp.MAUI.

--- a/docs/PROJECT_STRUCTURE.md
+++ b/docs/PROJECT_STRUCTURE.md
@@ -15,6 +15,7 @@ Ez a dokumentum fájlonként rögzíti a Wrecept megvalósításában szereplő 
    - **InvoiceApp.MAUI** – nézetek, ViewModel-ek és indítási logika
    - **InvoiceApp.Core** – modellek és szolgáltatás interfészek
    - **InvoiceApp.Data** – DbContext és repositoryk
+       - Initial placeholders added for these projects in July 2025.
 2. **MRS (Model–Repository–Service) Réteg** – a tárolási és üzleti logika felosztása
 3. **MVVM (Model–View–ViewModel) Réteg** – felület és logika elválasztása
 


### PR DESCRIPTION
## Summary
- create placeholder projects InvoiceApp.Core, InvoiceApp.Data and InvoiceApp.MAUI
- register them in the solution
- document new placeholders in MAUI_PORT_PREP and PROJECT_STRUCTURE
- note the addition in the main README

## Testing
- `dotnet build Wrecept.sln -v minimal` *(failed: Microsoft.NET.Sdk.WindowsDesktop not found)*
- `dotnet test tests/Wrecept.Tests/Wrecept.Tests.csproj -v minimal` *(failed: Wrecept.Storage not compatible)*

------
https://chatgpt.com/codex/tasks/task_e_68741831a9188322a41481d03497ab79