### PR TITLE
Add MAUI project scaffolding

### DIFF
--- a/InvoiceApp.Core/SeedStatus.cs
+++ b/InvoiceApp.Core/SeedStatus.cs
@@ -1,0 +1,9 @@
+namespace InvoiceApp.Core.Enums;
+
+public enum SeedStatus
+{
+    None,
+    Seeded,
+    OnlySampleData,
+    Failed
+}

--- a/InvoiceApp.Core/StageMenuAction.cs
+++ b/InvoiceApp.Core/StageMenuAction.cs
@@ -1,0 +1,26 @@
+namespace InvoiceApp.Core.Enums;
+
+public enum StageMenuAction
+{
+    InboundDeliveryNotes,
+    UpdateInboundInvoices,
+    EditProducts,
+    EditProductGroups,
+    EditSuppliers,
+    EditVatKeys,
+    EditPaymentMethods,
+    EditUnits,
+    ListProducts,
+    ListSuppliers,
+    ListInvoices,
+    InventoryCard,
+    CheckFiles,
+    AfterPowerOutage,
+    BackupData,
+    RestoreData,
+    ScreenSettings,
+    PrinterSettings,
+    EditUserInfo,
+    UserInfo,
+    ExitApplication
+}

--- a/InvoiceApp.MAUI/App.xaml
+++ b/InvoiceApp.MAUI/App.xaml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Application xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="InvoiceApp.MAUI.App">
+    <Application.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="Resources/Styles/RetroTheme.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </Application.Resources>
+</Application>

--- a/InvoiceApp.MAUI/App.xaml.cs
+++ b/InvoiceApp.MAUI/App.xaml.cs
@@ -1,0 +1,11 @@
+using Microsoft.Maui.Controls;
+
+namespace InvoiceApp.MAUI;
+
+public partial class App : Application
+{
+    public App()
+    {
+        InitializeComponent();
+    }
+}

--- a/InvoiceApp.MAUI/InvoiceApp.MAUI.csproj
+++ b/InvoiceApp.MAUI/InvoiceApp.MAUI.csproj
@@ -1,13 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0-windows10.0.19041.0</TargetFrameworks>
-    <Nullable>enable</Nullable>
+    <TargetFramework>net8.0</TargetFramework>
     <UseMaui>true</UseMaui>
-    <EnableWindowsTargeting>true</EnableWindowsTargeting>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <MauiXaml Include="Resources\Styles\RetroTheme.xaml" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\InvoiceApp.Core\InvoiceApp.Core.csproj" />

--- a/InvoiceApp.MAUI/MainPage.xaml
+++ b/InvoiceApp.MAUI/MainPage.xaml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="InvoiceApp.MAUI.MainPage">
+    <VerticalStackLayout>
+        <Label Text="Hello MAUI" />
+    </VerticalStackLayout>
+</ContentPage>

--- a/InvoiceApp.MAUI/MainPage.xaml.cs
+++ b/InvoiceApp.MAUI/MainPage.xaml.cs
@@ -1,0 +1,28 @@
+using Microsoft.Maui.Controls;
+using InvoiceApp.MAUI.Services;
+
+namespace InvoiceApp.MAUI;
+
+public partial class MainPage : ContentPage
+{
+    public MainPage()
+    {
+        InitializeComponent();
+    }
+
+    protected override void OnHandlerChanged()
+    {
+        base.OnHandlerChanged();
+        if (Handler?.MauiContext?.Window is IWindow window)
+        {
+            window.KeyDown += OnKeyDown;
+        }
+    }
+
+    private void OnKeyDown(object? sender, Microsoft.Maui.Input.KeyEventArgs e)
+    {
+        var km = MauiProgram.Services?.GetService<KeyboardManager>();
+        if (km != null && km.Process(e))
+            e.Handled = true;
+    }
+}

--- a/InvoiceApp.MAUI/MauiProgram.cs
+++ b/InvoiceApp.MAUI/MauiProgram.cs
@@ -1,0 +1,37 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Maui.Hosting;
+using Microsoft.Maui;
+using Microsoft.Maui.Storage;
+using InvoiceApp.Core;
+using InvoiceApp.MAUI.Services;
+
+namespace InvoiceApp.MAUI;
+
+public static class MauiProgram
+{
+    public static IServiceProvider? Services { get; private set; }
+    public static MauiApp CreateMauiApp()
+    {
+        var builder = MauiApp.CreateBuilder();
+        builder
+            .UseMauiApp<App>();
+
+        ConfigureServices(builder.Services);
+
+        var app = builder.Build();
+        Services = app.Services;
+        return app;
+    }
+
+    private static void ConfigureServices(IServiceCollection services)
+    {
+        var appDir = FileSystem.AppDataDirectory;
+        var settingsPath = Path.Combine(appDir, "settings.json");
+        services.AddCore();
+        services.AddStorageAsync(Path.Combine(appDir, "app.db"), Path.Combine(appDir, "user.json"), settingsPath).GetAwaiter().GetResult();
+        services.AddSingleton<AppStateService>(_ => new AppStateService(Path.Combine(appDir, "state.json")));
+        services.AddSingleton<KeyboardManager>();
+        services.AddTransient<StartupOrchestrator>();
+        services.AddTransient<MainPage>();
+    }
+}

--- a/InvoiceApp.MAUI/Program.cs
+++ b/InvoiceApp.MAUI/Program.cs
@@ -1,20 +1,15 @@
 using Microsoft.Maui;
 using Microsoft.Maui.Hosting;
+
 namespace InvoiceApp.MAUI;
+
 public class Program : MauiApplication
 {
-    public Program() : base()
-    {
-    }
     protected override MauiApp CreateMauiApp() => MauiProgram.CreateMauiApp();
-    static void Main(string[] args) => new Program().Run(args);
-}
 
-public static class MauiProgram
-{
-    public static MauiApp CreateMauiApp()
+    static void Main(string[] args)
     {
-        var builder = MauiApp.CreateBuilder();
-        return builder.Build();
+        var app = new Program();
+        app.Run(args);
     }
 }

--- a/InvoiceApp.MAUI/Resources/Styles/RetroTheme.xaml
+++ b/InvoiceApp.MAUI/Resources/Styles/RetroTheme.xaml
@@ -1,0 +1,142 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:sys="clr-namespace:System;assembly=mscorlib">
+    <!-- Light retro palette -->
+    <Color x:Key="BackgroundColor">#9b8b20</Color>
+    <Color x:Key="ForegroundColor">#000000</Color>
+    <Color x:Key="HighlightColor">#0000aa</Color>
+    <Color x:Key="SelectionColor">#000055</Color>
+    <Color x:Key="HeaderFooterColor">#806000</Color>
+
+    <Color x:Key="StageBackgroundColor">#9b8b20</Color>
+
+    <SolidColorBrush x:Key="StageBackground" Color="{StaticResource StageBackgroundColor}" />
+
+    <SolidColorBrush x:Key="BackgroundBrush" Color="{StaticResource BackgroundColor}" />
+    <SolidColorBrush x:Key="ForegroundBrush" Color="{StaticResource ForegroundColor}" />
+    <SolidColorBrush x:Key="HighlightBrush" Color="{StaticResource HighlightColor}" />
+    <SolidColorBrush x:Key="SelectionBrush" Color="{StaticResource SelectionColor}" />
+    <SolidColorBrush x:Key="ControlBackgroundBrush" Color="#c7bb4f" />
+    <SolidColorBrush x:Key="HeaderFooterBrush" Color="{StaticResource HeaderFooterColor}" />
+
+    <!-- Spacing helpers -->
+    <Thickness x:Key="DefaultMargin">6</Thickness>
+
+    <sys:Double x:Key="FontSizeNormal">16</sys:Double>
+    <sys:Double x:Key="FontSizeLarge">18</sys:Double>
+
+    <!-- Header font resources -->
+    <FontFamily x:Key="MonospacedFont">pack://application:,,,/Resources/#IBM Plex Mono</FontFamily>
+    <Style TargetType="TextBlock" x:Key="HeaderText">
+        <Setter Property="FontFamily" Value="{StaticResource MonospacedFont}" />
+        <Setter Property="FontSize" Value="14" />
+    </Style>
+    <Style TargetType="TextBlock" x:Key="HeaderTextBold">
+        <Setter Property="FontFamily" Value="{StaticResource MonospacedFont}" />
+        <Setter Property="FontSize" Value="16" />
+        <Setter Property="FontWeight" Value="Bold" />
+    </Style>
+
+    <Style TargetType="TextBlock" x:Key="LabelTextStyle">
+        <Setter Property="FontFamily" Value="{StaticResource MonospacedFont}" />
+        <Setter Property="FontSize" Value="14" />
+        <Setter Property="FontWeight" Value="SemiBold" />
+    </Style>
+
+    <Style TargetType="Label" x:Key="FormLabelStyle">
+        <Setter Property="FontFamily" Value="{StaticResource MonospacedFont}" />
+        <Setter Property="FontSize" Value="14" />
+        <Setter Property="FontWeight" Value="SemiBold" />
+    </Style>
+
+    <Style TargetType="TextBlock" x:Key="ValueTextStyle">
+        <Setter Property="FontFamily" Value="{StaticResource MonospacedFont}" />
+        <Setter Property="FontSize" Value="14" />
+        <Setter Property="TextAlignment" Value="Right" />
+    </Style>
+
+    <Style TargetType="TextBlock" x:Key="BoldTotalStyle" BasedOn="{StaticResource ValueTextStyle}">
+        <Setter Property="FontWeight" Value="Bold" />
+    </Style>
+
+    <Style TargetType="TextBlock">
+        <Setter Property="Foreground" Value="{StaticResource ForegroundBrush}" />
+        <Setter Property="FontFamily" Value="{StaticResource MonospacedFont}" />
+        <Setter Property="FontSize" Value="{StaticResource FontSizeNormal}" />
+    </Style>
+
+    <Style TargetType="TextBox">
+        <Setter Property="Foreground" Value="{StaticResource ForegroundBrush}" />
+        <Setter Property="Background" Value="{StaticResource ControlBackgroundBrush}" />
+        <Setter Property="BorderBrush" Value="{StaticResource HighlightBrush}" />
+        <Setter Property="FontFamily" Value="{StaticResource MonospacedFont}" />
+        <Setter Property="FontSize" Value="{StaticResource FontSizeNormal}" />
+    </Style>
+
+    <Style TargetType="TextBox" x:Key="HeaderTextBoxBold" BasedOn="{StaticResource {x:Type TextBox}}">
+        <Setter Property="FontFamily" Value="{StaticResource MonospacedFont}" />
+        <Setter Property="FontSize" Value="16" />
+        <Setter Property="FontWeight" Value="Bold" />
+    </Style>
+
+    <Style TargetType="ComboBox">
+        <Setter Property="FontFamily" Value="{StaticResource MonospacedFont}" />
+        <Setter Property="FontSize" Value="{StaticResource FontSizeNormal}" />
+    </Style>
+
+    <Style TargetType="Label">
+        <Setter Property="FontFamily" Value="{StaticResource MonospacedFont}" />
+        <Setter Property="FontSize" Value="{StaticResource FontSizeNormal}" />
+    </Style>
+
+    <Style TargetType="CheckBox">
+        <Setter Property="FontFamily" Value="{StaticResource MonospacedFont}" />
+        <Setter Property="FontSize" Value="{StaticResource FontSizeNormal}" />
+    </Style>
+
+    <Style TargetType="Button">
+        <Setter Property="Background" Value="{StaticResource HighlightBrush}" />
+        <Setter Property="Foreground" Value="White" />
+        <Setter Property="BorderBrush" Value="{StaticResource ForegroundBrush}" />
+        <Setter Property="FontFamily" Value="{StaticResource MonospacedFont}" />
+        <Setter Property="FontSize" Value="{StaticResource FontSizeLarge}" />
+    </Style>
+
+    <Style TargetType="Menu">
+        <Setter Property="Background" Value="{StaticResource HeaderFooterBrush}" />
+        <Setter Property="Foreground" Value="{StaticResource ForegroundBrush}" />
+        <Setter Property="FontFamily" Value="{StaticResource MonospacedFont}" />
+        <Setter Property="FontSize" Value="{StaticResource FontSizeLarge}" />
+    </Style>
+
+    <Style TargetType="MenuItem">
+        <Setter Property="Background" Value="{StaticResource HeaderFooterBrush}" />
+        <Setter Property="Foreground" Value="{StaticResource ForegroundBrush}" />
+        <Setter Property="FontFamily" Value="{StaticResource MonospacedFont}" />
+        <Setter Property="FontSize" Value="{StaticResource FontSizeLarge}" />
+    </Style>
+
+    <Style TargetType="DataGrid" x:Key="RetroDataGridStyle">
+        <Setter Property="Background" Value="{StaticResource ControlBackgroundBrush}" />
+        <Setter Property="Foreground" Value="{StaticResource ForegroundBrush}" />
+        <Setter Property="BorderBrush" Value="{StaticResource HighlightBrush}" />
+        <Setter Property="GridLinesVisibility" Value="All" />
+        <Setter Property="RowBackground" Value="{StaticResource ControlBackgroundBrush}" />
+        <Setter Property="AlternatingRowBackground" Value="{StaticResource ControlBackgroundBrush}" />
+        <Setter Property="FontFamily" Value="{StaticResource MonospacedFont}" />
+        <Setter Property="FontSize" Value="{StaticResource FontSizeLarge}" />
+    </Style>
+
+    <Style TargetType="DataGridRow" x:Key="RetroDataGridRowStyle">
+        <Setter Property="Foreground" Value="{StaticResource ForegroundBrush}" />
+        <Setter Property="Background" Value="{StaticResource ControlBackgroundBrush}" />
+        <Setter Property="FontFamily" Value="{StaticResource MonospacedFont}" />
+        <Setter Property="FontSize" Value="{StaticResource FontSizeLarge}" />
+        <Style.Triggers>
+            <Trigger Property="IsSelected" Value="True">
+                <Setter Property="Background" Value="{StaticResource SelectionBrush}" />
+                <Setter Property="Foreground" Value="White" />
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+</ResourceDictionary>

--- a/InvoiceApp.MAUI/Services/AppStateService.cs
+++ b/InvoiceApp.MAUI/Services/AppStateService.cs
@@ -1,0 +1,84 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using InvoiceApp.Core.Enums;
+using System;
+
+namespace InvoiceApp.MAUI.Services;
+
+using System.Text.Json;
+using System.Threading.Tasks;
+using System.IO;
+
+public partial class AppStateService : ObservableObject
+{
+    private readonly string _path;
+
+    public AppStateService(string path)
+    {
+        _path = path;
+    }
+
+    [ObservableProperty]
+    private AppInteractionState interactionState = AppInteractionState.None;
+
+    public event Action<AppInteractionState>? InteractionStateChanged;
+
+    partial void OnInteractionStateChanged(AppInteractionState value)
+        => InteractionStateChanged?.Invoke(value);
+
+    [ObservableProperty]
+    private StageMenuAction lastView = StageMenuAction.InboundDeliveryNotes;
+
+    [ObservableProperty]
+    private int? currentInvoiceId;
+
+    private record PersistedState(StageMenuAction LastView, int? InvoiceId);
+
+    public async Task LoadAsync()
+    {
+        if (!File.Exists(_path))
+            return;
+
+        try
+        {
+            var json = await File.ReadAllTextAsync(_path);
+            var data = JsonSerializer.Deserialize<PersistedState>(json);
+            if (data != null)
+            {
+                LastView = data.LastView;
+                CurrentInvoiceId = data.InvoiceId;
+            }
+        }
+        catch (Exception)
+        {
+            // sérült fájl esetén indulunk alap állapotból
+        }
+    }
+
+    public async Task SaveAsync()
+    {
+        var data = new PersistedState(LastView, CurrentInvoiceId);
+        Directory.CreateDirectory(Path.GetDirectoryName(_path)!);
+        var json = JsonSerializer.Serialize(data);
+        await File.WriteAllTextAsync(_path, json);
+    }
+
+    /// <summary>
+    /// Segédfüggvény modális dialógusokhoz. Ideiglenesen
+    /// <see cref="InteractionState"/> értékét <see cref="AppInteractionState.DialogOpen"/>
+    /// állítja, majd a művelet befejezése után visszaállítja a korábbi állapotot.
+    /// </summary>
+    /// <param name="action">A végrehajtandó aszinkron művelet.</param>
+    public async Task WithDialogOpen(Func<Task> action)
+    {
+        var previous = InteractionState;
+        InteractionState = AppInteractionState.DialogOpen;
+        try
+        {
+            await action();
+        }
+        finally
+        {
+            InteractionState = previous;
+        }
+    }
+}

--- a/InvoiceApp.MAUI/Services/KeyboardManager.cs
+++ b/InvoiceApp.MAUI/Services/KeyboardManager.cs
@@ -1,0 +1,31 @@
+using System.Collections.Generic;
+using Microsoft.Maui.Input;
+using InvoiceApp.Core.Enums;
+
+namespace InvoiceApp.MAUI.Services;
+
+public interface IKeyboardHandler
+{
+    bool HandleKey(KeyEventArgs e);
+}
+
+public class KeyboardManager
+{
+    private readonly AppStateService _state;
+    private readonly Dictionary<AppInteractionState, IKeyboardHandler> _handlers = new();
+
+    public KeyboardManager(AppStateService state)
+    {
+        _state = state;
+    }
+
+    public void Register(AppInteractionState state, IKeyboardHandler handler)
+        => _handlers[state] = handler;
+
+    public bool Process(KeyEventArgs e)
+    {
+        if (_handlers.TryGetValue(_state.InteractionState, out var handler))
+            return handler.HandleKey(e);
+        return false;
+    }
+}

--- a/InvoiceApp.MAUI/StartupOrchestrator.cs
+++ b/InvoiceApp.MAUI/StartupOrchestrator.cs
@@ -1,0 +1,31 @@
+using InvoiceApp.Core.Enums;
+using InvoiceApp.Core.Services;
+using InvoiceApp.Core.Utilities;
+
+namespace InvoiceApp.MAUI;
+
+public class StartupOrchestrator
+{
+    private readonly ILogService _log;
+    private readonly IDatabaseRecoveryService _recovery;
+
+    public StartupOrchestrator(ILogService log, IDatabaseRecoveryService recovery)
+    {
+        _log = log;
+        _recovery = recovery;
+    }
+
+    public Task<bool> DatabaseEmptyAsync(CancellationToken ct)
+        => Task.FromResult(true);
+
+    public Task<SeedStatus> SeedAsync(
+        IProgress<ProgressReport> progress,
+        CancellationToken ct,
+        int supplierCount,
+        int productCount,
+        int invoiceCount,
+        int minItems,
+        int maxItems,
+        bool slow)
+        => Task.FromResult(SeedStatus.None);
+}


### PR DESCRIPTION
## Summary
- scaffold `InvoiceApp.MAUI` as a .NET MAUI single project
- add global RetroTheme resources and a basic `MainPage`
- create `MauiProgram` with service registrations
- wire global keyboard events using `KeyboardManager`
- introduce `StageMenuAction` and `SeedStatus` enums
- provide basic `AppStateService` and stub `StartupOrchestrator`

## Testing
- `dotnet build InvoiceApp.MAUI/InvoiceApp.MAUI.csproj -nologo` *(fails: Could not resolve SDK "Microsoft.NET.Sdk.WindowsDesktop")*

------
https://chatgpt.com/codex/tasks/task_e_68741a547a2083228e9519b24d457228