### PR TITLE
Port WPF viewmodels to MAUI

### DIFF
--- a/InvoiceApp.MAUI/Services/FocusManager.cs
+++ b/InvoiceApp.MAUI/Services/FocusManager.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Maui.ApplicationModel;
+using Microsoft.Maui.Controls;
+using InvoiceApp.Core.Enums;
+
+namespace InvoiceApp.MAUI.Services;
+
+public class FocusManager
+{
+    private readonly AppStateService _state;
+    private readonly Dictionary<AppInteractionState, Func<VisualElement?>> _registry = new();
+
+    public FocusManager(AppStateService state)
+    {
+        _state = state;
+        _state.InteractionStateChanged += OnStateChanged;
+    }
+
+    public void Register(AppInteractionState state, Func<VisualElement?> provider)
+        => _registry[state] = provider;
+
+    private void OnStateChanged(AppInteractionState state)
+    {
+        if (_registry.TryGetValue(state, out var provider))
+            RequestFocus(provider());
+    }
+
+    public void RequestFocus(VisualElement? element)
+    {
+        if (element is null)
+            return;
+
+        MainThread.BeginInvokeOnMainThread(() => element.Focus());
+    }
+}

--- a/InvoiceApp.MAUI/Services/InvoiceEditorKeyboardHandler.cs
+++ b/InvoiceApp.MAUI/Services/InvoiceEditorKeyboardHandler.cs
@@ -1,0 +1,34 @@
+using Microsoft.Maui.Input;
+using InvoiceApp.MAUI.ViewModels;
+
+namespace InvoiceApp.MAUI.Services;
+
+public class InvoiceEditorKeyboardHandler : IKeyboardHandler
+{
+    private readonly InvoiceEditorViewModel _vm;
+
+    public InvoiceEditorKeyboardHandler(InvoiceEditorViewModel vm)
+    {
+        _vm = vm;
+    }
+
+    public bool HandleKey(KeyEventArgs e)
+    {
+        switch (e.Key)
+        {
+            case Key.Insert:
+                _vm.AddLineItemCommand.Execute(null);
+                return true;
+            case Key.Delete:
+                _vm.ShowArchivePromptCommand.Execute(null);
+                return true;
+            case Key.Enter or Key.Return:
+                _vm.SaveEditedItemCommand.Execute(null);
+                return true;
+            case Key.Escape:
+                _vm.CloseCommand.Execute(null);
+                return true;
+        }
+        return false;
+    }
+}

--- a/InvoiceApp.MAUI/Services/InvoiceLookupKeyboardHandler.cs
+++ b/InvoiceApp.MAUI/Services/InvoiceLookupKeyboardHandler.cs
@@ -1,0 +1,24 @@
+using Microsoft.Maui.Input;
+using InvoiceApp.MAUI.ViewModels;
+
+namespace InvoiceApp.MAUI.Services;
+
+public class InvoiceLookupKeyboardHandler : IKeyboardHandler
+{
+    private readonly InvoiceLookupViewModel _viewModel;
+
+    public InvoiceLookupKeyboardHandler(InvoiceLookupViewModel viewModel)
+    {
+        _viewModel = viewModel;
+    }
+
+    public bool HandleKey(KeyEventArgs e)
+    {
+        if (e.Key == Key.Insert || e.Key == Key.Up)
+        {
+            _viewModel.CreateNewInvoiceCommand.Execute(null);
+            return true;
+        }
+        return false;
+    }
+}

--- a/InvoiceApp.MAUI/Services/MasterDataKeyboardHandler.cs
+++ b/InvoiceApp.MAUI/Services/MasterDataKeyboardHandler.cs
@@ -1,0 +1,36 @@
+using Microsoft.Maui.Input;
+using CommunityToolkit.Mvvm.Input;
+using InvoiceApp.MAUI.ViewModels;
+
+namespace InvoiceApp.MAUI.Services;
+
+public class MasterDataKeyboardHandler : IKeyboardHandler
+{
+    private readonly StageViewModel _stage;
+
+    public MasterDataKeyboardHandler(StageViewModel stage)
+    {
+        _stage = stage;
+    }
+
+    public bool HandleKey(KeyEventArgs e)
+    {
+        switch (e.Key)
+        {
+            case Key.Insert:
+            case Key.Enter or Key.Return:
+                if (_stage.CurrentViewModel is IEditableMasterDataViewModel vmEdit)
+                    vmEdit.EditSelectedCommand.Execute(null);
+                return true;
+            case Key.Delete:
+                if (_stage.CurrentViewModel is IEditableMasterDataViewModel vmDel)
+                    vmDel.DeleteSelectedCommand.Execute(null);
+                return true;
+            case Key.Escape:
+                if (_stage.CurrentViewModel is IEditableMasterDataViewModel vmClose)
+                    vmClose.CloseDetailsCommand.Execute(null);
+                return true;
+        }
+        return false;
+    }
+}

--- a/InvoiceApp.MAUI/Services/MessageBoxNotificationService.cs
+++ b/InvoiceApp.MAUI/Services/MessageBoxNotificationService.cs
@@ -1,0 +1,28 @@
+using InvoiceApp.Core.Services;
+using Microsoft.Maui.ApplicationModel;
+using Microsoft.Maui.Controls;
+
+namespace InvoiceApp.MAUI.Services;
+
+public class MessageBoxNotificationService : INotificationService
+{
+    public void ShowError(string message) =>
+        MainThread.BeginInvokeOnMainThread(() =>
+            Application.Current?.MainPage?.DisplayAlert("Hiba", message, "OK"));
+
+    public void ShowInfo(string message) =>
+        MainThread.BeginInvokeOnMainThread(() =>
+            Application.Current?.MainPage?.DisplayAlert("Információ", message, "OK"));
+
+    public bool Confirm(string message)
+    {
+        var tcs = new TaskCompletionSource<bool>();
+        MainThread.BeginInvokeOnMainThread(async () =>
+        {
+            var result = await Application.Current!.MainPage!
+                .DisplayAlert("Megerősítés", message, "Igen", "Nem");
+            tcs.SetResult(result);
+        });
+        return tcs.Task.GetAwaiter().GetResult();
+    }
+}

--- a/InvoiceApp.MAUI/Services/StageMenuKeyboardHandler.cs
+++ b/InvoiceApp.MAUI/Services/StageMenuKeyboardHandler.cs
@@ -1,0 +1,40 @@
+using System;
+using Microsoft.Maui.Input;
+using CommunityToolkit.Mvvm.Input;
+using InvoiceApp.Core.Enums;
+using InvoiceApp.MAUI.ViewModels;
+
+namespace InvoiceApp.MAUI.Services;
+
+public class StageMenuKeyboardHandler : IKeyboardHandler
+{
+    private readonly StageViewModel _stage;
+    private readonly StageMenuAction[] _actions = Enum.GetValues<StageMenuAction>();
+    private int _index;
+
+    public StageMenuKeyboardHandler(StageViewModel stage)
+    {
+        _stage = stage;
+    }
+
+    public bool HandleKey(KeyEventArgs e)
+    {
+        switch (e.Key)
+        {
+            case Key.Up:
+                _index = (_index - 1 + _actions.Length) % _actions.Length;
+                _stage.StatusBar.ActiveMenu = _actions[_index].ToString();
+                return true;
+            case Key.Down:
+                _index = (_index + 1) % _actions.Length;
+                _stage.StatusBar.ActiveMenu = _actions[_index].ToString();
+                return true;
+            case Key.Insert:
+            case Key.Enter or Key.Return:
+                var action = _actions[_index];
+                _stage.HandleMenuCommand.Execute(action);
+                return true;
+        }
+        return false;
+    }
+}

--- a/InvoiceApp.MAUI/ViewModels/AboutViewModel.cs
+++ b/InvoiceApp.MAUI/ViewModels/AboutViewModel.cs
@@ -1,0 +1,66 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using System.IO;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using InvoiceApp.Core.Services;
+
+namespace InvoiceApp.MAUI.ViewModels;
+
+public partial class AboutViewModel : ObservableObject
+{
+    private readonly IUserInfoService _service;
+    private readonly string _baseText;
+
+    [ObservableProperty]
+    private string aboutText = string.Empty;
+
+    public AboutViewModel(IUserInfoService service)
+    {
+        _service = service;
+
+        var assembly = Assembly.GetExecutingAssembly();
+        var resourceName = "InvoiceApp.MAUI.Resources.about_hu.md";
+        using var stream = assembly.GetManifestResourceStream(resourceName);
+
+        var text = "A Névjegy információ nem található.";
+        if (stream is not null)
+        {
+            using var reader = new StreamReader(stream);
+            text = StripFrontMatter(reader.ReadToEnd());
+        }
+
+        _baseText = text;
+    }
+
+    public async Task LoadAsync()
+    {
+        var info = await _service.LoadAsync();
+        var sb = new StringBuilder(_baseText);
+
+        if (!string.IsNullOrWhiteSpace(info.CompanyName))
+        {
+            sb.AppendLine();
+            sb.AppendLine();
+            sb.AppendLine($"**Cégnév:** {info.CompanyName}");
+            sb.AppendLine($"**Cím:** {info.Address}");
+            sb.AppendLine($"**Telefon:** {info.Phone}");
+            sb.AppendLine($"**E-mail:** {info.Email}");
+        }
+
+        AboutText = sb.ToString();
+    }
+
+    private static string StripFrontMatter(string text)
+    {
+        if (text.StartsWith("---"))
+        {
+            var end = text.IndexOf("---", 3);
+            if (end != -1)
+            {
+                return text[(end + 3)..].Trim();
+            }
+        }
+        return text.Trim();
+    }
+}

--- a/InvoiceApp.MAUI/ViewModels/ArchivePromptViewModel.cs
+++ b/InvoiceApp.MAUI/ViewModels/ArchivePromptViewModel.cs
@@ -1,0 +1,32 @@
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace InvoiceApp.MAUI.ViewModels;
+
+public partial class ArchivePromptViewModel : ObservableObject
+{
+    private readonly InvoiceEditorViewModel _parent;
+
+    public ArchivePromptViewModel(InvoiceEditorViewModel parent)
+    {
+        _parent = parent;
+    }
+
+    public string Message => "Ez a művelet véglegesíti a számlát. A továbbiakban nem módosítható. Biztosan folytatod? (Enter=Igen, Esc=Mégsem)";
+
+    [RelayCommand]
+    private async Task ConfirmAsync()
+    {
+        await _parent.ArchiveAsync();
+        _parent.ArchivePrompt = null;
+    }
+
+    [RelayCommand]
+    private void Cancel()
+    {
+        _parent.ArchivePrompt = null;
+    }
+}
+

--- a/InvoiceApp.MAUI/ViewModels/DeleteItemPromptViewModel.cs
+++ b/InvoiceApp.MAUI/ViewModels/DeleteItemPromptViewModel.cs
@@ -1,0 +1,32 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace InvoiceApp.MAUI.ViewModels;
+
+public partial class DeleteItemPromptViewModel : ObservableObject
+{
+    private readonly InvoiceEditorViewModel _parent;
+    private readonly InvoiceItemRowViewModel _row;
+
+    public DeleteItemPromptViewModel(InvoiceEditorViewModel parent, InvoiceItemRowViewModel row)
+    {
+        _parent = parent;
+        _row = row;
+    }
+
+    public string Message => "Biztosan törlöd ezt a tételt? (Enter=Igen, Esc=Nem)";
+
+    [RelayCommand]
+    private void Confirm()
+    {
+        _parent.DeleteItemConfirmed(_row);
+        _parent.DeletePrompt = null;
+    }
+
+    [RelayCommand]
+    private void Cancel()
+    {
+        _parent.DeletePrompt = null;
+    }
+}

--- a/InvoiceApp.MAUI/ViewModels/EditableItemViewModel.cs
+++ b/InvoiceApp.MAUI/ViewModels/EditableItemViewModel.cs
@@ -1,0 +1,38 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace InvoiceApp.MAUI.ViewModels;
+
+public partial class EditableItemViewModel : InvoiceItemRowViewModel
+{
+    public bool IsEditingExisting { get; internal set; }
+    public InvoiceItemRowViewModel? TargetRow { get; internal set; }
+
+    public EditableItemViewModel(InvoiceEditorViewModel parent) : base(parent)
+    {
+    }
+}
+
+public class NewLineItemViewModel : EditableItemViewModel
+{
+    public NewLineItemViewModel(InvoiceEditorViewModel parent) : base(parent)
+    {
+    }
+}
+
+public class ExistingLineItemEditViewModel : EditableItemViewModel
+{
+    public ExistingLineItemEditViewModel(InvoiceEditorViewModel parent, InvoiceItemRowViewModel target) : base(parent)
+    {
+        IsEditingExisting = true;
+        TargetRow = target;
+        Product = target.Product;
+        Quantity = target.Quantity;
+        UnitPrice = target.UnitPrice;
+        TaxRateId = target.TaxRateId;
+        UnitId = target.UnitId;
+        UnitName = target.UnitName;
+        TaxRateName = target.TaxRateName;
+        ProductGroup = target.ProductGroup;
+        Description = target.Description;
+    }
+}

--- a/InvoiceApp.MAUI/ViewModels/EditableMasterDataViewModel.cs
+++ b/InvoiceApp.MAUI/ViewModels/EditableMasterDataViewModel.cs
@@ -1,0 +1,54 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using System.Threading.Tasks;
+using InvoiceApp.Core.Enums;
+using InvoiceApp.MAUI.Services;
+
+namespace InvoiceApp.MAUI.ViewModels;
+
+public abstract partial class EditableMasterDataViewModel<T> : MasterDataBaseViewModel<T>, IEditableMasterDataViewModel
+{
+    [ObservableProperty]
+    private bool isEditing;
+
+    private readonly AppStateService _state;
+
+    public IRelayCommand EditSelectedCommand { get; }
+    public IRelayCommand DeleteSelectedCommand { get; }
+    public IRelayCommand CloseDetailsCommand { get; }
+
+    protected EditableMasterDataViewModel(AppStateService state)
+    {
+        _state = state;
+        EditSelectedCommand = new RelayCommand(OnEditSelected, CanModify);
+        DeleteSelectedCommand = new RelayCommand(async () => await OnDeleteSelected(), CanModify);
+        CloseDetailsCommand = new RelayCommand(() => IsEditing = false);
+    }
+
+    protected override void SelectedItemChanged(T? value)
+    {
+        base.SelectedItemChanged(value);
+        (EditSelectedCommand as RelayCommand)?.NotifyCanExecuteChanged();
+        (DeleteSelectedCommand as RelayCommand)?.NotifyCanExecuteChanged();
+    }
+
+    private void OnEditSelected() => IsEditing = !IsEditing;
+
+    private async Task OnDeleteSelected()
+    {
+        if (SelectedItem != null)
+        {
+            await DeleteAsync();
+            await LoadAsync();
+        }
+    }
+
+    protected virtual Task DeleteAsync() => Task.CompletedTask;
+
+    private bool CanModify() => SelectedItem != null;
+
+    partial void OnIsEditingChanged(bool value)
+        => _state.InteractionState = value
+            ? AppInteractionState.EditingMasterData
+            : AppInteractionState.BrowsingInvoices;
+}

--- a/InvoiceApp.MAUI/ViewModels/IEditableMasterDataViewModel.cs
+++ b/InvoiceApp.MAUI/ViewModels/IEditableMasterDataViewModel.cs
@@ -1,0 +1,10 @@
+using CommunityToolkit.Mvvm.Input;
+
+namespace InvoiceApp.MAUI.ViewModels;
+
+public interface IEditableMasterDataViewModel : IMasterDataViewModel
+{
+    IRelayCommand EditSelectedCommand { get; }
+    IRelayCommand DeleteSelectedCommand { get; }
+    IRelayCommand CloseDetailsCommand { get; }
+}

--- a/InvoiceApp.MAUI/ViewModels/IMasterDataViewModel.cs
+++ b/InvoiceApp.MAUI/ViewModels/IMasterDataViewModel.cs
@@ -1,0 +1,8 @@
+using System.Threading.Tasks;
+
+namespace InvoiceApp.MAUI.ViewModels;
+
+public interface IMasterDataViewModel
+{
+    Task LoadAsync();
+}

--- a/InvoiceApp.MAUI/ViewModels/InvoiceEditorViewModel.cs
+++ b/InvoiceApp.MAUI/ViewModels/InvoiceEditorViewModel.cs
@@ -1,0 +1,703 @@
+using System;
+using System.Collections.ObjectModel;
+using System.Collections.Generic;
+using CommunityToolkit.Mvvm.ComponentModel;
+using System.Linq;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.Input;
+using InvoiceApp.Core.Models;
+using InvoiceApp.Core.Utilities;
+using InvoiceApp.MAUI.Resources;
+using InvoiceApp.Core.Services;
+using InvoiceApp.Core.Enums;
+using Microsoft.Maui.Controls;
+using InvoiceApp.MAUI.Views.Controls;
+using InvoiceApp.MAUI.Views;
+using Controls = InvoiceApp.MAUI.Views.Controls;
+using InvoiceApp.MAUI.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Maui.Storage;
+
+namespace InvoiceApp.MAUI.ViewModels;
+
+public partial class InvoiceItemRowViewModel : ObservableObject
+{
+    private readonly InvoiceEditorViewModel _parent;
+
+    [ObservableProperty]
+    private int id;
+
+    public InvoiceItemRowViewModel(InvoiceEditorViewModel parent)
+    {
+        _parent = parent;
+    }
+
+    [ObservableProperty]
+    private string product = string.Empty;
+
+    partial void OnProductChanged(string value)
+    {
+        if (!_parent.IsLoading)
+            _ = _parent.CheckProductAsync(this, value);
+    }
+
+    [ObservableProperty]
+    private decimal quantity;
+
+    [ObservableProperty]
+    private decimal unitPrice;
+
+    [ObservableProperty]
+    private Guid taxRateId;
+
+    [ObservableProperty]
+    private string taxRateName = string.Empty;
+
+    partial void OnTaxRateIdChanged(Guid value)
+        => TaxRateName = _parent.TaxRates.FirstOrDefault(t => t.Id == value)?.Name ?? string.Empty;
+
+    [ObservableProperty]
+    private Guid unitId;
+
+    [ObservableProperty]
+    private string unitName = string.Empty;
+
+    partial void OnUnitIdChanged(Guid value)
+        => UnitName = _parent.Units.FirstOrDefault(u => u.Id == value)?.Name ?? string.Empty;
+
+    [ObservableProperty]
+    private string description = string.Empty;
+
+    [ObservableProperty]
+    private string productGroup = string.Empty;
+
+    [ObservableProperty]
+    private bool isEditable = true;
+
+    [ObservableProperty]
+    private bool hasError;
+
+    [ObservableProperty]
+    private string errorMessage = string.Empty;
+
+    [ObservableProperty]
+    private bool isFirstRow;
+
+    [ObservableProperty]
+    private bool isAutofilled;
+
+    internal void SetInitialValues(InvoiceItem item)
+    {
+        Id = item.Id;
+        Product = item.Product?.Name ?? string.Empty;
+        Quantity = item.Quantity;
+        UnitPrice = item.UnitPrice;
+        TaxRateId = item.TaxRateId;
+        UnitId = item.Product?.UnitId ?? Guid.Empty;
+        UnitName = item.Product?.Unit?.Name ?? string.Empty;
+        TaxRateName = item.TaxRate?.Name ?? string.Empty;
+        ProductGroup = item.Product?.ProductGroup?.Name ?? string.Empty;
+        Description = item.Description;
+        IsEditable = false;
+    }
+}
+
+public partial class InvoiceEditorViewModel : ObservableObject
+{
+    public ObservableCollection<InvoiceItemRowViewModel> Items { get; }
+
+    public InvoiceLookupViewModel Lookup { get; }
+
+    public ObservableCollection<PaymentMethod> PaymentMethods { get; } = new();
+    public ObservableCollection<TaxRate> TaxRates { get; } = new();
+    public ObservableCollection<Supplier> Suppliers { get; } = new();
+    public ObservableCollection<Product> Products { get; } = new();
+    public ObservableCollection<Unit> Units { get; } = new();
+    public ObservableCollection<ProductGroup> ProductGroups { get; } = new();
+
+    internal bool IsLoading { get; private set; }
+
+    private readonly INumberingService _numbering;
+
+    private static int StepPercent(int step, int total) => step * 100 / total;
+
+    private static void FillCollection<T>(ObservableCollection<T> target, List<T> items, string message, int step, int totalSteps, IProgress<ProgressReport>? progress)
+    {
+        progress?.Report(new ProgressReport { GlobalPercent = StepPercent(step, totalSteps), SubtaskPercent = 0, Message = message });
+        target.Clear();
+        for (int i = 0; i < items.Count; i++)
+        {
+            target.Add(items[i]);
+            progress?.Report(new ProgressReport
+            {
+                GlobalPercent = StepPercent(step, totalSteps),
+                SubtaskPercent = (i + 1) * 100 / items.Count,
+                Message = $"{message} {i + 1}/{items.Count}"
+            });
+        }
+    }
+
+    [ObservableProperty]
+    private string supplier = string.Empty;
+    partial void OnSupplierChanged(string value)
+    {
+        if (!IsLoading)
+            _ = UpdateSupplierIdAsync(value);
+    }
+
+    [ObservableProperty]
+    private int supplierId;
+
+    [ObservableProperty]
+    private DateTime? invoiceDate;
+
+    partial void OnInvoiceDateChanged(DateTime? value) => RecalculateDueDate();
+
+    [ObservableProperty]
+    private DateTime? dueDate;
+
+    [ObservableProperty]
+    private string number = string.Empty;
+
+    [ObservableProperty]
+    private bool isNew = true;
+
+    [ObservableProperty]
+    private Guid paymentMethodId;
+
+    partial void OnPaymentMethodIdChanged(Guid value) => RecalculateDueDate();
+
+    [ObservableProperty]
+    private bool isGross;
+
+    [ObservableProperty]
+    private bool isArchived;
+
+    public bool IsEditable => !IsArchived;
+
+    partial void OnIsArchivedChanged(bool value) => OnPropertyChanged(nameof(IsEditable));
+
+
+    private readonly IPaymentMethodService _paymentMethods;
+    private readonly ITaxRateService _taxRates;
+    private readonly ISupplierService _suppliers;
+    private readonly IProductService _productsService;
+    private readonly IUnitService _unitsService;
+    private readonly IProductGroupService _groupsService;
+    private readonly IInvoiceService _invoiceService;
+    private readonly IInvoiceExportService _exporter;
+private readonly ILogService _log;
+    private readonly INotificationService _notifications;
+    private readonly ISessionService _session;
+    private readonly AppStateService _state;
+    public TotalsViewModel Totals { get; } = new();
+    public InvoiceItemEditorViewModel ItemsEditor { get; }
+    private Invoice _draft = new();
+private readonly Dictionary<(int, int), LastUsageData> _usageCache = new();
+
+    [ObservableProperty]
+    private int invoiceId;
+
+    [ObservableProperty]
+    private object? inlineCreator;
+
+    [ObservableProperty]
+    private VisualElement? inlineCreatorTarget;
+
+    public bool IsInlineCreatorVisible => InlineCreator != null;
+
+    partial void OnInlineCreatorChanged(object? value)
+    {
+        OnPropertyChanged(nameof(IsInlineCreatorVisible));
+        if (value is null)
+        {
+            InlineCreatorTarget = null;
+            _state.InteractionState = AppInteractionState.EditingInvoice;
+        }
+        else
+        {
+            _state.InteractionState = AppInteractionState.InlineCreatorActive;
+        }
+    }
+
+    public bool IsSavePromptVisible => SavePrompt != null;
+    public bool IsArchivePromptVisible => ArchivePrompt != null;
+    public bool IsDeletePromptVisible => DeletePrompt != null;
+
+    [ObservableProperty]
+    private object? savePrompt;
+
+    [ObservableProperty]
+    private object? archivePrompt;
+
+    [ObservableProperty]
+    private object? deletePrompt;
+
+    [ObservableProperty]
+    private bool isInLineFinalizationPrompt;
+
+    [ObservableProperty]
+    private string lastFocusedField = string.Empty;
+
+    partial void OnSavePromptChanged(object? value)
+    {
+        OnPropertyChanged(nameof(IsSavePromptVisible));
+        _state.InteractionState = value == null
+            ? AppInteractionState.EditingInvoice
+            : AppInteractionState.InlinePromptActive;
+    }
+
+    partial void OnArchivePromptChanged(object? value)
+    {
+        OnPropertyChanged(nameof(IsArchivePromptVisible));
+        _state.InteractionState = value == null
+            ? AppInteractionState.EditingInvoice
+            : AppInteractionState.InlinePromptActive;
+    }
+
+    partial void OnDeletePromptChanged(object? value)
+    {
+        OnPropertyChanged(nameof(IsDeletePromptVisible));
+        _state.InteractionState = value == null
+            ? AppInteractionState.EditingInvoice
+            : AppInteractionState.InlinePromptActive;
+    }
+
+    public InvoiceEditorViewModel(
+        IPaymentMethodService paymentMethods,
+        ITaxRateService taxRates,
+        ISupplierService suppliers,
+        IProductService products,
+        IUnitService units,
+        IProductGroupService groups,
+        IInvoiceService invoiceService,
+        IInvoiceExportService exporter,
+        ILogService logService,
+        INotificationService notificationService,
+        ISessionService sessionService,
+        AppStateService state,
+        InvoiceLookupViewModel lookup,
+        INumberingService numbering)
+    {
+        _paymentMethods = paymentMethods;
+        _taxRates = taxRates;
+        _suppliers = suppliers;
+        _productsService = products;
+        _unitsService = units;
+        _groupsService = groups;
+        _invoiceService = invoiceService;
+        _exporter = exporter;
+        _log = logService;
+        _notifications = notificationService;
+        _session = sessionService;
+        _state = state;
+        Lookup = lookup;
+        _numbering = numbering;
+        Lookup.InvoiceSelected += async item =>
+        {
+            await LoadInvoice(item.Id, item.Number);
+        };
+        Lookup.InvoiceCreated += async number =>
+        {
+            await LoadInvoice(0, number);
+        };
+        Items = new ObservableCollection<InvoiceItemRowViewModel>();
+        ItemsEditor = new InvoiceItemEditorViewModel(this, _invoiceService, _log, _notifications);
+    }
+
+    public async Task LoadAsync(IProgress<ProgressReport>? progress = null)
+    {
+        const int total = 6;
+        var step = 0;
+
+        IsLoading = true;
+
+        var paymentTask = _paymentMethods.GetActiveAsync();
+        var supplierTask = _suppliers.GetActiveAsync();
+        var taxTask = _taxRates.GetActiveAsync(DateTime.UtcNow);
+        var productTask = _productsService.GetActiveAsync();
+        var unitTask = _unitsService.GetActiveAsync();
+        var groupTask = _groupsService.GetActiveAsync();
+
+        await Task.WhenAll(paymentTask, supplierTask, taxTask, productTask, unitTask, groupTask);
+
+        FillCollection(PaymentMethods, paymentTask.Result, Resources.Strings.Load_PaymentMethods, step++, total, progress);
+        FillCollection(Suppliers, supplierTask.Result, Resources.Strings.Load_Suppliers, step++, total, progress);
+        FillCollection(TaxRates, taxTask.Result, Resources.Strings.Load_TaxRates, step++, total, progress);
+        FillCollection(Products, productTask.Result, Resources.Strings.Load_Products, step++, total, progress);
+        FillCollection(Units, unitTask.Result, Resources.Strings.Load_Units, step++, total, progress);
+        FillCollection(ProductGroups, groupTask.Result, Resources.Strings.Load_ProductGroups, step++, total, progress);
+
+        progress?.Report(new ProgressReport { GlobalPercent = 100, SubtaskPercent = 100, Message = Resources.Strings.Load_Complete });
+        IsLoading = false;
+    }
+
+    public async Task CheckProductAsync(InvoiceItemRowViewModel row, string name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            return;
+
+        var exists = Products.FirstOrDefault(p => p.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
+        if (exists is null)
+        {
+            InlineCreator = new ProductCreatorViewModel(this, row, _productsService)
+            {
+                Name = name
+            };
+        }
+        else
+        {
+            row.Product = exists.Name;
+            row.UnitId = exists.UnitId;
+            row.UnitName = Units.FirstOrDefault(u => u.Id == exists.UnitId)?.Name ?? string.Empty;
+            row.ProductGroup = exists.ProductGroup?.Name ?? string.Empty;
+            row.TaxRateId = exists.TaxRateId;
+            row.TaxRateName = TaxRates.FirstOrDefault(t => t.Id == exists.TaxRateId)?.Name ?? string.Empty;
+
+            if (SupplierId > 0)
+            {
+                var usage = await GetUsageDataAsync(SupplierId, exists.Id);
+                if (usage != null)
+                {
+                    row.Quantity = usage.Quantity;
+                    row.UnitPrice = usage.UnitPrice;
+                    row.TaxRateId = usage.TaxRateId;
+                    row.IsAutofilled = true;
+                }
+                else
+                {
+                    row.IsAutofilled = false;
+                }
+            }
+        }
+    }
+private async Task UpdateSupplierIdAsync(string name)
+{
+    var match = Suppliers.FirstOrDefault(s => s.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
+    if (match != null)
+    {
+        SupplierId = match.Id;
+        if (IsNew)
+            Number = await _numbering.GetNextInvoiceNumberAsync(SupplierId);
+    }
+}
+
+    private async Task<LastUsageData?> GetUsageDataAsync(int supplierId, int productId)
+    {
+        if (_usageCache.TryGetValue((supplierId, productId), out var cached))
+            return cached;
+
+        var data = await _invoiceService.GetLastUsageDataAsync(supplierId, productId);
+        if (data != null)
+            _usageCache[(supplierId, productId)] = data;
+        return data;
+    }
+    [RelayCommand]
+    private void ShowSupplierCreator(object? parameter)
+    {
+        if (parameter is VisualElement target)
+        {
+            InlineCreatorTarget = target;
+            var text = (target as Views.Controls.LookupBox)?.Text ?? string.Empty;
+            InlineCreator = new SupplierCreatorViewModel(this, _suppliers)
+            {
+                Name = text
+            };
+        }
+    }
+    [RelayCommand]
+    private void ShowProductCreator(object? parameter)
+    {
+        if (parameter is VisualElement target && target.BindingContext is InvoiceItemRowViewModel row)
+        {
+            InlineCreatorTarget = target;
+            var name = (target as Views.Controls.LookupBox)?.Text ?? row.Product;
+            InlineCreator = new ProductCreatorViewModel(this, row, _productsService)
+            {
+                Name = name
+            };
+        }
+    }
+
+    [RelayCommand]
+    private void ShowTaxRateCreator(object? parameter)
+    {
+        if (parameter is VisualElement target)
+        {
+            InlineCreatorTarget = target;
+            var name = (target as Controls.LookupBox)?.Text ?? string.Empty;
+            InlineCreator = new TaxRateCreatorViewModel(this, _taxRates)
+            {
+                Name = name
+            };
+        }
+    }
+
+    [RelayCommand]
+    private void ShowUnitCreator(object? parameter)
+    {
+        if (parameter is VisualElement target)
+        {
+            InlineCreatorTarget = target;
+            InlineCreator = new UnitCreatorViewModel(this, _unitsService);
+        }
+    }
+
+    [RelayCommand]
+    private void ShowPaymentMethodCreator(object? parameter)
+    {
+        if (parameter is VisualElement target)
+        {
+            InlineCreatorTarget = target;
+            InlineCreator = new PaymentMethodCreatorViewModel(this, _paymentMethods);
+        }
+    }
+
+    [RelayCommand]
+    internal async Task OpenSelectedInvoiceAsync()
+    {
+        if (Lookup.SelectedInvoice != null)
+            await LoadInvoice(Lookup.SelectedInvoice.Id, Lookup.SelectedInvoice.Number);
+    }
+
+    public async Task LoadInvoice(int id, string? number = null)
+    {
+        IsLoading = true;
+        if (id == 0)
+        {
+            _draft = new Invoice();
+            InvoiceId = 0;
+            IsNew = true;
+            SupplierId = 0;
+            Supplier = string.Empty;
+            InvoiceDate = DateTime.Today;
+            DueDate = null;
+            Number = number ?? string.Empty;
+            PaymentMethodId = Guid.Empty;
+            IsGross = false;
+            IsArchived = false;
+            Items.Clear();
+            ItemsEditor.EditableItem = new NewLineItemViewModel(this) { IsFirstRow = true };
+            Items.Add(ItemsEditor.EditableItem);
+            Totals.Recalculate(Items.Skip(1), TaxRates, IsGross);
+            await Task.Yield();
+            IsLoading = false;
+            await _session.SaveLastInvoiceIdAsync(null);
+            _state.CurrentInvoiceId = null;
+            await _state.SaveAsync();
+            _state.InteractionState = AppInteractionState.EditingInvoice;
+            return;
+        }
+
+        var invoice = await _invoiceService.GetAsync(id);
+        if (invoice == null)
+            return;
+
+        InvoiceId = invoice.Id;
+
+        IsNew = false;
+
+        SupplierId = invoice.SupplierId;
+        Supplier = invoice.Supplier?.Name ?? string.Empty;
+        InvoiceDate = invoice.Date.ToDateTime(TimeOnly.MinValue);
+        Number = invoice.Number;
+        PaymentMethodId = invoice.PaymentMethodId;
+        DueDate = invoice.DueDate.ToDateTime(TimeOnly.MinValue);
+        IsGross = invoice.IsGross;
+        IsArchived = invoice.IsArchived;
+
+        Items.Clear();
+        ItemsEditor.EditableItem = new NewLineItemViewModel(this) { IsFirstRow = true };
+        Items.Add(ItemsEditor.EditableItem);
+        foreach (var item in invoice.Items)
+        {
+            var row = new InvoiceItemRowViewModel(this);
+            row.SetInitialValues(item);
+            Items.Add(row);
+        }
+        Totals.Recalculate(Items.Skip(1), TaxRates, IsGross);
+        await Task.Yield();
+        IsLoading = false;
+        await _session.SaveLastInvoiceIdAsync(InvoiceId);
+        _state.CurrentInvoiceId = InvoiceId;
+        await _state.SaveAsync();
+        _state.InteractionState = AppInteractionState.EditingInvoice;
+    }
+
+    [RelayCommand]
+    private async Task SavePdfAsync()
+    {
+        var result = await FilePicker.Default.PickAsync(new PickOptions
+        {
+            PickerTitle = "PDF"
+        });
+        if (result != null)
+        {
+            var invoice = await _invoiceService.GetAsync(InvoiceId);
+            if (invoice != null)
+                await _exporter.SavePdfAsync(invoice, result.FullPath);
+        }
+    }
+
+    [RelayCommand]
+    private async Task PrintAsync()
+    {
+        var invoice = await _invoiceService.GetAsync(InvoiceId);
+        if (invoice != null)
+            await _exporter.PrintAsync(invoice);
+    }
+
+    [RelayCommand]
+    private void Close()
+    {
+        if (IsInLineFinalizationPrompt || SavePrompt != null)
+            return;
+
+        IsInLineFinalizationPrompt = true;
+        SavePrompt = new SaveLinePromptViewModel(
+            this,
+            "Végeztél a szerkesztéssel? (Enter=Mentés, Esc=Mégsem)",
+            finalize: true);
+    }
+
+    public void EditLineFromSelection(InvoiceItemRowViewModel selected)
+        => ItemsEditor.EditLineFromSelection(selected);
+
+
+    private void ShowSavePrompt()
+    {
+        if (SavePrompt is null)
+            SavePrompt = new SaveLinePromptViewModel(this);
+    }
+
+    [RelayCommand]
+    private async Task SaveAsync()
+    {
+        if (SupplierId <= 0 || PaymentMethodId == Guid.Empty || InvoiceDate is null)
+            return;
+
+        var date = DateOnly.FromDateTime(InvoiceDate.Value);
+        var dueDate = DueDate != null
+            ? DateOnly.FromDateTime(DueDate.Value)
+            : date.AddDays(PaymentMethods.FirstOrDefault(m => m.Id == PaymentMethodId)?.DueInDays ?? 0);
+
+        try
+        {
+            if (IsNew)
+            {
+                _draft.Number = Number;
+                _draft.SupplierId = SupplierId;
+                _draft.PaymentMethodId = PaymentMethodId;
+                _draft.Date = date;
+                _draft.IsGross = IsGross;
+                _draft.DueDate = dueDate;
+                var ok = await _invoiceService.CreateAsync(_draft);
+                if (ok)
+                {
+                    var newId = _draft.Id;
+                    var draftItems = _draft.Items.ToList();
+                    for (int i = 0; i < draftItems.Count && i + 1 < Items.Count; i++)
+                        Items[i + 1].Id = draftItems[i].Id;
+                    InvoiceId = newId;
+                    IsNew = false;
+                    _draft = new Invoice();
+                    await Lookup.LoadAsync();
+                    Lookup.SelectedInvoice = Lookup.Invoices.FirstOrDefault(i => i.Id == newId);
+                }
+            }
+            else
+            {
+                await _invoiceService.UpdateInvoiceHeaderAsync(InvoiceId, Number, date, dueDate, SupplierId, PaymentMethodId, IsGross);
+                await Lookup.LoadAsync();
+                Lookup.SelectedInvoice = Lookup.Invoices.FirstOrDefault(i => i.Id == InvoiceId);
+            }
+        }
+        catch (Exception ex)
+        {
+            await _log.LogError("SaveAsync", ex);
+            _notifications.ShowError("A számla mentése nem sikerült: " + ex.Message);
+        }
+    }
+
+    [RelayCommand]
+    private void ShowArchivePrompt()
+    {
+        if (ArchivePrompt is null)
+            ArchivePrompt = new ArchivePromptViewModel(this);
+    }
+
+    internal void RequestDeleteItem(InvoiceItemRowViewModel row)
+    {
+        if (!IsEditable || Items.IndexOf(row) <= 0)
+            return;
+        if (DeletePrompt is null)
+            DeletePrompt = new DeleteItemPromptViewModel(this, row);
+    }
+
+    internal void DeleteItemConfirmed(InvoiceItemRowViewModel row)
+    {
+        var index = Items.IndexOf(row);
+        if (index <= 0)
+            return;
+        Items.RemoveAt(index);
+        if (IsNew && index - 1 >= 0 && index - 1 < _draft.Items.Count)
+        {
+            var domainItem = _draft.Items.ElementAt(index - 1);
+            _draft.Items.Remove(domainItem);
+        }
+        else if (!IsNew && row.Id > 0)
+        {
+            _ = _invoiceService.RemoveItemAsync(row.Id);
+        }
+        Totals.Recalculate(Items.Skip(1), TaxRates, IsGross);
+    }
+
+    [RelayCommand]
+    internal async Task FinalizeInvoiceAsync()
+    {
+        await SaveAsync();
+        IsInLineFinalizationPrompt = false;
+    }
+
+    [RelayCommand]
+    internal async Task ArchiveAsync()
+    {
+        if (IsArchived)
+            return;
+
+        await _invoiceService.ArchiveAsync(InvoiceId);
+        IsArchived = true;
+        await _session.SaveLastInvoiceIdAsync(null);
+        _state.CurrentInvoiceId = null;
+        await _state.SaveAsync();
+        await Lookup.LoadAsync();
+        Lookup.SelectedInvoice = null;
+    }
+
+    private async void LookupLoadSelected()
+    {
+        try
+        {
+            if (Lookup.SelectedInvoice != null)
+                await LoadInvoice(Lookup.SelectedInvoice.Id);
+        }
+        catch (Exception ex)
+        {
+            await _log.LogError("LookupLoadSelected", ex);
+        }
+    }
+
+    private void RecalculateDueDate()
+    {
+        if (InvoiceDate != null && PaymentMethodId != Guid.Empty)
+        {
+            var method = PaymentMethods.FirstOrDefault(m => m.Id == PaymentMethodId);
+            if (method != null)
+                DueDate = InvoiceDate.Value.AddDays(method.DueInDays);
+        }
+        else
+        {
+            DueDate = null;
+        }
+    }
+}

--- a/InvoiceApp.MAUI/ViewModels/InvoiceItemEditorViewModel.cs
+++ b/InvoiceApp.MAUI/ViewModels/InvoiceItemEditorViewModel.cs
@@ -1,0 +1,226 @@
+using System;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using InvoiceApp.Core.Models;
+using InvoiceApp.Core.Services;
+using InvoiceApp.MAUI.Resources;
+using InvoiceApp.MAUI.Services;
+
+namespace InvoiceApp.MAUI.ViewModels;
+
+public partial class InvoiceItemEditorViewModel : ObservableObject
+{
+    private readonly InvoiceEditorViewModel _owner;
+    private readonly IInvoiceService _invoiceService;
+    private readonly ILogService _log;
+    private readonly INotificationService _notifications;
+
+    public ObservableCollection<InvoiceItemRowViewModel> Items => _owner.Items;
+
+    [ObservableProperty]
+    private EditableItemViewModel editableItem;
+
+    public InvoiceItemEditorViewModel(
+        InvoiceEditorViewModel owner,
+        IInvoiceService invoiceService,
+        ILogService log,
+        INotificationService notifications)
+    {
+        _owner = owner;
+        _invoiceService = invoiceService;
+        _log = log;
+        _notifications = notifications;
+        editableItem = new NewLineItemViewModel(owner) { IsFirstRow = true };
+        Items.Add(editableItem);
+    }
+
+    partial void OnEditableItemChanged(EditableItemViewModel value)
+    {
+        if (Items.Count > 0)
+            Items[0] = value;
+    }
+
+    private bool ValidateLineItem(InvoiceItemRowViewModel line, out string error)
+    {
+        if (line.Quantity == 0)
+        {
+            error = Strings.InvoiceLine_InvalidQuantity;
+            return false;
+        }
+
+        if (line.UnitPrice < 0)
+        {
+            error = Strings.InvoiceLine_InvalidPrice;
+            return false;
+        }
+
+        if (line.TaxRateId == Guid.Empty)
+        {
+            error = Strings.InvoiceLine_TaxRequired;
+            return false;
+        }
+
+        error = string.Empty;
+        return true;
+    }
+
+    private void NotifyReadOnly()
+    {
+        if (Items.Count > 0)
+        {
+            var edit = EditableItem;
+            edit.HasError = true;
+            edit.ErrorMessage = Strings.InvoiceEditor_ReadOnly;
+        }
+    }
+
+    [RelayCommand]
+    internal async Task AddLineItemAsync()
+    {
+        if (!_owner.IsEditable)
+        {
+            NotifyReadOnly();
+            return;
+        }
+
+        var edit = EditableItem;
+        if (string.IsNullOrWhiteSpace(edit.Product)) return;
+
+        if (!ValidateLineItem(edit, out var error))
+        {
+            edit.HasError = true;
+            edit.ErrorMessage = error;
+            return;
+        }
+
+        edit.HasError = false;
+        edit.ErrorMessage = string.Empty;
+
+        var product = _owner.Products.FirstOrDefault(p => p.Name.Equals(edit.Product, StringComparison.OrdinalIgnoreCase));
+        if (product == null) return;
+
+        var item = new InvoiceItem
+        {
+            ProductId = product.Id,
+            TaxRateId = edit.TaxRateId != Guid.Empty ? edit.TaxRateId : product.TaxRateId,
+            Quantity = edit.Quantity,
+            UnitPrice = edit.UnitPrice,
+            Description = edit.Description
+        };
+
+        if (_owner.IsNew)
+        {
+            _owner.Draft.Items.Add(item);
+        }
+        else
+        {
+            try
+            {
+                item.InvoiceId = _owner.InvoiceId;
+                var newId = await _invoiceService.AddItemAsync(item);
+                item.Id = newId;
+            }
+            catch (Exception ex)
+            {
+                await _log.LogError("AddLineItemAsync", ex);
+                _notifications.ShowError("A sor mentése nem sikerült: " + ex.Message);
+                return;
+            }
+        }
+
+        var row = new InvoiceItemRowViewModel(_owner)
+        {
+            Id = item.Id,
+            Product = product.Name,
+            Quantity = edit.Quantity,
+            UnitPrice = edit.UnitPrice,
+            TaxRateId = item.TaxRateId,
+            UnitId = edit.UnitId,
+            UnitName = edit.UnitName,
+            TaxRateName = _owner.TaxRates.FirstOrDefault(t => t.Id == item.TaxRateId)?.Name ?? string.Empty,
+            ProductGroup = edit.ProductGroup,
+            Description = edit.Description,
+            IsEditable = false
+        };
+
+        Items.Insert(1, row);
+        _owner.Totals.Recalculate(Items.Skip(1), _owner.TaxRates, _owner.IsGross);
+        edit.Product = string.Empty;
+        edit.Quantity = 0;
+        edit.UnitPrice = 0;
+        edit.TaxRateId = Guid.Empty;
+        edit.UnitId = Guid.Empty;
+        edit.UnitName = string.Empty;
+        edit.TaxRateName = string.Empty;
+        edit.ProductGroup = string.Empty;
+        edit.Description = string.Empty;
+        edit.IsAutofilled = false;
+        edit.IsEditingExisting = false;
+        edit.TargetRow = null;
+    }
+
+    [RelayCommand]
+    internal void SaveEditedItem()
+    {
+        if (EditableItem is not ExistingLineItemEditViewModel edit || edit.TargetRow is null)
+            return;
+
+        if (!_owner.IsEditable)
+        {
+            NotifyReadOnly();
+            return;
+        }
+
+        if (!ValidateLineItem(edit, out var error))
+        {
+            edit.HasError = true;
+            edit.ErrorMessage = error;
+            return;
+        }
+
+        var target = edit.TargetRow;
+        target.Product = edit.Product;
+        target.Quantity = edit.Quantity;
+        target.UnitPrice = edit.UnitPrice;
+        target.TaxRateId = edit.TaxRateId;
+        target.UnitId = edit.UnitId;
+        target.UnitName = edit.UnitName;
+        target.TaxRateName = edit.TaxRateName;
+        target.ProductGroup = edit.ProductGroup;
+        target.Description = edit.Description;
+
+        edit.HasError = false;
+        edit.ErrorMessage = string.Empty;
+
+        _owner.Totals.Recalculate(Items.Skip(1), _owner.TaxRates, _owner.IsGross);
+
+        edit.Product = string.Empty;
+        edit.Quantity = 0;
+        edit.UnitPrice = 0;
+        edit.TaxRateId = Guid.Empty;
+        edit.UnitId = Guid.Empty;
+        edit.UnitName = string.Empty;
+        edit.TaxRateName = string.Empty;
+        edit.ProductGroup = string.Empty;
+        edit.Description = string.Empty;
+        edit.IsEditingExisting = false;
+        edit.TargetRow = null;
+    }
+
+    internal void EditLineFromSelection(InvoiceItemRowViewModel selected)
+    {
+        if (Items.IndexOf(selected) <= 0) return;
+        var edit = EditableItem;
+        edit.Product = selected.Product;
+        edit.Quantity = selected.Quantity;
+        edit.UnitPrice = selected.UnitPrice;
+        edit.TaxRateId = selected.TaxRateId;
+        edit.UnitId = selected.UnitId;
+        edit.UnitName = selected.UnitName;
+        edit.TaxRateName = selected.TaxRateName;
+        edit.ProductGroup = selected.ProductGroup;
+    }
+}

--- a/InvoiceApp.MAUI/ViewModels/InvoiceLookupViewModel.cs
+++ b/InvoiceApp.MAUI/ViewModels/InvoiceLookupViewModel.cs
@@ -1,0 +1,91 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using System.Collections.ObjectModel;
+using System;
+using System.Threading.Tasks;
+using System.Linq;
+using InvoiceApp.Core.Models;
+using InvoiceApp.Core.Services;
+
+namespace InvoiceApp.MAUI.ViewModels;
+
+public partial class InvoiceLookupItem : ObservableObject
+{
+    public int Id { get; set; }
+    public string Number { get; set; } = string.Empty;
+    public DateOnly Date { get; set; }
+    public string Supplier { get; set; } = string.Empty;
+    public int SupplierId { get; set; }
+}
+
+public partial class InvoiceLookupViewModel : ObservableObject
+{
+    private readonly IInvoiceService _invoices;
+    private readonly INumberingService _numbering;
+
+    public event Action<InvoiceLookupItem>? InvoiceSelected;
+    public event Action<string>? InvoiceCreated;
+
+    public ObservableCollection<InvoiceLookupItem> Invoices { get; } = new();
+
+    [ObservableProperty]
+    private InvoiceLookupItem? selectedInvoice;
+
+    partial void OnSelectedInvoiceChanged(InvoiceLookupItem? value)
+    {
+        if (value != null)
+            InvoiceSelected?.Invoke(value);
+    }
+
+    [RelayCommand]
+    private async Task CreateNewInvoiceAsync()
+    {
+        var supplierId = SelectedInvoice?.SupplierId ?? 0;
+        var number = await _numbering.GetNextInvoiceNumberAsync(supplierId);
+        await CreateInvoiceAsync(number);
+    }
+
+    public InvoiceLookupViewModel(IInvoiceService invoices, INumberingService numbering)
+    {
+        _invoices = invoices;
+        _numbering = numbering;
+    }
+
+    public async Task LoadAsync()
+    {
+        var items = await _invoices.GetRecentAsync(50);
+        Invoices.Clear();
+        foreach (var inv in items)
+        {
+                Invoices.Add(new InvoiceLookupItem
+                {
+                    Id = inv.Id,
+                    Number = inv.Number,
+                    Date = inv.Date,
+                    Supplier = inv.Supplier?.Name ?? string.Empty,
+                    SupplierId = inv.SupplierId
+                });
+        }
+
+        if (Invoices.Count > 0)
+            SelectedInvoice = Invoices[0];
+    }
+
+    public Task<int> CreateInvoiceAsync(string number)
+    {
+        var item = new InvoiceLookupItem
+        {
+            Id = 0,
+            Number = number,
+            Date = DateOnly.FromDateTime(DateTime.Today),
+            Supplier = string.Empty
+        };
+
+        Invoices.Insert(0, item);
+        SelectedInvoice = item;
+        InvoiceCreated?.Invoke(number);
+        return Task.FromResult(0);
+    }
+
+
+}

--- a/InvoiceApp.MAUI/ViewModels/MasterDataBaseViewModel.cs
+++ b/InvoiceApp.MAUI/ViewModels/MasterDataBaseViewModel.cs
@@ -1,0 +1,29 @@
+using System.Collections.ObjectModel;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace InvoiceApp.MAUI.ViewModels;
+
+public abstract partial class MasterDataBaseViewModel<T> : ObservableObject, IMasterDataViewModel
+{
+    public ObservableCollection<T> Items { get; } = new();
+
+    [ObservableProperty]
+    private T? selectedItem;
+
+    partial void OnSelectedItemChanged(T? value)
+        => SelectedItemChanged(value);
+
+    protected virtual void SelectedItemChanged(T? value) { }
+
+    public virtual async Task LoadAsync()
+    {
+        var items = await GetItemsAsync();
+        Items.Clear();
+        foreach (var item in items)
+            Items.Add(item);
+    }
+
+    protected abstract Task<List<T>> GetItemsAsync();
+}

--- a/InvoiceApp.MAUI/ViewModels/PaymentMethodCreatorViewModel.cs
+++ b/InvoiceApp.MAUI/ViewModels/PaymentMethodCreatorViewModel.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using InvoiceApp.Core.Models;
+using InvoiceApp.Core.Services;
+
+namespace InvoiceApp.MAUI.ViewModels;
+
+public partial class PaymentMethodCreatorViewModel : ObservableObject
+{
+    private readonly InvoiceEditorViewModel _parent;
+    private readonly IPaymentMethodService _methods;
+
+    [ObservableProperty]
+    private string name = string.Empty;
+
+    [ObservableProperty]
+    private int dueInDays;
+
+    public PaymentMethodCreatorViewModel(InvoiceEditorViewModel parent, IPaymentMethodService methods)
+    {
+        _parent = parent;
+        _methods = methods;
+    }
+
+    [RelayCommand]
+    private async Task ConfirmAsync()
+    {
+        var method = new PaymentMethod { Name = Name, DueInDays = DueInDays };
+        var id = await _methods.AddAsync(method);
+        method.Id = id;
+        _parent.PaymentMethods.Add(method);
+        _parent.PaymentMethodId = method.Id;
+        _parent.InlineCreator = null;
+    }
+
+    [RelayCommand]
+    private void Cancel() => _parent.InlineCreator = null;
+}

--- a/InvoiceApp.MAUI/ViewModels/PaymentMethodMasterViewModel.cs
+++ b/InvoiceApp.MAUI/ViewModels/PaymentMethodMasterViewModel.cs
@@ -1,0 +1,32 @@
+using InvoiceApp.Core.Models;
+using InvoiceApp.Core.Services;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Threading.Tasks;
+using InvoiceApp.MAUI.Services;
+
+namespace InvoiceApp.MAUI.ViewModels;
+
+public partial class PaymentMethodMasterViewModel : EditableMasterDataViewModel<PaymentMethod>
+{
+    public ObservableCollection<PaymentMethod> PaymentMethods => Items;
+    private readonly IPaymentMethodService _service;
+
+    public PaymentMethodMasterViewModel(IPaymentMethodService service, AppStateService state)
+        : base(state)
+    {
+        _service = service;
+    }
+
+    protected override Task<List<PaymentMethod>> GetItemsAsync()
+        => _service.GetActiveAsync();
+
+    protected override async Task DeleteAsync()
+    {
+        if (SelectedItem != null)
+        {
+            SelectedItem.IsArchived = true;
+            await _service.UpdateAsync(SelectedItem);
+        }
+    }
+}

--- a/InvoiceApp.MAUI/ViewModels/PlaceholderViewModel.cs
+++ b/InvoiceApp.MAUI/ViewModels/PlaceholderViewModel.cs
@@ -1,0 +1,9 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace InvoiceApp.MAUI.ViewModels;
+
+public partial class PlaceholderViewModel : ObservableObject
+{
+    [ObservableProperty]
+    private string message = "Funkció fejlesztés alatt";
+}

--- a/InvoiceApp.MAUI/ViewModels/ProductCreatorViewModel.cs
+++ b/InvoiceApp.MAUI/ViewModels/ProductCreatorViewModel.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using InvoiceApp.Core.Models;
+using InvoiceApp.Core.Services;
+using System.Collections.ObjectModel;
+using System.Linq;
+
+namespace InvoiceApp.MAUI.ViewModels;
+
+public partial class ProductCreatorViewModel : ObservableObject
+{
+    private readonly InvoiceEditorViewModel _parent;
+    private readonly InvoiceItemRowViewModel _row;
+    private readonly IProductService _products;
+
+    [ObservableProperty]
+    private bool isInlineOpen = true;
+
+    public ObservableCollection<Unit> Units => _parent.Units;
+    public ObservableCollection<TaxRate> TaxRates => _parent.TaxRates;
+    public ObservableCollection<ProductGroup> ProductGroups => _parent.ProductGroups;
+
+    [ObservableProperty]
+    private string name = string.Empty;
+
+    [ObservableProperty]
+    private decimal net;
+
+    [ObservableProperty]
+    private decimal gross;
+
+    [ObservableProperty]
+    private Guid unitId;
+
+    [ObservableProperty]
+    private Guid taxRateId;
+
+    [ObservableProperty]
+    private Guid productGroupId;
+
+    public ProductCreatorViewModel(InvoiceEditorViewModel parent, InvoiceItemRowViewModel row, IProductService products)
+    {
+        _parent = parent;
+        _row = row;
+        _products = products;
+        name = row.Product;
+    }
+
+    [RelayCommand]
+    private async Task ConfirmAsync()
+    {
+        var product = new Product
+        {
+            Name = Name,
+            Net = Net,
+            Gross = Gross,
+            UnitId = UnitId,
+            TaxRateId = TaxRateId,
+            ProductGroupId = ProductGroupId
+        };
+
+        var id = await _products.AddAsync(product);
+        product.Id = id;
+        _parent.Products.Add(product);
+        _row.Product = product.Name;
+        _row.UnitId = product.UnitId;
+        _row.UnitName = _parent.Units.FirstOrDefault(u => u.Id == UnitId)?.Name ?? string.Empty;
+        _row.TaxRateId = product.TaxRateId;
+        _row.TaxRateName = _parent.TaxRates.FirstOrDefault(t => t.Id == TaxRateId)?.Name ?? string.Empty;
+        _row.ProductGroup = _parent.ProductGroups.FirstOrDefault(g => g.Id == ProductGroupId)?.Name ?? string.Empty;
+        _parent.InlineCreator = null;
+        if (_parent.IsEditable)
+            await _parent.AddLineItemCommand.ExecuteAsync(null);
+    }
+
+    [RelayCommand]
+    private void Cancel()
+        => CloseEditor();
+
+    [RelayCommand]
+    private void CloseEditor()
+    {
+        IsInlineOpen = false;
+        _parent.InlineCreator = null;
+    }
+}

--- a/InvoiceApp.MAUI/ViewModels/ProductEditorViewModel.cs
+++ b/InvoiceApp.MAUI/ViewModels/ProductEditorViewModel.cs
@@ -1,0 +1,25 @@
+using System;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+
+namespace InvoiceApp.MAUI.ViewModels;
+
+public partial class ProductEditorViewModel : ObservableObject
+{
+    [ObservableProperty] private string name = string.Empty;
+    [ObservableProperty] private decimal net;
+    [ObservableProperty] private decimal gross;
+    [ObservableProperty] private Guid taxRateId;
+
+    public IRelayCommand OkCommand { get; }
+    public IRelayCommand CancelCommand { get; }
+
+    public ProductEditorViewModel()
+    {
+        OkCommand = new RelayCommand(() => OnOk?.Invoke(this));
+        CancelCommand = new RelayCommand(() => OnCancel?.Invoke());
+    }
+
+    public Action<ProductEditorViewModel>? OnOk;
+    public Action? OnCancel;
+}

--- a/InvoiceApp.MAUI/ViewModels/ProductGroupMasterViewModel.cs
+++ b/InvoiceApp.MAUI/ViewModels/ProductGroupMasterViewModel.cs
@@ -1,0 +1,33 @@
+using InvoiceApp.Core.Models;
+using InvoiceApp.Core.Services;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Threading.Tasks;
+using InvoiceApp.MAUI.Services;
+
+namespace InvoiceApp.MAUI.ViewModels;
+
+public partial class ProductGroupMasterViewModel : EditableMasterDataViewModel<ProductGroup>
+{
+    public ObservableCollection<ProductGroup> ProductGroups => Items;
+
+    private readonly IProductGroupService _service;
+
+public ProductGroupMasterViewModel(IProductGroupService service, AppStateService state)
+    : base(state)
+{
+    _service = service;
+}
+
+    protected override Task<List<ProductGroup>> GetItemsAsync()
+        => _service.GetActiveAsync();
+
+    protected override async Task DeleteAsync()
+    {
+        if (SelectedItem != null)
+        {
+            SelectedItem.IsArchived = true;
+            await _service.UpdateAsync(SelectedItem);
+        }
+    }
+}

--- a/InvoiceApp.MAUI/ViewModels/ProductMasterViewModel.cs
+++ b/InvoiceApp.MAUI/ViewModels/ProductMasterViewModel.cs
@@ -1,0 +1,88 @@
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using InvoiceApp.Core.Models;
+using InvoiceApp.Core.Services;
+using InvoiceApp.MAUI.Services;
+using System.Threading.Tasks;
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.DependencyInjection;
+using InvoiceApp.MAUI;
+
+namespace InvoiceApp.MAUI.ViewModels;
+
+public partial class ProductMasterViewModel : EditableMasterDataViewModel<Product>
+{
+    public ObservableCollection<Product> Products => Items;
+    public ObservableCollection<TaxRate> TaxRates { get; } = new();
+
+    private readonly IProductService _service;
+    private readonly ITaxRateService _taxRates;
+
+    public new IRelayCommand EditSelectedCommand { get; }
+
+public ProductMasterViewModel(IProductService service, ITaxRateService taxRates, AppStateService state)
+    : base(state)
+{
+    _service = service;
+    _taxRates = taxRates;
+    EditSelectedCommand = new RelayCommand(EditSelected, () => SelectedItem != null);
+}
+
+    protected override Task<List<Product>> GetItemsAsync()
+        => _service.GetActiveAsync();
+
+    protected override async Task DeleteAsync()
+    {
+        if (SelectedItem != null)
+        {
+            SelectedItem.IsArchived = true;
+            await _service.UpdateAsync(SelectedItem);
+        }
+    }
+
+    public override async Task LoadAsync()
+    {
+        await base.LoadAsync();
+        var rates = await _taxRates.GetActiveAsync(DateTime.UtcNow);
+        TaxRates.Clear();
+        foreach (var r in rates)
+            TaxRates.Add(r);
+    }
+
+    private async void EditSelected()
+    {
+        try
+        {
+            if (SelectedItem is null)
+                return;
+
+            var vm = new ProductEditorViewModel
+            {
+                Name = SelectedItem.Name,
+                Net = SelectedItem.Net,
+                Gross = SelectedItem.Gross,
+                TaxRateId = SelectedItem.TaxRateId
+            };
+
+            vm.OnOk = async m =>
+            {
+                SelectedItem.Name = m.Name;
+                SelectedItem.Net = m.Net;
+                SelectedItem.Gross = m.Gross;
+                SelectedItem.TaxRateId = m.TaxRateId;
+                await _service.UpdateAsync(SelectedItem);
+                await LoadAsync();
+            };
+
+            DialogService.EditEntity<Views.EditDialogs.ProductEditorView, ProductEditorViewModel>(
+                vm, vm.OkCommand, vm.CancelCommand);
+        }
+        catch (Exception ex)
+        {
+            var log = App.Provider.GetRequiredService<ILogService>();
+            await log.LogError("ProductMasterViewModel.EditSelected", ex);
+        }
+    }
+}

--- a/InvoiceApp.MAUI/ViewModels/ProgressViewModel.cs
+++ b/InvoiceApp.MAUI/ViewModels/ProgressViewModel.cs
@@ -1,0 +1,19 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using System.Windows.Input;
+
+namespace InvoiceApp.MAUI.ViewModels;
+
+public partial class ProgressViewModel : ObservableObject
+{
+    [ObservableProperty]
+    private int globalProgress;
+
+    [ObservableProperty]
+    private int subProgress;
+
+    [ObservableProperty]
+    private string statusMessage = string.Empty;
+
+    public ICommand? CancelCommand { get; set; }
+}

--- a/InvoiceApp.MAUI/ViewModels/SaveLinePromptViewModel.cs
+++ b/InvoiceApp.MAUI/ViewModels/SaveLinePromptViewModel.cs
@@ -1,0 +1,43 @@
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using InvoiceApp.MAUI.Views;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace InvoiceApp.MAUI.ViewModels;
+
+public partial class SaveLinePromptViewModel : ObservableObject
+{
+    private readonly InvoiceEditorViewModel _parent;
+    private readonly bool _finalize;
+
+    public SaveLinePromptViewModel(InvoiceEditorViewModel parent,
+        string message = "Mentsem ezt a sort? (Enter=Igen, Esc=Nem)",
+        bool finalize = false)
+    {
+        _parent = parent;
+        Message = message;
+        _finalize = finalize;
+    }
+
+    public string Message { get; }
+
+    [RelayCommand]
+    private async Task ConfirmAsync()
+    {
+        if (_finalize)
+            await _parent.FinalizeInvoiceCommand.ExecuteAsync(null);
+        else
+            await _parent.AddLineItemAsync();
+        _parent.SavePrompt = null;
+        _parent.IsInLineFinalizationPrompt = false;
+    }
+
+    [RelayCommand]
+    private void Cancel()
+    {
+        _parent.SavePrompt = null;
+        _parent.IsInLineFinalizationPrompt = false;
+    }
+}
+

--- a/InvoiceApp.MAUI/ViewModels/ScreenModeViewModel.cs
+++ b/InvoiceApp.MAUI/ViewModels/ScreenModeViewModel.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.ObjectModel;
+using Microsoft.Maui.Controls;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using InvoiceApp.Core;
+using InvoiceApp.MAUI.Services;
+
+namespace InvoiceApp.MAUI.ViewModels;
+
+public partial class ScreenModeViewModel : ObservableObject
+{
+    private readonly ScreenModeManager _manager;
+
+    public ObservableCollection<ScreenMode> Modes { get; } = new(Enum.GetValues<ScreenMode>());
+
+    [ObservableProperty]
+    private ScreenMode selectedMode;
+
+    public ScreenModeViewModel(ScreenModeManager manager)
+    {
+        _manager = manager;
+        SelectedMode = manager.CurrentMode;
+    }
+
+    [RelayCommand]
+    private Task Apply(Window window)
+        => _manager.ChangeModeAsync(window, SelectedMode);
+}

--- a/InvoiceApp.MAUI/ViewModels/SeedOptionsViewModel.cs
+++ b/InvoiceApp.MAUI/ViewModels/SeedOptionsViewModel.cs
@@ -1,0 +1,35 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.ApplicationModel;
+
+namespace InvoiceApp.MAUI.ViewModels;
+
+public partial class SeedOptionsViewModel : ObservableObject
+{
+    [ObservableProperty]
+    private int supplierCount = 20;
+
+    [ObservableProperty]
+    private int productCount = 500;
+
+    [ObservableProperty]
+    private int invoiceCount = 100;
+
+    [ObservableProperty]
+    private int minItemsPerInvoice = 5;
+
+    [ObservableProperty]
+    private int maxItemsPerInvoice = 60;
+
+    public IRelayCommand OkCommand { get; }
+    public IRelayCommand CancelCommand { get; }
+
+    public event Action<bool>? DialogResult;
+
+    public SeedOptionsViewModel()
+    {
+        OkCommand = new RelayCommand(() => DialogResult?.Invoke(true));
+        CancelCommand = new RelayCommand(() => DialogResult?.Invoke(false));
+    }
+}

--- a/InvoiceApp.MAUI/ViewModels/SetupViewModel.cs
+++ b/InvoiceApp.MAUI/ViewModels/SetupViewModel.cs
@@ -1,0 +1,53 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Storage;
+using System.IO;
+
+namespace InvoiceApp.MAUI.ViewModels;
+
+public partial class SetupViewModel : ObservableObject
+{
+    [ObservableProperty]
+    private string databasePath;
+
+    [ObservableProperty]
+    private string configPath;
+
+    public IRelayCommand OkCommand { get; }
+    public IRelayCommand CancelCommand { get; }
+
+    public event Action<bool>? DialogResult;
+    public IRelayCommand BrowseDbCommand { get; }
+    public IRelayCommand BrowseConfigCommand { get; }
+
+    public SetupViewModel(string dbPath, string cfgPath)
+    {
+        databasePath = dbPath;
+        configPath = cfgPath;
+        OkCommand = new RelayCommand(() => DialogResult?.Invoke(true));
+        CancelCommand = new RelayCommand(() => DialogResult?.Invoke(false));
+        BrowseDbCommand = new RelayCommand(OnBrowseDb);
+        BrowseConfigCommand = new RelayCommand(OnBrowseConfig);
+    }
+
+    private async void OnBrowseDb()
+    {
+        var result = await FilePicker.Default.PickAsync(new PickOptions
+        {
+            PickerTitle = "SQLite DB"
+        });
+        if (result != null)
+            DatabasePath = result.FullPath;
+    }
+
+    private async void OnBrowseConfig()
+    {
+        var result = await FilePicker.Default.PickAsync(new PickOptions
+        {
+            PickerTitle = "Config JSON"
+        });
+        if (result != null)
+            ConfigPath = result.FullPath;
+    }
+}

--- a/InvoiceApp.MAUI/ViewModels/StageViewModel.cs
+++ b/InvoiceApp.MAUI/ViewModels/StageViewModel.cs
@@ -1,0 +1,145 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Microsoft.Extensions.DependencyInjection;
+using System.Threading.Tasks;
+
+using InvoiceApp.Core.Enums;
+using System.IO;
+using InvoiceApp.Core.Entities;
+using InvoiceApp.Core.Services;
+using InvoiceApp.MAUI.Resources;
+using InvoiceApp.MAUI.Views;
+using InvoiceApp.MAUI.Services;
+
+namespace InvoiceApp.MAUI.ViewModels;
+
+public enum StageMenuAction
+{
+    InboundDeliveryNotes,
+    UpdateInboundInvoices,
+    EditProducts,
+    EditProductGroups,
+    EditSuppliers,
+    EditVatKeys,
+    EditPaymentMethods,
+    EditUnits,
+    ListProducts,
+    ListSuppliers,
+    ListInvoices,
+    InventoryCard,
+    CheckFiles,
+    AfterPowerOutage,
+    BackupData,
+    RestoreData,
+    ScreenSettings,
+    PrinterSettings,
+    EditUserInfo,
+    UserInfo,
+    ExitApplication
+}
+
+public partial class StageViewModel : ObservableObject
+{
+    [ObservableProperty]
+    private object? currentViewModel;
+
+    private readonly InvoiceEditorViewModel _invoiceEditor;
+    private readonly ProductMasterViewModel _productMaster;
+    private readonly ProductGroupMasterViewModel _productGroupMaster;
+    private readonly SupplierMasterViewModel _supplierMaster;
+    private readonly TaxRateMasterViewModel _taxRateMaster;
+    private readonly PaymentMethodMasterViewModel _paymentMethodMaster;
+    private readonly UnitMasterViewModel _unitMaster;
+    private readonly UserInfoViewModel _userInfo;
+    private readonly AboutViewModel _about;
+    private readonly PlaceholderViewModel _placeholder;
+    private readonly StatusBarViewModel _statusBar;
+    private readonly IDbHealthService _dbHealth;
+    private readonly ISessionService _session;
+    private readonly AppStateService _state;
+    private readonly StageMenuHandler _menuHandler;
+
+    public StatusBarViewModel StatusBar => _statusBar;
+    public UserInfoViewModel UserInfo => _userInfo;
+
+    public StageViewModel(
+        InvoiceEditorViewModel invoiceEditor,
+        ProductMasterViewModel productMaster,
+        ProductGroupMasterViewModel productGroupMaster,
+        SupplierMasterViewModel supplierMaster,
+        TaxRateMasterViewModel taxRateMaster,
+        PaymentMethodMasterViewModel paymentMethodMaster,
+        UnitMasterViewModel unitMaster,
+        UserInfoViewModel userInfo,
+        AboutViewModel about,
+        PlaceholderViewModel placeholder,
+        StatusBarViewModel statusBar,
+        IDbHealthService dbHealth,
+        ISessionService session,
+        AppStateService state,
+        StageMenuHandler menuHandler)
+    {
+        _invoiceEditor = invoiceEditor;
+        _productMaster = productMaster;
+        _productGroupMaster = productGroupMaster;
+        _supplierMaster = supplierMaster;
+        _taxRateMaster = taxRateMaster;
+        _paymentMethodMaster = paymentMethodMaster;
+        _unitMaster = unitMaster;
+        _userInfo = userInfo;
+        _about = about;
+        _placeholder = placeholder;
+        _statusBar = statusBar;
+        _dbHealth = dbHealth;
+        _session = session;
+        _state = state;
+        _menuHandler = menuHandler;
+        ApplySavedState();
+        _state.InteractionState = AppInteractionState.MainMenu;
+    }
+
+    private void ApplySavedState()
+    {
+        _statusBar.ActiveMenu = "Főmenü";
+        StageMenuAction view = _state.LastView;
+        switch (view)
+        {
+            case StageMenuAction.EditProducts:
+            case StageMenuAction.ListProducts:
+                CurrentViewModel = _productMaster;
+                _state.InteractionState = AppInteractionState.EditingMasterData;
+                break;
+            case StageMenuAction.EditSuppliers:
+            case StageMenuAction.ListSuppliers:
+                CurrentViewModel = _supplierMaster;
+                _state.InteractionState = AppInteractionState.EditingMasterData;
+                break;
+            case StageMenuAction.EditProductGroups:
+                CurrentViewModel = _productGroupMaster;
+                _state.InteractionState = AppInteractionState.EditingMasterData;
+                break;
+            case StageMenuAction.EditVatKeys:
+                CurrentViewModel = _taxRateMaster;
+                _state.InteractionState = AppInteractionState.EditingMasterData;
+                break;
+            case StageMenuAction.EditPaymentMethods:
+                CurrentViewModel = _paymentMethodMaster;
+                _state.InteractionState = AppInteractionState.EditingMasterData;
+                break;
+            case StageMenuAction.EditUnits:
+                CurrentViewModel = _unitMaster;
+                _state.InteractionState = AppInteractionState.EditingMasterData;
+                break;
+            default:
+                CurrentViewModel = _invoiceEditor;
+                if (_state.CurrentInvoiceId.HasValue)
+                    _ = _invoiceEditor.LoadInvoice(_state.CurrentInvoiceId.Value);
+                _state.InteractionState = AppInteractionState.EditingInvoice;
+                break;
+        }
+    }
+
+[RelayCommand]
+private Task HandleMenu(StageMenuAction action)
+    => _menuHandler.HandleAsync(this, action);
+}

--- a/InvoiceApp.MAUI/ViewModels/StatusBarViewModel.cs
+++ b/InvoiceApp.MAUI/ViewModels/StatusBarViewModel.cs
@@ -1,0 +1,40 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using System;
+using System.Timers;
+using Microsoft.Maui.ApplicationModel;
+using InvoiceApp.MAUI.Resources;
+
+namespace InvoiceApp.MAUI.ViewModels;
+
+public partial class StatusBarViewModel : ObservableObject
+{
+    private readonly Timer _timer;
+
+    [ObservableProperty]
+    private string dateTime = string.Empty;
+
+    [ObservableProperty]
+    private string activeMenu = string.Empty;
+
+
+    [ObservableProperty]
+    private string message = Resources.Strings.StatusBar_DefaultMessage;
+
+
+    public StatusBarViewModel()
+    {
+        _timer = new Timer(1000)
+        {
+            AutoReset = true
+        };
+        _timer.Elapsed += (_, _) => Update();
+        _timer.Start();
+        Update();
+    }
+
+    private void Update()
+    {
+        MainThread.BeginInvokeOnMainThread(() =>
+            DateTime = System.DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss"));
+    }
+}

--- a/InvoiceApp.MAUI/ViewModels/SupplierCreatorViewModel.cs
+++ b/InvoiceApp.MAUI/ViewModels/SupplierCreatorViewModel.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using InvoiceApp.Core.Models;
+using InvoiceApp.Core.Services;
+
+namespace InvoiceApp.MAUI.ViewModels;
+
+public partial class SupplierCreatorViewModel : ObservableObject
+{
+    private readonly InvoiceEditorViewModel _parent;
+    private readonly ISupplierService _suppliers;
+
+    [ObservableProperty]
+    private string name = string.Empty;
+
+    [ObservableProperty]
+    private string taxId = string.Empty;
+
+    public SupplierCreatorViewModel(InvoiceEditorViewModel parent, ISupplierService suppliers)
+    {
+        _parent = parent;
+        _suppliers = suppliers;
+    }
+
+    [RelayCommand]
+    private async Task ConfirmAsync()
+    {
+        var supplier = new Supplier { Name = Name, TaxId = TaxId };
+        var id = await _suppliers.AddAsync(supplier);
+        supplier.Id = id;
+        _parent.Suppliers.Add(supplier);
+        _parent.SupplierId = supplier.Id;
+        _parent.InlineCreator = null;
+    }
+
+    [RelayCommand]
+    private void Cancel()
+        => _parent.InlineCreator = null;
+}

--- a/InvoiceApp.MAUI/ViewModels/SupplierMasterViewModel.cs
+++ b/InvoiceApp.MAUI/ViewModels/SupplierMasterViewModel.cs
@@ -1,0 +1,33 @@
+using InvoiceApp.Core.Models;
+using InvoiceApp.Core.Services;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Threading.Tasks;
+using InvoiceApp.MAUI.Services;
+
+namespace InvoiceApp.MAUI.ViewModels;
+
+public partial class SupplierMasterViewModel : EditableMasterDataViewModel<Supplier>
+{
+    private readonly ISupplierService _service;
+
+    public SupplierMasterViewModel(ISupplierService service, AppStateService state)
+        : base(state)
+    {
+        _service = service;
+    }
+
+    public ObservableCollection<Supplier> Suppliers => Items;
+
+    protected override Task<List<Supplier>> GetItemsAsync()
+        => _service.GetActiveAsync();
+
+    protected override async Task DeleteAsync()
+    {
+        if (SelectedItem != null)
+        {
+            SelectedItem.IsArchived = true;
+            await _service.UpdateAsync(SelectedItem);
+        }
+    }
+}

--- a/InvoiceApp.MAUI/ViewModels/TaxRateCreatorViewModel.cs
+++ b/InvoiceApp.MAUI/ViewModels/TaxRateCreatorViewModel.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using InvoiceApp.Core.Models;
+using InvoiceApp.Core.Services;
+
+namespace InvoiceApp.MAUI.ViewModels;
+
+public partial class TaxRateCreatorViewModel : ObservableObject
+{
+    private readonly InvoiceEditorViewModel _parent;
+    private readonly ITaxRateService _taxRates;
+
+    [ObservableProperty]
+    private string name = string.Empty;
+
+    [ObservableProperty]
+    private string code = string.Empty;
+
+    [ObservableProperty]
+    private decimal percentage;
+
+    public TaxRateCreatorViewModel(InvoiceEditorViewModel parent, ITaxRateService taxRates)
+    {
+        _parent = parent;
+        _taxRates = taxRates;
+    }
+
+    [RelayCommand]
+    private async Task ConfirmAsync()
+    {
+        var rate = new TaxRate
+        {
+            Name = Name,
+            Percentage = Percentage,
+            Code = Code,
+            EffectiveFrom = DateTime.UtcNow
+        };
+        var id = await _taxRates.AddAsync(rate);
+        rate.Id = id;
+        _parent.TaxRates.Add(rate);
+        _parent.InlineCreator = null;
+    }
+
+    [RelayCommand]
+    private void Cancel()
+        => _parent.InlineCreator = null;
+}

--- a/InvoiceApp.MAUI/ViewModels/TaxRateMasterViewModel.cs
+++ b/InvoiceApp.MAUI/ViewModels/TaxRateMasterViewModel.cs
@@ -1,0 +1,35 @@
+using System;
+using InvoiceApp.Core.Models;
+using InvoiceApp.Core.Services;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Threading.Tasks;
+using InvoiceApp.MAUI.Services;
+
+namespace InvoiceApp.MAUI.ViewModels;
+
+public partial class TaxRateMasterViewModel : EditableMasterDataViewModel<TaxRate>
+{
+    public ObservableCollection<TaxRate> TaxRates => Items;
+
+    private readonly ITaxRateService _service;
+
+    public TaxRateMasterViewModel(ITaxRateService service, AppStateService state)
+        : base(state)
+    {
+        _service = service;
+    }
+
+    protected override Task<List<TaxRate>> GetItemsAsync()
+        => _service.GetActiveAsync(DateTime.UtcNow);
+
+    protected override async Task DeleteAsync()
+    {
+        if (SelectedItem != null)
+        {
+            SelectedItem.IsArchived = true;
+            await _service.UpdateAsync(SelectedItem);
+        }
+    }
+
+}

--- a/InvoiceApp.MAUI/ViewModels/TotalsViewModel.cs
+++ b/InvoiceApp.MAUI/ViewModels/TotalsViewModel.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using CommunityToolkit.Mvvm.ComponentModel;
+using InvoiceApp.Core.Services;
+using InvoiceApp.Core.Models;
+using InvoiceApp.Core.Utilities;
+
+namespace InvoiceApp.MAUI.ViewModels;
+
+public partial class VatSummaryRowViewModel : ObservableObject
+{
+    [ObservableProperty]
+    private string rate = string.Empty;
+
+    [ObservableProperty]
+    private decimal net;
+
+    [ObservableProperty]
+    private decimal vat;
+
+    [ObservableProperty]
+    private decimal gross;
+}
+
+public partial class TotalsViewModel : ObservableObject
+{
+    public ObservableCollection<VatSummaryRowViewModel> VatSummaries { get; } = new();
+
+    [ObservableProperty]
+    private decimal netTotal;
+
+    [ObservableProperty]
+    private decimal vatTotal;
+
+    [ObservableProperty]
+    private decimal grossTotal;
+
+    [ObservableProperty]
+    private string amountInWords = string.Empty;
+
+    public void Recalculate(IEnumerable<InvoiceItemRowViewModel> items, IEnumerable<TaxRate> taxRates, bool isGross)
+    {
+        decimal net = 0;
+        decimal vat = 0;
+        decimal gross = 0;
+        VatSummaries.Clear();
+        var byTax = new Dictionary<Guid, InvoiceTotals>();
+
+        foreach (var row in items)
+        {
+            var tax = taxRates.FirstOrDefault(t => t.Id == row.TaxRateId);
+            if (tax is null) continue;
+
+            decimal netUnit = isGross
+                ? row.UnitPrice / (1 + tax.Percentage / 100m)
+                : row.UnitPrice;
+
+            decimal netAmount = row.Quantity * netUnit;
+            decimal vatAmount = netAmount * (tax.Percentage / 100m);
+            decimal grossAmount = netAmount + vatAmount;
+
+            net += netAmount;
+            vat += vatAmount;
+            gross += grossAmount;
+
+            if (!byTax.TryGetValue(tax.Id, out var totals))
+            {
+                totals = new InvoiceTotals();
+                byTax[tax.Id] = totals;
+            }
+            totals.Net += netAmount;
+            totals.Tax += vatAmount;
+            totals.Gross += grossAmount;
+        }
+
+        NetTotal = Math.Round(net, 2, MidpointRounding.AwayFromZero);
+        VatTotal = Math.Round(vat, 2, MidpointRounding.AwayFromZero);
+        GrossTotal = Math.Round(gross, 2, MidpointRounding.AwayFromZero);
+        foreach (var kv in byTax)
+        {
+            var name = taxRates.FirstOrDefault(t => t.Id == kv.Key)?.Name ?? string.Empty;
+            VatSummaries.Add(new VatSummaryRowViewModel
+            {
+                Rate = name,
+                Net = Math.Round(kv.Value.Net, 2, MidpointRounding.AwayFromZero),
+                Vat = Math.Round(kv.Value.Tax, 2, MidpointRounding.AwayFromZero),
+                Gross = Math.Round(kv.Value.Gross, 2, MidpointRounding.AwayFromZero)
+            });
+        }
+        AmountInWords = NumberToWordsConverter.Convert((long)GrossTotal) + " Ft";
+    }
+}

--- a/InvoiceApp.MAUI/ViewModels/UnitCreatorViewModel.cs
+++ b/InvoiceApp.MAUI/ViewModels/UnitCreatorViewModel.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using InvoiceApp.Core.Models;
+using InvoiceApp.Core.Services;
+
+namespace InvoiceApp.MAUI.ViewModels;
+
+public partial class UnitCreatorViewModel : ObservableObject
+{
+    private readonly InvoiceEditorViewModel _parent;
+    private readonly IUnitService _units;
+
+    [ObservableProperty]
+    private string name = string.Empty;
+
+    [ObservableProperty]
+    private string code = string.Empty;
+
+    public UnitCreatorViewModel(InvoiceEditorViewModel parent, IUnitService units)
+    {
+        _parent = parent;
+        _units = units;
+    }
+
+    [RelayCommand]
+    private async Task ConfirmAsync()
+    {
+        var unit = new Unit { Name = Name, Code = Code };
+        var id = await _units.AddAsync(unit);
+        unit.Id = id;
+        _parent.Units.Add(unit);
+        _parent.InlineCreator = null;
+    }
+
+    [RelayCommand]
+    private void Cancel()
+        => _parent.InlineCreator = null;
+}

--- a/InvoiceApp.MAUI/ViewModels/UnitMasterViewModel.cs
+++ b/InvoiceApp.MAUI/ViewModels/UnitMasterViewModel.cs
@@ -1,0 +1,33 @@
+using InvoiceApp.Core.Models;
+using InvoiceApp.Core.Services;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Threading.Tasks;
+using InvoiceApp.MAUI.Services;
+
+namespace InvoiceApp.MAUI.ViewModels;
+
+public partial class UnitMasterViewModel : EditableMasterDataViewModel<Unit>
+{
+    public ObservableCollection<Unit> Units => Items;
+
+    private readonly IUnitService _service;
+
+    public UnitMasterViewModel(IUnitService service, AppStateService state)
+        : base(state)
+    {
+        _service = service;
+    }
+
+    protected override Task<List<Unit>> GetItemsAsync()
+        => _service.GetActiveAsync();
+
+    protected override async Task DeleteAsync()
+    {
+        if (SelectedItem != null)
+        {
+            SelectedItem.IsArchived = true;
+            await _service.UpdateAsync(SelectedItem);
+        }
+    }
+}

--- a/InvoiceApp.MAUI/ViewModels/UserInfoEditorViewModel.cs
+++ b/InvoiceApp.MAUI/ViewModels/UserInfoEditorViewModel.cs
@@ -1,0 +1,83 @@
+using System;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Microsoft.Extensions.DependencyInjection;
+using InvoiceApp.Core.Services;
+using InvoiceApp.MAUI.Services;
+
+
+namespace InvoiceApp.MAUI.ViewModels;
+
+public partial class UserInfoEditorViewModel : ObservableObject
+{
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(OkCommand))]
+    private string companyName = string.Empty;
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(OkCommand))]
+    private string address = string.Empty;
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(OkCommand))]
+    private string phone = string.Empty;
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(OkCommand))]
+    private string email = string.Empty;
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(OkCommand))]
+    private string taxNumber = string.Empty;
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(OkCommand))]
+    private string bankAccount = string.Empty;
+
+    [ObservableProperty] private bool companyNameError;
+    [ObservableProperty] private bool addressError;
+    [ObservableProperty] private bool phoneError;
+    [ObservableProperty] private bool emailError;
+    [ObservableProperty] private bool taxNumberError;
+    [ObservableProperty] private bool bankAccountError;
+
+    private readonly INotificationService _notifications;
+
+    public IRelayCommand OkCommand { get; }
+    public IRelayCommand CancelCommand { get; }
+
+    public UserInfoEditorViewModel(INotificationService? notifications = null)
+    {
+        _notifications = notifications ?? (App.Services != null
+            ? App.Provider.GetRequiredService<INotificationService>()
+            : new MessageBoxNotificationService());
+        OkCommand = new RelayCommand(ExecuteOk, () => IsValid);
+        CancelCommand = new RelayCommand(() => OnCancel?.Invoke());
+    }
+
+    private void ExecuteOk()
+    {
+        Validate();
+        if (!IsValid) return;
+
+        var summary = $"Cégnév: {CompanyName}\nCím: {Address}\nTelefonszám: {Phone}\nE-mail: {Email}\nAdószám: {TaxNumber}\nBankszámla: {BankAccount}";
+        if (_notifications.Confirm($"Helyesek az adatok?\n\n{summary}"))
+            OnOk?.Invoke(this);
+    }
+
+    public bool IsValid =>
+        !string.IsNullOrWhiteSpace(CompanyName) &&
+        !string.IsNullOrWhiteSpace(Address) &&
+        !string.IsNullOrWhiteSpace(Phone) &&
+        !string.IsNullOrWhiteSpace(Email) &&
+        !string.IsNullOrWhiteSpace(TaxNumber) &&
+        !string.IsNullOrWhiteSpace(BankAccount);
+
+    private void Validate()
+    {
+        CompanyNameError = string.IsNullOrWhiteSpace(CompanyName);
+        AddressError = string.IsNullOrWhiteSpace(Address);
+        PhoneError = string.IsNullOrWhiteSpace(Phone);
+        EmailError = string.IsNullOrWhiteSpace(Email);
+        TaxNumberError = string.IsNullOrWhiteSpace(TaxNumber);
+        BankAccountError = string.IsNullOrWhiteSpace(BankAccount);
+    }
+
+    public Action<UserInfoEditorViewModel>? OnOk;
+    public Action? OnCancel;
+}

--- a/InvoiceApp.MAUI/ViewModels/UserInfoViewModel.cs
+++ b/InvoiceApp.MAUI/ViewModels/UserInfoViewModel.cs
@@ -1,0 +1,49 @@
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using InvoiceApp.Core.Entities;
+using InvoiceApp.Core.Services;
+
+namespace InvoiceApp.MAUI.ViewModels;
+
+public partial class UserInfoViewModel : ObservableObject
+{
+    private readonly IUserInfoService _service;
+
+    [ObservableProperty] private string companyName = string.Empty;
+    [ObservableProperty] private string address = string.Empty;
+    [ObservableProperty] private string phone = string.Empty;
+    [ObservableProperty] private string email = string.Empty;
+    [ObservableProperty] private string taxNumber = string.Empty;
+    [ObservableProperty] private string bankAccount = string.Empty;
+
+    public UserInfoViewModel(IUserInfoService service)
+    {
+        _service = service;
+    }
+
+    public async Task LoadAsync()
+    {
+        var info = await _service.LoadAsync();
+        CompanyName = info.CompanyName;
+        Address = info.Address;
+        Phone = info.Phone;
+        Email = info.Email;
+        TaxNumber = info.TaxNumber;
+        BankAccount = info.BankAccount;
+    }
+
+    [RelayCommand]
+    public async Task SaveAsync()
+    {
+        await _service.SaveAsync(new UserInfo
+        {
+            CompanyName = CompanyName,
+            Address = Address,
+            Phone = Phone,
+            Email = Email,
+            TaxNumber = TaxNumber,
+            BankAccount = BankAccount
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- copy WPF viewmodels into MAUI project
- implement MAUI versions of input services
- replace MessageBoxNotificationService with DisplayAlert implementation
- add FocusManager for controlling focus
- update SetupViewModel and other components to use MAUI APIs

## Testing
- `dotnet build InvoiceApp.MAUI/InvoiceApp.MAUI.csproj` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_68741ceaa8d483229250bdf4a78ae799