### PR TITLE
Implement MAUI setup flow and storage path

### DIFF
--- a/InvoiceApp.Data/Data/AppDbContext.cs
+++ b/InvoiceApp.Data/Data/AppDbContext.cs
@@ -1,0 +1,7 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace InvoiceApp.Data.Data;
+
+public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(options)
+{
+}

--- a/InvoiceApp.Data/Data/WalPragmaInterceptor.cs
+++ b/InvoiceApp.Data/Data/WalPragmaInterceptor.cs
@@ -1,0 +1,30 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using System.Data.Common;
+
+namespace InvoiceApp.Data.Data;
+
+public class WalPragmaInterceptor : DbConnectionInterceptor
+{
+    private const string Sql = "PRAGMA journal_mode=WAL";
+
+    public override async Task ConnectionOpenedAsync(DbConnection connection, ConnectionEndEventData eventData, CancellationToken cancellationToken = default)
+    {
+        if (connection is SqliteConnection)
+        {
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = Sql;
+            await cmd.ExecuteScalarAsync(cancellationToken);
+        }
+    }
+
+    public override void ConnectionOpened(DbConnection connection, ConnectionEndEventData eventData)
+    {
+        if (connection is SqliteConnection)
+        {
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = Sql;
+            cmd.ExecuteScalar();
+        }
+    }
+}

--- a/InvoiceApp.Data/InvoiceApp.Data.csproj
+++ b/InvoiceApp.Data/InvoiceApp.Data.csproj
@@ -11,6 +11,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Bogus" Version="35.0.1" />
+    <PackageReference Include="Microsoft.Maui.Storage" Version="8.0.0" />
     <PackageReference Include="Serilog" Version="3.1.1" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
   </ItemGroup>

--- a/InvoiceApp.Data/ServiceCollectionExtensions.cs
+++ b/InvoiceApp.Data/ServiceCollectionExtensions.cs
@@ -1,0 +1,29 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using System.IO;
+using Microsoft.Maui.Storage;
+
+namespace InvoiceApp.Data;
+
+public static class ServiceCollectionExtensions
+{
+    public static Task AddStorageAsync(this IServiceCollection services, string dbPath, string userInfoPath, string settingsPath)
+    {
+        if (string.IsNullOrWhiteSpace(dbPath))
+        {
+            var appDir = FileSystem.AppDataDirectory;
+            Directory.CreateDirectory(appDir);
+            dbPath = Path.Combine(appDir, "app.db");
+        }
+
+        services.AddSingleton<Data.WalPragmaInterceptor>();
+        services.AddDbContext<Data.AppDbContext>((sp, o) =>
+            o.UseSqlite($"Data Source={dbPath}")
+             .AddInterceptors(sp.GetRequiredService<Data.WalPragmaInterceptor>()));
+        services.AddDbContextFactory<Data.AppDbContext>((sp, o) =>
+            o.UseSqlite($"Data Source={dbPath}")
+             .AddInterceptors(sp.GetRequiredService<Data.WalPragmaInterceptor>()));
+
+        return Task.CompletedTask;
+    }
+}

--- a/InvoiceApp.MAUI/InvoiceApp.MAUI.csproj
+++ b/InvoiceApp.MAUI/InvoiceApp.MAUI.csproj
@@ -11,6 +11,9 @@
   </ItemGroup>
   <ItemGroup>
     <MauiXaml Include="Resources\Styles\RetroTheme.xaml" />
+    <MauiXaml Include="Views/Dialogs/SetupPage.xaml" />
+    <MauiXaml Include="Views/Dialogs/SeedOptionsPage.xaml" />
+    <MauiXaml Include="Views/Dialogs/UserInfoEditorPage.xaml" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\InvoiceApp.Core\InvoiceApp.Core.csproj" />

--- a/InvoiceApp.MAUI/MauiProgram.cs
+++ b/InvoiceApp.MAUI/MauiProgram.cs
@@ -6,6 +6,7 @@ using InvoiceApp.Core;
 using InvoiceApp.MAUI.ViewModels;
 using InvoiceApp.MAUI.Views;
 using InvoiceApp.MAUI.Services;
+using InvoiceApp.MAUI.Views.Dialogs;
 
 namespace InvoiceApp.MAUI;
 
@@ -31,6 +32,12 @@ public static class MauiProgram
         var settingsPath = Path.Combine(appDir, "settings.json");
         services.AddCore();
         services.AddStorageAsync(Path.Combine(appDir, "app.db"), Path.Combine(appDir, "user.json"), settingsPath).GetAwaiter().GetResult();
+        services.AddTransient<ISetupFlow, SetupFlow>();
+        services.AddTransient<Dialogs.SetupPage>();
+        services.AddTransient<Dialogs.UserInfoEditorPage>();
+        services.AddTransient<Dialogs.SeedOptionsPage>();
+        services.AddTransient<SeedOptionsViewModel>();
+        services.AddTransient<UserInfoEditorViewModel>();
         services.AddSingleton<AppStateService>(_ => new AppStateService(Path.Combine(appDir, "state.json")));
         services.AddSingleton<KeyboardManager>();
         services.AddSingleton<FocusManager>();

--- a/InvoiceApp.MAUI/Services/ISetupFlow.cs
+++ b/InvoiceApp.MAUI/Services/ISetupFlow.cs
@@ -1,0 +1,8 @@
+namespace InvoiceApp.MAUI.Services;
+
+public record SetupData(string DatabasePath, string ConfigPath);
+
+public interface ISetupFlow
+{
+    Task<SetupData> RunAsync(string defaultDb, string defaultCfg);
+}

--- a/InvoiceApp.MAUI/Services/SetupFlow.cs
+++ b/InvoiceApp.MAUI/Services/SetupFlow.cs
@@ -1,0 +1,50 @@
+using InvoiceApp.MAUI.ViewModels;
+using InvoiceApp.MAUI.Views.Dialogs;
+using Microsoft.Maui.Controls;
+
+namespace InvoiceApp.MAUI.Services;
+
+public class SetupFlow : ISetupFlow
+{
+    public async Task<SetupData> RunAsync(string defaultDb, string defaultCfg)
+    {
+        var vm = new SetupViewModel(defaultDb, defaultCfg);
+        var page = new SetupPage { BindingContext = vm };
+        var result = await ShowDialogAsync(page, vm);
+        if (!result)
+            throw new OperationCanceledException();
+
+        var infoVm = new UserInfoEditorViewModel();
+        var infoPage = new UserInfoEditorPage { BindingContext = infoVm };
+        result = await ShowDialogAsync(infoPage, infoVm);
+        if (!result)
+            throw new OperationCanceledException();
+
+        return new SetupData(vm.DatabasePath, vm.ConfigPath);
+    }
+
+    private static Task<bool> ShowDialogAsync(ContentPage page, object vm)
+    {
+        var tcs = new TaskCompletionSource<bool>();
+        if (vm is SetupViewModel svm)
+        {
+            svm.DialogResult += r => { tcs.SetResult(r); };
+        }
+        else if (vm is SeedOptionsViewModel s)
+        {
+            s.DialogResult += r => { tcs.SetResult(r); };
+        }
+        else if (vm is UserInfoEditorViewModel u)
+        {
+            u.OnOk = _ => tcs.SetResult(true);
+            u.OnCancel = () => tcs.SetResult(false);
+        }
+
+        Application.Current!.MainPage!.Navigation.PushModalAsync(page);
+        return tcs.Task.ContinueWith(async t =>
+        {
+            await Application.Current.MainPage.Navigation.PopModalAsync();
+            return t.Result;
+        }).Unwrap();
+    }
+}

--- a/InvoiceApp.MAUI/Views/Dialogs/SeedOptionsPage.xaml
+++ b/InvoiceApp.MAUI/Views/Dialogs/SeedOptionsPage.xaml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="InvoiceApp.MAUI.Views.Dialogs.SeedOptionsPage"
+             x:DataType="vm:SeedOptionsViewModel"
+             xmlns:vm="clr-namespace:InvoiceApp.MAUI.ViewModels">
+    <StackLayout Padding="20" Spacing="10">
+        <Label Text="Szállítók száma:" />
+        <Entry Text="{Binding SupplierCount}" WidthRequest="120" Keyboard="Numeric" />
+        <Label Text="Termékek száma:" />
+        <Entry Text="{Binding ProductCount}" WidthRequest="120" Keyboard="Numeric" />
+        <Label Text="Számlák száma:" />
+        <Entry Text="{Binding InvoiceCount}" WidthRequest="120" Keyboard="Numeric" />
+        <Label Text="Tételek számlánként (min-max):" />
+        <HorizontalStackLayout>
+            <Entry Text="{Binding MinItemsPerInvoice}" WidthRequest="50" Keyboard="Numeric" />
+            <Label Text="-" VerticalOptions="Center" />
+            <Entry Text="{Binding MaxItemsPerInvoice}" WidthRequest="50" Keyboard="Numeric" />
+        </HorizontalStackLayout>
+        <HorizontalStackLayout HorizontalOptions="End" Spacing="10" Padding="0,20,0,0">
+            <Button Text="OK" Command="{Binding OkCommand}" />
+            <Button Text="Mégse" Command="{Binding CancelCommand}" />
+        </HorizontalStackLayout>
+    </StackLayout>
+</ContentPage>

--- a/InvoiceApp.MAUI/Views/Dialogs/SeedOptionsPage.xaml.cs
+++ b/InvoiceApp.MAUI/Views/Dialogs/SeedOptionsPage.xaml.cs
@@ -1,0 +1,11 @@
+using Microsoft.Maui.Controls;
+
+namespace InvoiceApp.MAUI.Views.Dialogs;
+
+public partial class SeedOptionsPage : ContentPage
+{
+    public SeedOptionsPage()
+    {
+        InitializeComponent();
+    }
+}

--- a/InvoiceApp.MAUI/Views/Dialogs/SetupPage.xaml
+++ b/InvoiceApp.MAUI/Views/Dialogs/SetupPage.xaml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="InvoiceApp.MAUI.Views.Dialogs.SetupPage"
+             x:DataType="vm:SetupViewModel"
+             xmlns:vm="clr-namespace:InvoiceApp.MAUI.ViewModels">
+    <StackLayout Padding="20" Spacing="10">
+        <Label Text="Adatbázis fájl:" />
+        <HorizontalStackLayout>
+            <Entry Text="{Binding DatabasePath}" WidthRequest="280" />
+            <Button Text="..." Command="{Binding BrowseDbCommand}" WidthRequest="30" />
+        </HorizontalStackLayout>
+        <Label Text="Konfigurációs fájl:" />
+        <HorizontalStackLayout>
+            <Entry Text="{Binding ConfigPath}" WidthRequest="280" />
+            <Button Text="..." Command="{Binding BrowseConfigCommand}" WidthRequest="30" />
+        </HorizontalStackLayout>
+        <HorizontalStackLayout HorizontalOptions="End" Spacing="10" Padding="0,20,0,0">
+            <Button Text="OK" Command="{Binding OkCommand}" />
+            <Button Text="Mégse" Command="{Binding CancelCommand}" />
+        </HorizontalStackLayout>
+    </StackLayout>
+</ContentPage>

--- a/InvoiceApp.MAUI/Views/Dialogs/SetupPage.xaml.cs
+++ b/InvoiceApp.MAUI/Views/Dialogs/SetupPage.xaml.cs
@@ -1,0 +1,11 @@
+using Microsoft.Maui.Controls;
+
+namespace InvoiceApp.MAUI.Views.Dialogs;
+
+public partial class SetupPage : ContentPage
+{
+    public SetupPage()
+    {
+        InitializeComponent();
+    }
+}

--- a/InvoiceApp.MAUI/Views/Dialogs/UserInfoEditorPage.xaml
+++ b/InvoiceApp.MAUI/Views/Dialogs/UserInfoEditorPage.xaml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="InvoiceApp.MAUI.Views.Dialogs.UserInfoEditorPage"
+             x:DataType="vm:UserInfoEditorViewModel"
+             xmlns:vm="clr-namespace:InvoiceApp.MAUI.ViewModels">
+    <ScrollView>
+        <StackLayout Padding="20" Spacing="10">
+            <Label Text="Cégnév" />
+            <Entry Text="{Binding CompanyName}" />
+            <Label Text="Cím" />
+            <Entry Text="{Binding Address}" />
+            <Label Text="Telefonszám" />
+            <Entry Text="{Binding Phone}" />
+            <Label Text="E-mail" />
+            <Entry Text="{Binding Email}" />
+            <Label Text="Adószám" />
+            <Entry Text="{Binding TaxNumber}" />
+            <Label Text="Bankszámla" />
+            <Entry Text="{Binding BankAccount}" />
+            <HorizontalStackLayout HorizontalOptions="End" Spacing="10" Padding="0,20,0,0">
+                <Button Text="OK" Command="{Binding OkCommand}" />
+                <Button Text="Mégse" Command="{Binding CancelCommand}" />
+            </HorizontalStackLayout>
+        </StackLayout>
+    </ScrollView>
+</ContentPage>

--- a/InvoiceApp.MAUI/Views/Dialogs/UserInfoEditorPage.xaml.cs
+++ b/InvoiceApp.MAUI/Views/Dialogs/UserInfoEditorPage.xaml.cs
@@ -1,0 +1,11 @@
+using Microsoft.Maui.Controls;
+
+namespace InvoiceApp.MAUI.Views.Dialogs;
+
+public partial class UserInfoEditorPage : ContentPage
+{
+    public UserInfoEditorPage()
+    {
+        InitializeComponent();
+    }
+}


### PR DESCRIPTION
## Summary
- add minimal EF Core setup for InvoiceApp.Data with WAL handling
- support cross-platform app data folder using `FileSystem.AppDataDirectory`
- create SetupFlow for MAUI and related dialog pages
- register new services and pages in `MauiProgram`

## Testing
- `dotnet test --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874238b24248322abc8d4127ddbe423