### PR TITLE
Switch plugin modules to non-Windows SDK

### DIFF
--- a/InvoiceApp.Data/InvoiceApp.Data.csproj
+++ b/InvoiceApp.Data/InvoiceApp.Data.csproj
@@ -12,9 +12,9 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Bogus" Version="35.0.1" />
-    <PackageReference Include="Microsoft.Maui.Storage" Version="8.0.0" />
-    <PackageReference Include="Serilog" Version="3.1.1" />
-    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
+    <PackageReference Include="Serilog" Version="4.3.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\InvoiceApp.Core\InvoiceApp.Core.csproj" />

--- a/refactor/InvoiceApp.InvoiceModule/InvoiceApp.InvoiceModule.csproj
+++ b/refactor/InvoiceApp.InvoiceModule/InvoiceApp.InvoiceModule.csproj
@@ -1,6 +1,6 @@
-<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/refactor/InvoiceApp.Plugins.Abstractions/InvoiceApp.Plugins.Abstractions.csproj
+++ b/refactor/InvoiceApp.Plugins.Abstractions/InvoiceApp.Plugins.Abstractions.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/refactor/InvoiceApp.Plugins.Abstractions/PluginLoader.cs
+++ b/refactor/InvoiceApp.Plugins.Abstractions/PluginLoader.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace InvoiceApp.Plugins.Abstractions;
 


### PR DESCRIPTION
## Summary
- switch plugin csprojs to `Microsoft.NET.Sdk`
- target `net8.0` framework
- fix PluginLoader missing DI using
- fix missing Serilog sink and package mismatches so projects build

## Testing
- `dotnet build refactor/Wrecept.Refactor.sln -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_6874425db3f88322bc0b3bc00a9dac28