### PR TITLE
Update docs for MAUI transition

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -46,7 +46,7 @@ Ezek fölött `InvoiceService`, `ProductService` és mostantól `SupplierService
 Az `InvoiceService` kezeli a fejléc frissítését (`UpdateInvoiceHeaderAsync`) és az archiválást.
 Fejléc mentésekor az `InvoiceLookupViewModel` újratölti a listát és a módosított számlát jelöli ki.
 Az új `RemoveItemAsync` metódus lehetővé teszi egy meglévő tétel törlését adatbázisból.
-Az `IInvoiceExportService` felülete biztosít PDF mentést és nyomtatást, a `PdfInvoiceExporter` a WPF rétegben valósítja meg.
+Az `IInvoiceExportService` felülete biztosít PDF mentést és nyomtatást, a `PdfInvoiceExporter` a MAUI felületen keresztül jeleníti meg a dokumentumokat.
 
 Az `OnModelCreating` metódus indexeket készít a gyakran szűrt mezőkre:
 `Invoices.Date`, `Invoices.SupplierId` és `Products.Name`. A korábbi
@@ -54,7 +54,7 @@ Az `OnModelCreating` metódus indexeket készít a gyakran szűrt mezőkre:
 segítik.
 
 Minden hibát az `ILogService` rögzít, amelyet a Storage réteg `LogService` implementációja valósít meg. A naplók a `%AppData%/Wrecept/logs` mappában napi bontású fájlokba kerülnek.
-Felhasználói üzenetekhez az `INotificationService` ad egységes felületet. WPF alatt a `MessageBoxNotificationService` jeleníti meg a dialógusokat, míg a tesztekben egy csonk "MockNotificationService" működik.
+Felhasználói üzenetekhez az `INotificationService` ad egységes felületet. MAUI alatt a `MessageBoxNotificationService` jeleníti meg a dialógusokat, míg a tesztekben egy csonk "MockNotificationService" működik.
 Az alapvető cégadatokat a `UserInfoService` kezeli. Az adatok a `%AppData%/Wrecept/wrecept.json` fájlban tárolódnak, betöltésük az alkalmazás futása közben történik.
 Az aktuális képernyőmódot a `SettingsService` tartja nyilván `settings.json` fájlban, amit a `ScreenModeManager` olvas be induláskor.
 Az adatbázis integritását az `IDbHealthService` ellenőrzi `PRAGMA integrity_check` parancs futtatásával.
@@ -88,7 +88,7 @@ Ha a második adatlekérdezés is hibát jelez, a részleteket az `ILogService` 
 
 Az alkalmazás betöltésekor a `StartupOrchestrator` fut le, amely két szintű előrehaladási értéket jelent az UI felé. A `ProgressViewModel` által kötött nézet két `ProgressBar`-on keresztül mutatja a globális és részfeladatok százalékos állását, így a felhasználó valós időben látja a migráció és a mintaadatok betöltésének állapotát.
 
-Az első indításkor a `LoadSettingsAsync` metódus a `ISetupFlow` szolgáltatás segítségével kéri be az adatbázis- és cégadatok elérési útvonalát. A `SetupFlow` alapértelmezett implementáció WPF dialógusokat használ, de tesztben könnyen helyettesíthető.
+Az első indításkor a `LoadSettingsAsync` metódus a `ISetupFlow` szolgáltatás segítségével kéri be az adatbázis- és cégadatok elérési útvonalát. A `SetupFlow` alapértelmezett implementáció MAUI oldalakat használ, de tesztben könnyen helyettesíthető.
 A folyamat megszakításakor az `IEnvironmentService` hívódik, így a kilépés tesztkörnyezetben is ellenőrizhető.
 
 Az `InvoiceEditorLayout` megnyitásakor hasonló ablak jelenik meg. A törzsadatok (fizetési módok, szállítók, ÁFA‑kulcsok, termékek, mértékegységek) betöltése lépésenként történik, a második sáv pedig az adott lista elemeinek betöltési arányát írja ki.

--- a/docs/TEST_STRATEGY.md
+++ b/docs/TEST_STRATEGY.md
@@ -14,8 +14,8 @@ A Wrecept stabilitását több szinten biztosítjuk.
 1. **Unit tesztek** – A Core és ViewModel rétegek logikáját izoláltan ellenőrizzük.
 2. **Integration tesztek** – Adatbázis műveletek és szolgáltatások együttműködését vizsgáljuk SQLite in-memory módban.
    * Egy külön teszt a fizikai `app.db` fájlon fut, hogy ellenőrizzük a tényleges mentést és betöltést.
-3. **UI tesztek** – WinAppDriverrel automatizáltan teszteljük a felületet. Részletek: [developer_guide_hu.md](manuals/developer_guide_hu.md#ui-tesztek-winappdriverrel).
-   * Példa projekt: `tests/Wrecept.UiTests`.
+3. **UI tesztek** – A MAUI alkalmazást a cross-platform `MauiUITest` keretrendszerrel futtatjuk emulátorokon és fizikai eszközökön.
+   * A tesztek a `tests/Wrecept.MauiTests` projektben találhatók.
 
 ## Hülyebiztos validáció
 

--- a/docs/about.md
+++ b/docs/about.md
@@ -16,5 +16,5 @@ The Wrecept application is built with the following attributes:
 - **Short description:** An offline capable, keyboard-focused invoice recording tool.
 - Focus and key handling is provided by central services.
 - **License:** Free, open source program and code.
-- **Technologies:** .NET 8, WPF, SQLite, EF Core, MVVM architecture.
+- **Technologies:** .NET 8, MAUI, SQLite, EF Core, MVVM.
 - **History:** Based on the original DOS Clipper RECEPT.EXE written by Tácsi Egon (HA3MN).

--- a/docs/manuals/developer_guide_hu.md
+++ b/docs/manuals/developer_guide_hu.md
@@ -27,7 +27,7 @@ Ez a dokumentum a projekt fejlesztéséhez szükséges alapvető lépéseket tar
    ```
 4. **Futtatás** fejlesztői módban:
    ```bash
-   dotnet run --project Wrecept.Wpf
+   dotnet run --project InvoiceApp.MAUI
    ```
 
 ## Navigáció a projektben


### PR DESCRIPTION
## Summary
- clarify MAUI implementation lines in architecture doc
- list current technologies in the about page
- update run instructions to use InvoiceApp.MAUI project
- remove WinAppDriver mention and describe MAUI UI tests

## Testing
- `dotnet test InvoiceApp.sln -v minimal -p:EnableWindowsTargeting=true` *(fails: workloads not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687447c7e8848322b0a8aba8b00a3d2c