### PR TITLE
Update docs for InvoiceApp naming

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -53,9 +53,9 @@ Az `OnModelCreating` metódus indexeket készít a gyakran szűrt mezőkre:
 `TaxRate` és `Unit` indexekhez hasonlóan ezek is a lekérdezések gyorsítását
 segítik.
 
-Minden hibát az `ILogService` rögzít, amelyet a Storage réteg `LogService` implementációja valósít meg. A naplók a `%AppData%/Wrecept/logs` mappában napi bontású fájlokba kerülnek.
+Minden hibát az `ILogService` rögzít, amelyet a Storage réteg `LogService` implementációja valósít meg. A naplók a `%AppData%/InvoiceApp/logs` mappában napi bontású fájlokba kerülnek.
 Felhasználói üzenetekhez az `INotificationService` ad egységes felületet. MAUI alatt a `MessageBoxNotificationService` jeleníti meg a dialógusokat, míg a tesztekben egy csonk "MockNotificationService" működik.
-Az alapvető cégadatokat a `UserInfoService` kezeli. Az adatok a `%AppData%/Wrecept/wrecept.json` fájlban tárolódnak, betöltésük az alkalmazás futása közben történik.
+Az alapvető cégadatokat a `UserInfoService` kezeli. Az adatok a `%AppData%/InvoiceApp/invoiceapp.json` fájlban tárolódnak, betöltésük az alkalmazás futása közben történik.
 Az aktuális képernyőmódot a `SettingsService` tartja nyilván `settings.json` fájlban, amit a `ScreenModeManager` olvas be induláskor.
 Az adatbázis integritását az `IDbHealthService` ellenőrzi `PRAGMA integrity_check` parancs futtatásával.
 Az utolsó megnyitott számla azonosítóját a `SessionService` jegyzi meg a `session.json` fájlban.

--- a/docs/CODE_STANDARDS.md
+++ b/docs/CODE_STANDARDS.md
@@ -11,7 +11,7 @@ A kód minden rétegében egységes konvenciókat követünk, hogy a projekt át
 
 ## Naming
 
-* **Namespace**: `Wrecept.<Layer>.<Module>`
+* **Namespace**: `InvoiceApp.<Layer>.<Module>`
 * **Osztályok**: PascalCase
 * **Mezők**: `_camelCase`
 * **Fájlok**: az osztály nevét viselik

--- a/docs/DEV_SPECS.md
+++ b/docs/DEV_SPECS.md
@@ -1,4 +1,4 @@
-# 📘 Development Specification – Wrecept
+# 📘 Development Specification – InvoiceApp
 
 ---
 title: "Development Specification"
@@ -9,7 +9,7 @@ date: "2025-06-27"
 
 ## 🎯 Purpose
 
-Wrecept is an offline-first, single-user application for invoice recording and procurement workflows. The codebase now targets **.NET MAUI** so the same features work on Windows, macOS and Linux desktops.
+InvoiceApp is an offline-first, single-user application for invoice recording and procurement workflows. The codebase now targets **.NET MAUI** so the same features work on Windows, macOS and Linux desktops.
 
 The design must be:
 

--- a/docs/DEV_SPECS_hu.md
+++ b/docs/DEV_SPECS_hu.md
@@ -5,7 +5,7 @@ author: "root_agent"
 date: "2025-06-27"
 ---
 
-# 📘 Fejlesztési specifikáció – Wrecept
+# 📘 Fejlesztési specifikáció – InvoiceApp
 
-A Wrecept offline-első számlázó alkalmazás, amely immár **.NET MAUI** alapokon fut Windows, macOS és Linux rendszereken is.
+Az InvoiceApp offline-első számlázó alkalmazás, amely immár **.NET MAUI** alapokon fut Windows, macOS és Linux rendszereken is.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -92,9 +92,9 @@ InvoiceApp.sln
 The MAUI project lives in `InvoiceApp.MAUI` and contains the following basics:
 
 * `App.xaml` and `App.xaml.cs` – application configuration
-* `MainWindow.xaml` – main window
+* `MainPage.xaml` – main window
 * `App.xaml.cs` holds DI and startup logic
-* `MainWindow` loads the `StageView` layout
+* `MainPage` loads the `StageView` layout
 
 These ensure the program runs immediately in a Windows environment.
 

--- a/docs/about.md
+++ b/docs/about.md
@@ -7,9 +7,9 @@ date: "2025-06-29"
 
 # ℹ️ About
 
-The Wrecept application is built with the following attributes:
+The InvoiceApp application is built with the following attributes:
 
-- **Name:** Wrecept
+- **Name:** InvoiceApp
 - **Version:** 0.1 (versioning is still being introduced)
 - **Build date:** 2025-06-29 (UTC)
 - **Developers:** Tankó Ferenc & ChatGPT Codex Agents (<tankoferenc@icloud.com>)

--- a/docs/about_hu.md
+++ b/docs/about_hu.md
@@ -7,9 +7,9 @@ date: "2025-06-29"
 
 # ℹ️ Névjegy
 
-A Wrecept program az alábbi adatokkal rendelkezik:
+Az InvoiceApp program az alábbi adatokkal rendelkezik:
 
-- **Program neve:** Wrecept
+- **Program neve:** InvoiceApp
 - **Verzió:** 0.1 (a verziókezelés bevezetés alatt áll)
 - **Build dátuma:** 2025-06-29 (UTC)
 - **Fejlesztő:** Tankó Ferenc & ChatGPT Codex Agents (<tankoferenc@icloud.com>)

--- a/docs/manuals/developer_guide_hu.md
+++ b/docs/manuals/developer_guide_hu.md
@@ -60,14 +60,14 @@ Ez a dokumentum a projekt fejlesztéséhez szükséges alapvető lépéseket tar
 ## Indítási UI tesztek
 
 A `StartupWindowTests` a teljes indulási folyamatot automatizálja. A tesztek a
-`tests/Wrecept.UiTests` projektben találhatók. Az alkalmazás elérési útját
+`tests/InvoiceApp.UiTests` projektben találhatók. Az alkalmazás elérési útját
 a teszt futáskor relatívan számítjuk ki,
 így nem függ a fejlesztői könyvtárstruktúrától.
 
 ### Tesztek sorrendje
 
 1. **Application_Launches_And_Closes** – egyszerűen megnyitja majd bezárja a főablakot.
-2. **SeedOptions_Cancel_OpensMainWindow** – a „Mintaszámok” ablakban a *Mégse* gombra kattint, majd ellenőrzi, hogy a *Wrecept* főablak jelenik meg.
+2. **SeedOptions_Cancel_OpensMainWindow** – a „Mintaszámok” ablakban a *Mégse* gombra kattint, majd ellenőrzi, hogy az *InvoiceApp* főablak jelenik meg.
 3. **SeedOptions_Ok_ShowsStartupWindow** – az *OK* gombbal elindítja a mintadatok feltöltését, és ellenőrzi, hogy megjelenik az *Indulás* ablak.
 4. **UserInfoEditor_FillFields_Confirms** – első indításkor kitölti a tulajdonosi adatokat, majd az *Enter* billentyűvel megerősít.
 
@@ -76,7 +76,7 @@ A tesztek a `settings.json` állomány törlésével vagy létrehozásával kül
 A fenti esetek egyenként futtathatók például:
 
 ```bash
-dotnet test tests/Wrecept.UiTests/Wrecept.UiTests.csproj --filter "Name=SeedOptions_Ok_ShowsStartupWindow"
+dotnet test tests/InvoiceApp.UiTests/InvoiceApp.UiTests.csproj --filter "Name=SeedOptions_Ok_ShowsStartupWindow"
 ```
 
 Az új tesztsegéd automatikusan kezeli az első indítási ablakokat, és hiba esetén képernyőképet ment az aktuális könyvtárba `error_YYYYMMDD_HHMMSS.png` néven.

--- a/docs/manuals/user_manual_hu.md
+++ b/docs/manuals/user_manual_hu.md
@@ -7,13 +7,13 @@ date: "2025-06-27"
 
 # 📗 Felhasználói kézikönyv
 
-Ez a dokumentum bemutatja a Wrecept telepítésének és használatának alapjait.
+Ez a dokumentum bemutatja az InvoiceApp telepítésének és használatának alapjait.
 
 ## Telepítés és első indítás
 
 1. Töltsd le a kiadott csomagot, majd csomagold ki egy tetszőleges mappába.
 2. Győződj meg róla, hogy a **.NET Desktop Runtime 8** elérhető a gépen.
-3. Indítsd el a `Wrecept.Wpf.exe` állományt. Az első indításkor megadhatod a konfigurációs fájl helyét, vagy elfogadhatod az alapértelmezést.
+3. Indítsd el az MAUI alkalmazás futtatható állományát (például `InvoiceApp.MAUI.exe`). Az első indításkor megadhatod a konfigurációs fájl helyét, vagy elfogadhatod az alapértelmezést.
 
 ## Alapvető navigáció
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,10 +1,10 @@
 # Plug-in architektúra
 
-Ez a dokumentum bemutatja, hogyan bővíthető a Wrecept moduláris plug-inekkel.
+Ez a dokumentum bemutatja, hogyan bővíthető az InvoiceApp moduláris plug-inekkel.
 
 ## IPlugin interfész
 
-A `refactor/Wrecept.Plugins.Abstractions` projekt tartalmazza az `IPlugin` interfészt és a `PluginLoader` segédosztályt.
+A `refactor/InvoiceApp.Plugins.Abstractions` projekt tartalmazza az `IPlugin` interfészt és a `PluginLoader` segédosztályt.
 
 ```csharp
 public interface IPlugin
@@ -17,7 +17,7 @@ A `PluginLoader.LoadPluginsAsync` metódus betölti a megadott mappában találh
 
 ## Saját modulok
 
-Minden projekt létrehozhat egy modulosztályt, amely implementálja az `IPlugin` interfészt és regisztrálja a szükséges szolgáltatásokat. Például a `Wrecept.Wpf` projekt a `WpfModule` osztályt tartalmazza.
+Minden projekt létrehozhat egy modulosztályt, amely implementálja az `IPlugin` interfészt és regisztrálja a szükséges szolgáltatásokat. Például az `InvoiceApp.MAUI` projekt egy `MauiModule` osztályt tartalmaz.
 
 A host alkalmazás az indításkor betölti a plug-ineket:
 


### PR DESCRIPTION
## Summary
- rename MainWindow references to MainPage in `docs/README.md`
- update log/config paths in `docs/ARCHITECTURE.md`
- revise Hungarian manuals for MAUI executable
- switch docs to `InvoiceApp.*` namespaces
- update about pages and development specs

## Testing
- `git status --short`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_68744a8da3988322afa134cd0ec3d58f