### PR TITLE
Fix MAUI targets and docs

### DIFF
--- a/InvoiceApp.Data/ServiceCollectionExtensions.cs
+++ b/InvoiceApp.Data/ServiceCollectionExtensions.cs
@@ -13,7 +13,7 @@ namespace InvoiceApp.Data;
 
 public static class ServiceCollectionExtensions
 {
-    public static async Task AddStorageAsync(this IServiceCollection services, string dbPath, string userInfoPath, string settingsPath)
+    public static Task AddStorageAsync(this IServiceCollection services, string dbPath, string userInfoPath, string settingsPath)
     {
         if (string.IsNullOrWhiteSpace(dbPath))
         {
@@ -50,5 +50,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IDatabaseRecoveryService>(sp =>
             new DatabaseRecoveryService(dbPath, sp.GetRequiredService<IDbContextFactory<AppDbContext>>(), sp.GetRequiredService<ILogService>()));
         services.AddSingleton<IDatabaseInitializer, DatabaseInitializer>();
+
+        return Task.CompletedTask;
     }
 }

--- a/InvoiceApp.MAUI/InvoiceApp.MAUI.csproj
+++ b/InvoiceApp.MAUI/InvoiceApp.MAUI.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0-windows10.0.19041.0;net8.0-maccatalyst;net8.0-linux</TargetFrameworks>
+    <TargetFrameworks>net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.19041.0</TargetFrameworks>
     <UseMaui>true</UseMaui>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/docs/README.md
+++ b/docs/README.md
@@ -119,12 +119,14 @@ dotnet publish InvoiceApp.MAUI -f net8.0-windows10.0.19041.0 -c Release \
   -p:WindowsPackageType=MSIX
 ```
 
-macOS and Linux builds use the standard `dotnet publish` command:
+macOS builds use the standard `dotnet publish` command:
 
 ```bash
 dotnet publish InvoiceApp.MAUI -f net8.0-maccatalyst -c Release
-dotnet publish InvoiceApp.MAUI -f net8.0-linux -c Release
 ```
+
+> **Note:** Linux is not an officially supported MAUI target. Attempting to
+> publish with `net8.0-linux` results in `NETSDK1139`.
 
 ---
 

--- a/docs/README_hu.md
+++ b/docs/README_hu.md
@@ -73,12 +73,14 @@ dotnet publish InvoiceApp.MAUI -f net8.0-windows10.0.19041.0 -c Release \
   -p:WindowsPackageType=MSIX
 ```
 
-macOS és Linux esetén a szokásos `dotnet publish` használható:
+macOS esetén a szokásos `dotnet publish` használható:
 
 ```bash
 dotnet publish InvoiceApp.MAUI -f net8.0-maccatalyst -c Release
-dotnet publish InvoiceApp.MAUI -f net8.0-linux -c Release
 ```
+
+> **Megjegyzés:** A Linux célzás (`net8.0-linux`) jelenleg nem támogatott,
+> használata `NETSDK1139` hibát eredményez.
 
 ---
 

--- a/tests/InvoiceApp.MAUI.Tests/InvoiceApp.MAUI.Tests.csproj
+++ b/tests/InvoiceApp.MAUI.Tests/InvoiceApp.MAUI.Tests.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <IsPackable>false</IsPackable>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
## Summary
- update MAUI project to use official target frameworks
- fix async warning in `ServiceCollectionExtensions`
- adjust MAUI test project to target Windows
- clarify README sections about unsupported Linux target

## Testing
- `dotnet workload restore` *(succeeds)*
- `dotnet restore InvoiceApp.sln` *(fails: NETSDK1147 due to missing workloads)*
- `dotnet build InvoiceApp.sln -clp:ErrorsOnly` *(fails: NETSDK1147 due to missing workloads)*

------
https://chatgpt.com/codex/tasks/task_e_6874637ac644832289be27db120a72d0