### PR TITLE
Fix nullable warnings in tests

### DIFF
--- a/tests/InvoiceApp.Core.Tests/Data/WalPragmaInterceptorTests.cs
+++ b/tests/InvoiceApp.Core.Tests/Data/WalPragmaInterceptorTests.cs
@@ -18,7 +18,7 @@ public class WalPragmaInterceptorTests
         await using (var cmd = connection.CreateCommand())
         {
             cmd.CommandText = "PRAGMA journal_mode";
-            var initial = (string)await cmd.ExecuteScalarAsync();
+            var initial = (await cmd.ExecuteScalarAsync())?.ToString() ?? string.Empty;
             Assert.NotEqual("wal", initial.ToLowerInvariant());
         }
 
@@ -28,7 +28,7 @@ public class WalPragmaInterceptorTests
         await using (var cmd = connection.CreateCommand())
         {
             cmd.CommandText = "PRAGMA journal_mode";
-            var mode = (string)await cmd.ExecuteScalarAsync();
+            var mode = (await cmd.ExecuteScalarAsync())?.ToString() ?? string.Empty;
             Assert.Equal("wal", mode.ToLowerInvariant());
         }
     }

--- a/tests/InvoiceApp.Core.Tests/Infrastructure/WalPragmaTests.cs
+++ b/tests/InvoiceApp.Core.Tests/Infrastructure/WalPragmaTests.cs
@@ -27,9 +27,9 @@ public class WalPragmaTests
         var factory = provider.GetRequiredService<IDbContextFactory<AppDbContext>>();
         await using var ctx = await factory.CreateDbContextAsync();
         await ctx.Database.OpenConnectionAsync();
-        await using var cmd = ctx.Database.GetDbConnection().CreateCommand();
+        await using var cmd = ctx.Database.GetDbConnection()!.CreateCommand();
         cmd.CommandText = "PRAGMA journal_mode";
-        var mode = (string)await cmd.ExecuteScalarAsync();
+        var mode = (await cmd.ExecuteScalarAsync())?.ToString() ?? string.Empty;
         await ctx.Database.CloseConnectionAsync();
 
         Assert.Equal("wal", mode.ToLowerInvariant());

--- a/tests/InvoiceApp.Core.Tests/Services/DbHealthServiceTests.cs
+++ b/tests/InvoiceApp.Core.Tests/Services/DbHealthServiceTests.cs
@@ -52,13 +52,14 @@ public class DbHealthServiceTests
         {
             public FakeFacade(DbContext context) : base(context) { }
 
-            public new DbConnection GetDbConnection() => new FakeConnection();
-            public new Task OpenConnectionAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
-            public new Task CloseConnectionAsync() => Task.CompletedTask;
+            public DbConnection GetDbConnection() => new FakeConnection();
+            public Task OpenConnectionAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task CloseConnectionAsync() => Task.CompletedTask;
         }
 
         private class FakeConnection : DbConnection
         {
+#pragma warning disable CS8765
             public override string ConnectionString { get; set; } = string.Empty;
             public override string Database => string.Empty;
             public override string DataSource => string.Empty;
@@ -70,10 +71,12 @@ public class DbHealthServiceTests
             public override Task OpenAsync(CancellationToken cancellationToken) => Task.CompletedTask;
             protected override DbTransaction BeginDbTransaction(IsolationLevel isolationLevel) => throw new NotImplementedException();
             protected override DbCommand CreateDbCommand() => new FakeCommand();
+#pragma warning restore CS8765
         }
 
         private class FakeCommand : DbCommand
         {
+#pragma warning disable CS8765
             public override string CommandText { get; set; } = string.Empty;
             public override int CommandTimeout { get; set; }
             public override CommandType CommandType { get; set; }
@@ -89,10 +92,12 @@ public class DbHealthServiceTests
             protected override DbDataReader ExecuteDbDataReader(CommandBehavior behavior) => throw new NotImplementedException();
             public override void Prepare() { }
             protected override DbParameter CreateDbParameter() => new FakeParameter();
+#pragma warning restore CS8765
         }
 
         private class FakeParameter : DbParameter
         {
+#pragma warning disable CS8765
             public override DbType DbType { get; set; }
             public override ParameterDirection Direction { get; set; }
             public override bool IsNullable { get; set; }
@@ -102,10 +107,12 @@ public class DbHealthServiceTests
             public override void ResetDbType() { }
             public override int Size { get; set; }
             public override bool SourceColumnNullMapping { get; set; }
+#pragma warning restore CS8765
         }
 
         private class FakeParameterCollection : DbParameterCollection
         {
+#pragma warning disable CS8765 // Nullability of parameter doesn't match base member
             public override int Count => 0;
             public override object SyncRoot { get; } = new();
             public override int Add(object value) => 0;
@@ -128,6 +135,7 @@ public class DbHealthServiceTests
             protected override DbParameter GetParameter(string parameterName) => throw new NotImplementedException();
             protected override void SetParameter(int index, DbParameter value) { }
             protected override void SetParameter(string parameterName, DbParameter value) { }
+#pragma warning restore CS8765
         }
     }
 


### PR DESCRIPTION
## Summary
- adjust WAL tests for null safety
- silence DbHealthServiceTests mismatched nullability warnings

## Testing
- `dotnet build tests/InvoiceApp.Core.Tests/InvoiceApp.Core.Tests.csproj -v q`
- `dotnet test tests/InvoiceApp.Core.Tests/InvoiceApp.Core.Tests.csproj --no-build -v q` *(fails: DatabaseRecoveryServiceTests, ProductRepositoryTests, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_687469ab17288322a41e8ec076850600