### PR TITLE
bugfix: resolve duplicate EmbeddedResource

### DIFF
--- a/InvoiceApp.MAUI/InvoiceApp.MAUI.csproj
+++ b/InvoiceApp.MAUI/InvoiceApp.MAUI.csproj
@@ -18,9 +18,6 @@
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.0" />
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="Resources\Strings\UIStrings.hu.resx" />
-  </ItemGroup>
-  <ItemGroup>
     <MauiXaml Include="Resources\Styles\RetroTheme.xaml" />
     <MauiXaml Include="Views/Dialogs/SetupPage.xaml" />
     <MauiXaml Include="Views/Dialogs/SeedOptionsPage.xaml" />


### PR DESCRIPTION
## Summary
- remove explicit EmbeddedResource entry to avoid SDK duplicate warning

## Testing
- `dotnet clean InvoiceApp.sln`
- `dotnet test tests/InvoiceApp.Core.Tests/InvoiceApp.Core.Tests.csproj -v minimal` *(fails: 17 failed)*
- `dotnet test tests/InvoiceApp.MAUI.Tests/InvoiceApp.MAUI.Tests.csproj -v minimal` *(fails to build)*

------
https://chatgpt.com/codex/tasks/task_e_6874c361ea748322abb9c92008e33924