### PR TITLE
Fix duplicate resources

### DIFF
--- a/InvoiceApp.MAUI/InvoiceApp.MAUI.csproj
+++ b/InvoiceApp.MAUI/InvoiceApp.MAUI.csproj
@@ -18,12 +18,6 @@
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.0" />
   </ItemGroup>
   <ItemGroup>
-    <MauiXaml Include="Resources\Styles\RetroTheme.xaml" />
-    <MauiXaml Include="Views/Dialogs/SetupPage.xaml" />
-    <MauiXaml Include="Views/Dialogs/SeedOptionsPage.xaml" />
-    <MauiXaml Include="Views/Dialogs/UserInfoEditorPage.xaml" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\InvoiceApp.Core\InvoiceApp.Core.csproj" />
     <ProjectReference Include="..\InvoiceApp.Data\InvoiceApp.Data.csproj" />
   </ItemGroup>

--- a/InvoiceApp.MAUI/ViewModels/ProductMasterViewModel.cs
+++ b/InvoiceApp.MAUI/ViewModels/ProductMasterViewModel.cs
@@ -80,8 +80,9 @@ public ProductMasterViewModel(IProductService service, ITaxRateService taxRates,
         }
         catch (Exception ex)
         {
-            var log = MauiProgram.Services?.GetRequiredService<ILogService>();
-            await log.LogError("ProductMasterViewModel.EditSelected", ex);
+            var log = MauiProgram.Services?.GetService<ILogService>();
+            if (log is not null)
+                await log.LogError("ProductMasterViewModel.EditSelected", ex);
         }
     }
 }


### PR DESCRIPTION
## Summary
- remove explicit MauiXaml items that caused duplicate resources
- null-check log service on edit

## Testing
- `dotnet build InvoiceApp.sln -c Debug` *(fails: VisualElement not found)*
- `dotnet test tests/InvoiceApp.Core.Tests/InvoiceApp.Core.Tests.csproj` *(fails: tests failing)*
- `dotnet test tests/InvoiceApp.MAUI.Tests/InvoiceApp.MAUI.Tests.csproj` *(fails: VisualElement not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874ce53f15c8322b3b001245d9630f8