### PR TITLE
Fix build error in Program.cs

### DIFF
--- a/InvoiceApp.MAUI/Program.cs
+++ b/InvoiceApp.MAUI/Program.cs
@@ -3,7 +3,7 @@ using Microsoft.Maui.Hosting;
 
 namespace InvoiceApp.MAUI;
 
-public class Program : MauiWinUIApplication
+public class Program : MauiApplication
 {
     protected override MauiApp CreateMauiApp() => MauiProgram.CreateMauiApp();
 


### PR DESCRIPTION
## Summary
- ensure Program class derives from `MauiApplication`

## Testing
- `dotnet build InvoiceApp.sln -v minimal`
- `dotnet test tests/InvoiceApp.Core.Tests/InvoiceApp.Core.Tests.csproj -v minimal`
- `dotnet test -v minimal` *(fails: Microsoft.Maui references not found)*

------
https://chatgpt.com/codex/tasks/task_e_68752501dcc883228d667ef5a1381ec9