### PR TITLE
Fix MAUI keyboard namespace

### DIFF
--- a/InvoiceApp.MAUI/Services/InvoiceEditorKeyboardHandler.cs
+++ b/InvoiceApp.MAUI/Services/InvoiceEditorKeyboardHandler.cs
@@ -1,7 +1,6 @@
 using System;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Controls.Xaml;
-using Microsoft.Maui.Input;
 using InvoiceApp.MAUI.ViewModels;
 
 namespace InvoiceApp.MAUI.Services;

--- a/InvoiceApp.MAUI/Services/InvoiceLookupKeyboardHandler.cs
+++ b/InvoiceApp.MAUI/Services/InvoiceLookupKeyboardHandler.cs
@@ -1,4 +1,4 @@
-using Microsoft.Maui.Input;
+using Microsoft.Maui.Controls;
 using InvoiceApp.MAUI.ViewModels;
 
 namespace InvoiceApp.MAUI.Services;

--- a/InvoiceApp.MAUI/Services/KeyboardManager.cs
+++ b/InvoiceApp.MAUI/Services/KeyboardManager.cs
@@ -1,5 +1,5 @@
 using System.Collections.Generic;
-using Microsoft.Maui.Input;
+using Microsoft.Maui.Controls;
 using InvoiceApp.Core.Enums;
 
 namespace InvoiceApp.MAUI.Services;

--- a/InvoiceApp.MAUI/Services/MasterDataKeyboardHandler.cs
+++ b/InvoiceApp.MAUI/Services/MasterDataKeyboardHandler.cs
@@ -1,4 +1,4 @@
-using Microsoft.Maui.Input;
+using Microsoft.Maui.Controls;
 using CommunityToolkit.Mvvm.Input;
 using InvoiceApp.MAUI.ViewModels;
 

--- a/InvoiceApp.MAUI/Services/StageMenuKeyboardHandler.cs
+++ b/InvoiceApp.MAUI/Services/StageMenuKeyboardHandler.cs
@@ -1,5 +1,5 @@
 using System;
-using Microsoft.Maui.Input;
+using Microsoft.Maui.Controls;
 using CommunityToolkit.Mvvm.Input;
 using InvoiceApp.Core.Enums;
 using InvoiceApp.MAUI.ViewModels;

--- a/tests/InvoiceApp.MAUI.Tests/KeyboardManagerTests.cs
+++ b/tests/InvoiceApp.MAUI.Tests/KeyboardManagerTests.cs
@@ -1,6 +1,6 @@
 using InvoiceApp.Core.Enums;
 using InvoiceApp.MAUI.Services;
-using Microsoft.Maui.Input;
+using Microsoft.Maui.Controls;
 using Xunit;
 
 namespace InvoiceApp.Tests;


### PR DESCRIPTION
## Summary
- fix missing Microsoft.Maui.Input namespace errors by referencing `Microsoft.Maui.Controls`
- adjust corresponding test imports

## Testing
- `dotnet test tests/InvoiceApp.Core.Tests/InvoiceApp.Core.Tests.csproj --no-build -v n`
- `dotnet test tests/InvoiceApp.MAUI.Tests/InvoiceApp.MAUI.Tests.csproj --no-build` *(fails: Workload not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687529acb6c88322a346ed377823bf28