### PR TITLE
Fix MAUI stubs conflicts

### DIFF
--- a/InvoiceApp.MAUI/InvoiceApp.MAUI.csproj
+++ b/InvoiceApp.MAUI/InvoiceApp.MAUI.csproj
@@ -17,6 +17,13 @@
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.0" />
   </ItemGroup>
+  <!-- Exclude stub implementations when building with the real MAUI workload -->
+  <ItemGroup Condition="'$(UseMaui)'=='true'">
+    <Compile Remove="Stubs\**\*.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(UseMaui)'!='true'">
+    <Compile Include="Stubs\**\*.cs" />
+  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\InvoiceApp.Core\InvoiceApp.Core.csproj" />
     <ProjectReference Include="..\InvoiceApp.Data\InvoiceApp.Data.csproj" />


### PR DESCRIPTION
## Summary
- avoid compiling stub classes when MAUI workload is available

## Testing
- `dotnet test tests/InvoiceApp.MAUI.Tests/InvoiceApp.MAUI.Tests.csproj --logger "trx" -v m` *(fails: The type or namespace name 'Maui' does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_6875329d8d048322b3098d5d1641c0ca