### PR TITLE
Fix Maui stubs inclusion

### DIFF
--- a/InvoiceApp.MAUI/InvoiceApp.MAUI.csproj
+++ b/InvoiceApp.MAUI/InvoiceApp.MAUI.csproj
@@ -21,9 +21,6 @@
   <ItemGroup Condition="'$(UseMaui)'=='true'">
     <Compile Remove="Stubs\**\*.cs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(UseMaui)'!='true'">
-    <Compile Include="Stubs\**\*.cs" />
-  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\InvoiceApp.Core\InvoiceApp.Core.csproj" />
     <ProjectReference Include="..\InvoiceApp.Data\InvoiceApp.Data.csproj" />


### PR DESCRIPTION
## Summary
- avoid duplicate compile entries for Maui stubs

## Testing
- `dotnet build --no-restore /p:UseMaui=false`
- `dotnet test tests/InvoiceApp.MAUI.Tests/InvoiceApp.MAUI.Tests.csproj --no-build /p:UseMaui=false` *(fails: no output)*

------
https://chatgpt.com/codex/tasks/task_e_687536b4e0d0832281dfdc79a309f0d4