### PR TITLE
Fix MAUI build defaults

### DIFF
--- a/InvoiceApp.MAUI/InvoiceApp.MAUI.csproj
+++ b/InvoiceApp.MAUI/InvoiceApp.MAUI.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net8.0-windows10.0.19041.0</TargetFrameworks>
-    <UseMaui>true</UseMaui>
+    <UseMaui Condition="'$(UseMaui)'==''">false</UseMaui>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <SingleProject>true</SingleProject>


### PR DESCRIPTION
## Summary
- set UseMaui to false by default so stubs are used when the MAUI workload isn't installed

## Testing
- `dotnet build InvoiceApp.sln -c Debug`
- `dotnet test tests/InvoiceApp.Core.Tests/InvoiceApp.Core.Tests.csproj` *(fails: 17, passed: 86)*
- `dotnet test tests/InvoiceApp.MAUI.Tests/InvoiceApp.MAUI.Tests.csproj` *(fails to build)*

------
https://chatgpt.com/codex/tasks/task_e_68753e053d988322ae4940e81a27bf60