### PR TITLE
Fix stale MAUI code conflicts

### DIFF
--- a/InvoiceApp.MAUI/InvoiceApp.MAUI.csproj
+++ b/InvoiceApp.MAUI/InvoiceApp.MAUI.csproj
@@ -21,6 +21,10 @@
   <ItemGroup Condition="'$(UseMaui)'=='true'">
     <Compile Remove="Stubs\**\*.cs" />
   </ItemGroup>
+  <!-- Ensure stale MAUI-generated files are not compiled when stubs are used -->
+  <ItemGroup Condition="'$(UseMaui)'!='true'">
+    <Compile Remove="obj\**\Microsoft.Maui.Controls.SourceGen\**\*.cs" />
+  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\InvoiceApp.Core\InvoiceApp.Core.csproj" />
     <ProjectReference Include="..\InvoiceApp.Data\InvoiceApp.Data.csproj" />


### PR DESCRIPTION
## Summary
- clean MAUI generated files when building without the MAUI workload

## Testing
- `dotnet build InvoiceApp.sln -c Debug`
- `dotnet test tests/InvoiceApp.Core.Tests/InvoiceApp.Core.Tests.csproj --no-build -v minimal` *(fails: DatabaseRecoveryServiceTests.CheckAndRecoverAsync_RestoresData, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68754082a86083228b9a8188fa8a5f6b