### PR TITLE
Enable MAUI runtime by default

### DIFF
--- a/InvoiceApp.MAUI/InvoiceApp.MAUI.csproj
+++ b/InvoiceApp.MAUI/InvoiceApp.MAUI.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net8.0-windows10.0.19041.0</TargetFrameworks>
-    <UseMaui Condition="'$(UseMaui)'==''">false</UseMaui>
+    <UseMaui Condition="'$(UseMaui)'==''">true</UseMaui>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <SingleProject>true</SingleProject>


### PR DESCRIPTION
## Summary
- use the real MAUI runtime by default so the main window appears

## Testing
- `dotnet test tests/InvoiceApp.Core.Tests/InvoiceApp.Core.Tests.csproj` *(fails: 17 failed, 86 passed)*

------
https://chatgpt.com/codex/tasks/task_e_687544d0c9b48322bf01569aeb7c16b7