### PR TITLE
Fix KeyEventArgs missing under Windows

### DIFF
--- a/InvoiceApp.MAUI/InvoiceApp.MAUI.csproj
+++ b/InvoiceApp.MAUI/InvoiceApp.MAUI.csproj
@@ -25,6 +25,7 @@
   <!-- Exclude stub implementations when building with the real MAUI workload -->
   <ItemGroup Condition="'$(UseMaui)'=='true'">
     <Compile Remove="Stubs\**\*.cs" />
+    <Compile Include="Platforms/WinKeyStubs.cs" />
   </ItemGroup>
   <!-- Ensure stale MAUI-generated files are not compiled when stubs are used -->
   <ItemGroup Condition="'$(UseMaui)'!='true'">

--- a/InvoiceApp.MAUI/Platforms/WinKeyStubs.cs
+++ b/InvoiceApp.MAUI/Platforms/WinKeyStubs.cs
@@ -1,0 +1,28 @@
+#if WINDOWS
+namespace Microsoft.Maui.Controls
+{
+    public class KeyEventArgs : System.EventArgs
+    {
+        public Key Key { get; }
+        public bool IsDown { get; }
+        public KeyEventArgs(Key key, bool isDown)
+        {
+            Key = key;
+            IsDown = isDown;
+        }
+    }
+
+    public enum Key
+    {
+        None,
+        A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z,
+        Up,
+        Down,
+        Insert,
+        Delete,
+        Enter,
+        Return,
+        Escape
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- ensure KeyEventArgs and Key enum exist when the MAUI runtime is available
- compile new stub on Windows builds

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687e737579b48322a3da37f26e98ffae