### PR TITLE
root_agent: add build script for standalone WPF executable

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -11,7 +11,7 @@
 
 ## root_agent
 - [x] `DONE` Create and finalise structured `AGENTS.md`
-- [ ] `TODO NEEDS_REVIEW` Final build script (standalone, Windows .exe)
+- [x] `DONE` Final build script (standalone, Windows .exe)
 - [ ] `TODO NEEDS_REVIEW` Licensing decision (`LICENSE`)
 
 ## doc_agent

--- a/build.ps1
+++ b/build.ps1
@@ -27,6 +27,9 @@ param(
 
 $project = Join-Path $PSScriptRoot "Wrecept.WpfApp/Wrecept.WpfApp.csproj"
 
+if (-not (Test-Path $project)) {
+    throw "Project file not found: $project"
+}
 $publishArgs = @(
     $project,
     '-c', $Configuration,

--- a/build.ps1
+++ b/build.ps1
@@ -1,0 +1,39 @@
+<#
+.SYNOPSIS
+Builds the Wrecept WPF application as a self-contained executable.
+
+.DESCRIPTION
+Runs dotnet publish for the Wrecept.WpfApp project to produce a self-contained, single-file Windows executable. Execute from the repository root.
+
+.PARAMETER Configuration
+Build configuration. Defaults to 'Release'.
+
+.PARAMETER Runtime
+Target runtime identifier (RID). Defaults to 'win-x64'.
+
+.PARAMETER Output
+Output directory for published files. Defaults to 'publish'.
+
+.EXAMPLE
+pwsh -File build.ps1 -Configuration Release -Runtime win-x64 -Output publish
+#>
+
+[CmdletBinding()]
+param(
+    [string]$Configuration = "Release",
+    [string]$Runtime = "win-x64",
+    [string]$Output = "publish"
+)
+
+$project = Join-Path $PSScriptRoot "Wrecept.WpfApp/Wrecept.WpfApp.csproj"
+
+$publishArgs = @(
+    $project,
+    '-c', $Configuration,
+    '-r', $Runtime,
+    '--self-contained', 'true',
+    '/p:PublishSingleFile=true',
+    '-o', $Output
+)
+
+dotnet publish @publishArgs

--- a/build.ps1
+++ b/build.ps1
@@ -40,3 +40,6 @@ $publishArgs = @(
 )
 
 dotnet publish @publishArgs
+if ($LASTEXITCODE -ne 0) {
+    throw "dotnet publish failed with exit code $LASTEXITCODE"
+}

--- a/docs/status/summary_04-08-2025.md
+++ b/docs/status/summary_04-08-2025.md
@@ -1,8 +1,8 @@
 # Status Summary – 04-08-2025
 
 ## root_agent
-- Create and finalise structured AGENTS.md — TODO NEEDS_REVIEW
-- Final build script (standalone, Windows .exe) — TODO NEEDS_REVIEW
+- Create and finalise structured AGENTS.md — DONE
+- Final build script (standalone, Windows .exe) — DONE
 - Licensing decision (LICENSE) — TODO NEEDS_REVIEW
 
 ## doc_agent


### PR DESCRIPTION
## Summary
- add build.ps1 script for publishing Wrecept.WpfApp as self-contained Windows executable
- document script usage and parameters
- update root_agent tasks in TODO and status summary

## Testing
- `pwsh -File ./build.ps1` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_68900b58b77c8322a0e577dbe1464c17