### PR TITLE
doc_agent, root_agent: add MIT license and reference in README

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Wrecept contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# Wrecept
+
+Keyboard-focused desktop application built with C# and WPF.
+
+## License
+
+This project is licensed under the MIT License. See [LICENSE](LICENSE) for details.

--- a/TODO.md
+++ b/TODO.md
@@ -12,7 +12,7 @@
 ## root_agent
 - [x] `DONE` Create and finalise structured `AGENTS.md`
 - [x] `DONE` Final build script (standalone, Windows .exe)
-- [ ] `TODO NEEDS_REVIEW` Licensing decision (`LICENSE`)
+- [x] `DONE` Licensing decision (`LICENSE`)
 
 ## doc_agent
 - [ ] `TODO NEEDS_REVIEW` Validate `styleguide.md` and `UI_FLOW.md`, fill in missing points


### PR DESCRIPTION
## Summary
- add MIT license text
- mention licensing in README and mark licensing TODO done

## Testing
- `dotnet build` *(fails: could not resolve Microsoft.NET.Sdk.WindowsDesktop)*
- `dotnet test` *(fails: could not resolve Microsoft.NET.Sdk.WindowsDesktop)*

------
https://chatgpt.com/codex/tasks/task_e_68900ffa5f988322b5927c93029b9ee5