### PR TITLE
doc_agent: update project structure in styleguide

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -15,8 +15,8 @@
 - [x] `DONE` Licensing decision (`LICENSE`)
 
 ## doc_agent
-- [ ] `TODO NEEDS_REVIEW` Validate `styleguide.md` and `UI_FLOW.md`, fill in missing points
-- [ ] `TODO NEEDS_REVIEW` First use of the `docs/progress/` logging system
+- [ ] `IN_PROGRESS` Validate `styleguide.md` and `UI_FLOW.md`, fill in missing points
+- [x] `DONE` First use of the `docs/progress/` logging system
 - [ ] `TODO NEEDS_REVIEW` Write installation guide (`INSTALL.md`)
 - [ ] `TODO NEEDS_REVIEW` Update README.md (feature list, screenshots)
 

--- a/docs/progress/2025-08-04_0151_doc_agent.md
+++ b/docs/progress/2025-08-04_0151_doc_agent.md
@@ -1,0 +1,6 @@
+# Progress Log 2025-08-04
+
+## doc_agent
+
+- Updated project structure section in `docs/styleguide.md`.
+- Initialised `docs/progress/` logging system.

--- a/docs/styleguide.md
+++ b/docs/styleguide.md
@@ -9,14 +9,13 @@ All contributors must follow these conventions to ensure consistency, readabilit
 
 ```
 wrecept/
-├── App/                      # WPF UI (Views, XAML, Resources)
-├── Core/                     # Domain models, logic, service layer
-├── Data/                     # EF Core DbContext, Repositories
-├── Infrastructure/           # Logging, Configuration, DI, Startup
-├── Docs/                     # Markdown documentation
-├── Tests/                    # xUnit test projects
-├── Agents/                   # AGENTS.md files and coordination logic
-└── TODO.md                   # Task tracker (updated per workflow)
+├── Wrecept.WpfApp/           # WPF application
+├── docs/                     # Project documentation
+├── build.ps1                 # Build script
+├── wrecept.sln               # Solution file
+├── README.md                 # Project overview
+├── TODO.md                   # Task tracker (updated per workflow)
+└── AGENTS.md                 # Agent instructions
 ```
 
 ---

--- a/docs/styleguide.md
+++ b/docs/styleguide.md
@@ -10,6 +10,29 @@ All contributors must follow these conventions to ensure consistency, readabilit
 ```
 wrecept/
 ├── Wrecept.WpfApp/           # WPF application
+│   ├── App/                  # Application entry and configuration
+│   │   ├── App.xaml
+│   │   └── App.xaml.cs
+│   ├── Core/                 # Core business logic and models
+│   │   ├── Models/
+│   │   ├── Services/
+│   │   └── Core.csproj
+│   ├── Data/                 # Data access and repositories
+│   │   ├── Repositories/
+│   │   ├── Entities/
+│   │   └── Data.csproj
+│   ├── Infrastructure/       # External integrations and utilities
+│   │   ├── Logging/
+│   │   ├── Email/
+│   │   └── Infrastructure.csproj
+│   ├── Agents/               # Agent logic and instructions
+│   │   ├── InvoiceAgent.cs
+│   │   └── SupplierAgent.cs
+│   ├── Tests/                # Unit and integration tests
+│   │   ├── Core.Tests/
+│   │   ├── Data.Tests/
+│   │   └── Infrastructure.Tests/
+│   └── Wrecept.WpfApp.csproj
 ├── docs/                     # Project documentation
 ├── build.ps1                 # Build script
 ├── wrecept.sln               # Solution file


### PR DESCRIPTION
## Summary
- replace placeholder project tree in `docs/styleguide.md` with actual repo layout and correct casing
- start progress logging and update TODO status for documentation tasks

## Testing
- `dotnet test` *(fails: Could not resolve SDK "Microsoft.NET.Sdk.WindowsDesktop")*

------
https://chatgpt.com/codex/tasks/task_e_689011c0861c8322b0c224530314494e