### PR TITLE
doc_agent: add installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Wrecept is an offline-first invoicing desktop application built with C# (.NET 8)
 
 ## Installation
 
-> **Note:** A detailed installation guide will be added soon. For now, ensure you have .NET 8 SDK installed and run the application by building the solution.
+See the [installation guide](docs/INSTALL.md) for prerequisites and step-by-step setup instructions. In short, ensure the .NET 8 SDK is installed and run the application by building the solution.
 
 ## Progress Logs
 

--- a/TODO.md
+++ b/TODO.md
@@ -18,7 +18,7 @@
 - [ ] `IN_PROGRESS` Validate `styleguide.md` and `UI_FLOW.md`, fill in missing points
 - [x] `DONE` First use of the `docs/progress/` logging system
 - [x] `DONE` Mention progress logs in `README.md`
-- [ ] `TODO NEEDS_REVIEW` Write installation guide (`INSTALL.md`)
+- [x] `DONE` Write installation guide (`INSTALL.md`)
 - [ ] `TODO NEEDS_REVIEW` Update README.md (feature list, screenshots)
 
 ## logic_agent

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -1,0 +1,43 @@
+# Installation Guide
+
+Follow these steps to set up **Wrecept** on your machine.
+
+## Prerequisites
+
+- Windows 10 or later
+- [.NET 8 SDK](https://dotnet.microsoft.com/en-us/download)
+- Git
+- [PowerShell 7](https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell) (optional, for build script)
+- Visual Studio 2022 or later (optional)
+
+## Build and Run
+
+1. Clone the repository:
+   ```bash
+   git clone https://github.com/yourusername/wrecept.git
+   cd wrecept
+   ```
+2. Restore dependencies:
+   ```bash
+   dotnet restore
+   ```
+3. Build the solution:
+   ```bash
+   dotnet build
+   ```
+4. Run the application:
+   ```bash
+   dotnet run --project Wrecept.WpfApp
+   ```
+
+## Publish a Self-contained Build
+
+To create a standalone Windows executable:
+
+```powershell
+pwsh -File build.ps1 -Configuration Release -Runtime win-x64 -Output publish
+```
+
+The published files will appear in the specified output directory.
+
+---

--- a/docs/progress/2025-08-04_0658_doc_agent.md
+++ b/docs/progress/2025-08-04_0658_doc_agent.md
@@ -1,0 +1,7 @@
+# Progress Log 2025-08-04
+
+## doc_agent
+
+- Added installation guide (`docs/INSTALL.md`) with prerequisites and build steps. Ref: TODO Write installation guide.
+- Linked installation guide from `README.md`.
+- Marked installation guide task as complete in `TODO.md`.

--- a/docs/progress/progress_2025-08-04.md
+++ b/docs/progress/progress_2025-08-04.md
@@ -4,3 +4,4 @@
 
 - Established milestone tracking with a dated progress file.
 - Referenced progress logs in the project README.
+- Added installation guide and linked it from the README.


### PR DESCRIPTION
## Summary
- document installation prerequisites and build steps in `docs/INSTALL.md`
- link installation guide from `README.md`
- mark installation task complete in `TODO.md` and log progress

## Testing
- `dotnet build` *(fails: Could not resolve SDK "Microsoft.NET.Sdk.WindowsDesktop"; no Windows Desktop SDK in environment)*

------
https://chatgpt.com/codex/tasks/task_e_689059b5df3c8322bd378f3c54c15b55