### PR TITLE
docs: enforce keyboard-only UI flow

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -16,7 +16,7 @@
 - [x] `DONE` Separate WPF UI into `Wrecept.UI` and create `Wrecept.Core.sln`
 
 ## doc_agent
-- [ ] `IN_PROGRESS NEEDS_REVIEW` Validate `styleguide.md` and `UI_FLOW.md`, fill in missing points
+- [x] `DONE` Validate `styleguide.md` and `UI_FLOW.md`, fill in missing points
 - [x] `DONE` First use of the `docs/progress/` logging system
 - [x] `DONE` Mention progress logs in `README.md`
 - [x] `DONE` Write installation guide (`INSTALL.md`)

--- a/docs/UI_FLOW.md
+++ b/docs/UI_FLOW.md
@@ -1,50 +1,75 @@
-UI_FLOW.md
+# UI Flow
 
-🧱 Overview
+<!-- markdownlint-disable MD013 -->
 
-This document describes the workflow of the Wrecept user interface. It details the navigation model, expected behaviors, and data entry steps, in line with inline editing support.
+## 🧱 Overview
 
-📌 Navigation model
+This document describes the workflow of the Wrecept user interface. It details the
+navigation model, expected behaviors, and data entry steps, in line with inline
+editing support.
 
-When launched, an empty screen appears with the Accounts menu item selected in the top menu bar.
+## 📌 Navigation model
 
-📀 Screen layouts
+Navigation is strictly keyboard-based. Press `Enter` to move forward or confirm,
+and `Escape` to move back or cancel. Mouse input and the `Tab` key are not used.
 
-🔳 Main menu flow
+## 📀 Screen layouts
+
+### 🔳 Main menu flow
 
 ┌──────────────────────────────────────────────────────┐
-│ [Accounts] [Stocks] [Lists] [Maintenance] [Contacts]│
+│ [Accounts] [Stocks] [Lists] [Maintenance] [Contacts] │
 │                                                      │
-│ > Incoming delivery notes │
+│ > Incoming delivery notes                            │
 └──────────────────────────────────────────────────────┘
 
-🧾 Invoice editor view
+### 🧾 Invoice editor view
 
 ┌───── List ────┬──────── Invoice editor ───────────────┐
-│ [Invoice number] │ Supplier: [              ] │
-│ [Date]        │ Date:    [2025-08-04  ] │
-│ [Supplier] │ Number: [              ] │
-│                │ Payment method: [            ][ ] Net invoice │
-│                ├──────────────────────────────────────────┤
-│                │ Product  Qty. Group Unit price  VAT │
-│                │ [Edit] [  1] ... │
-│                │ ... Previously entered lines ... │
-│                │                                            │
-└────────────────┴──────────────────────────────────────────┘
+│ [Invoice number] │ Supplier: [              ]        │
+│ [Date]           │ Number:   [              ]        │
+│ [Supplier]       │ Payment method: [        ][ ] Net │
+│                  ├───────────────────────────────────┤
+│                  │ Product  Qty. Group Unit price VAT│
+│                  │ [Edit] [ 1] ...                   │
+│                  │ ... Previously entered lines ...  │
+│                  │                                   │
+└──────────────────┴───────────────────────────────────┘
 
-📌 Restrictions
+## Invoice entry workflow
 
-- Archiving can only be done according to business rules and cannot be modified afterwards.
+1. From the main menu, start a new invoice with `Enter`.
+2. `Invoice No` field is focused; type the value and press `Enter`.
+3. `Date` accepts manual input; press `Enter` to continue.
+4. In `Customer`, type letters and press `Enter` to accept the first match.
+5. `Customer ID` auto-fills; press `Enter` to proceed to the item grid.
+6. For each item row:
+   - Enter item code and press `Enter`.
+   - Description fills automatically; press `Enter`.
+   - Enter quantity, then `Enter`.
+   - Enter unit price, then `Enter`.
+   - Tax rate is selected automatically; press `Enter` to accept.
+   - Press `Enter` at the end of the row to add a new one.
+   - Press `Escape` on an empty row to remove it.
+7. Move to `[Save]` and press `Enter` to store the invoice; `Escape` cancels.
+8. After saving, focus returns to the invoice list.
+
+## 📌 Restrictions
+
+- Archiving can only be done according to business rules and cannot be modified
+  afterwards.
 - The Gross designation determines the pricing throughout.
-- The interface must always reflect which operations are available in the current state.
+- The interface must always reflect which operations are available in the current
+  state.
+
 ### Recording owner data
 
-When first launched, `UserInfoWindow` requests the company details. The fields are mandatory, after the
-last
-field the focus moves to the `OK` button and a confirmation message appears:
-"Are the details correct?". `Enter` accepts, `Escape` takes you back to the previous field
-. All required fields are highlighted in red until they are filled in.
-It then checks the database for the entry and, if it does not exist, creates it after confirmation.
+When first launched, `UserInfoWindow` requests the company details. The fields are
+mandatory. After the last field, the focus moves to the `OK` button and a
+confirmation message appears: "Are the details correct?". `Enter` accepts,
+`Escape` returns to the previous field. All required fields are highlighted in red
+until they are filled in. The program checks the database for the entry and
+creates it after confirmation if it does not exist.
 
 For later modifications, the *Service / Edit owner...* menu item opens the same
 `UserInfoWindow` dialog.

--- a/docs/UI_FLOW.md
+++ b/docs/UI_FLOW.md
@@ -41,7 +41,7 @@ and `Escape` to move back or cancel. Mouse input and the `Tab` key are not used.
 1. From the main menu, start a new invoice with `Enter`.
 2. `Invoice No` field is focused; type the value and press `Enter`.
 3. `Date` accepts manual input; press `Enter` to continue.
-4. In `Customer`, type letters and press `Enter` to accept the first match.
+4. In `Supplier`, type letters and press `Enter` to accept the first match.
 5. `Customer ID` auto-fills; press `Enter` to proceed to the item grid.
 6. For each item row:
    - Enter item code and press `Enter`.

--- a/docs/progress/2025-08-04_1200_doc_agent.md
+++ b/docs/progress/2025-08-04_1200_doc_agent.md
@@ -1,0 +1,5 @@
+# Progress Log 2025-08-04
+
+## doc_agent
+
+- Validated `styleguide.md` and expanded `UI_FLOW.md` based on invoice workflow; removed mouse and Tab references. Ref: TODO doc_agent.

--- a/docs/styleguide.md
+++ b/docs/styleguide.md
@@ -1,13 +1,16 @@
 ﻿# Style Guide for `wrecept`
 
-This style guide defines the standards for code, documentation, and UI design used throughout the `wrecept` project.
-All contributors must follow these conventions to ensure consistency, readability, and maintainability across the codebase.
+<!-- markdownlint-disable MD013 -->
+
+This style guide defines the standards for code, documentation, and UI design used
+throughout the `wrecept` project. All contributors must follow these conventions to
+ensure consistency, readability, and maintainability across the codebase.
 
 ---
 
 ## 📁 Project Structure
 
-```
+```text
 wrecept/
 ├── Wrecept.WpfApp/           # WPF application
 │   ├── App/                  # Application entry and configuration
@@ -39,7 +42,7 @@ wrecept/
 ├── README.md                 # Project overview
 ├── TODO.md                   # Task tracker (updated per workflow)
 └── AGENTS.md                 # Agent instructions
-```
+```text
 
 ---
 
@@ -161,7 +164,7 @@ wrecept/
 
 **Example:**
 
-```
+```text
 [core] Implemented invoice total recalculation logic
 Ref: TODO #42, Milestone: stage-3
 ```
@@ -170,10 +173,11 @@ Ref: TODO #42, Milestone: stage-3
 
 ## 📋 UI/UX Workflow Rules
 
-* No console output allowed in production builds
-* All messages must be in **Hungarian**, and shown in dialog if user-facing
-* Use Enter/Esc navigation for confirmation dialogs
-* Do not block UI thread (use async where needed)
+* Interaction is strictly keyboard-based; mouse input is not used.
+* `Enter` confirms and advances; `Escape` cancels or moves back. `Tab` is disabled.
+* No console output allowed in production builds.
+* All messages must be in **Hungarian**, and shown in dialog if user-facing.
+* Do not block UI thread (use async where needed).
 
 ---
 


### PR DESCRIPTION
## Summary
- clarify keyboard-only rules in styleguide and prohibit mouse/Tab usage
- expand UI flow with invoice entry steps using only Enter and Escape
- record doc_agent progress and close TODO

## Testing
- `markdownlint docs/styleguide.md docs/UI_FLOW.md`
- `dotnet test Wrecept.Core.sln --filter "Category!=UI"`


------
https://chatgpt.com/codex/tasks/task_e_6894feb36354832283be1a3fb22a3ece