### PR TITLE
test_agent: fix Appium WindowsDriver references

### DIFF
--- a/tests/Wrecept.UI.AutomatedTests/MainViewTests.cs
+++ b/tests/Wrecept.UI.AutomatedTests/MainViewTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using OpenQA.Selenium;
+using OpenQA.Selenium.Appium;
 using OpenQA.Selenium.Appium.Windows;
 
 namespace Wrecept.UI.AutomatedTests;
@@ -30,7 +31,7 @@ public class MainViewTests : IDisposable
             Arguments = "127.0.0.1 4723"
         });
 
-        var options = new OpenQA.Selenium.Appium.AppiumOptions();
+        var options = new AppiumOptions();
         // Get Wrecept.exe path from environment variable or use default relative path
         var exePath = Environment.GetEnvironmentVariable("WRECEPT_EXE_PATH");
         if (string.IsNullOrWhiteSpace(exePath))
@@ -38,7 +39,7 @@ public class MainViewTests : IDisposable
             exePath = Path.GetFullPath(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, @"..\..\..\..\wrecept\bin\Debug\net8.0-windows\Wrecept.exe"));
         }
         options.AddAdditionalCapability("app", exePath);
-        _session = new WindowsDriver(new Uri("http://127.0.0.1:4723"), options);
+        _session = new WindowsDriver<WindowsElement>(new Uri("http://127.0.0.1:4723"), options);
     }
 
     [SkippableFact(DisplayName = "F2 új sor hozzáadása működik")]

--- a/tests/Wrecept.UI.AutomatedTests/Wrecept.UI.AutomatedTests.csproj
+++ b/tests/Wrecept.UI.AutomatedTests/Wrecept.UI.AutomatedTests.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
-    <PackageReference Include="Appium.WebDriver" Version="5.2.0" />
+    <PackageReference Include="Appium.WebDriver" Version="4.4.5" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Wrecept.UI.AutomatedTests/Wrecept.UI.AutomatedTests.csproj
+++ b/tests/Wrecept.UI.AutomatedTests/Wrecept.UI.AutomatedTests.csproj
@@ -8,6 +8,11 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <!--
+      Downgraded Appium.WebDriver from 5.2.0 to 4.4.5 due to compatibility issues with our current test infrastructure and dependencies.
+      Please review before upgrading, as newer versions may introduce breaking changes or incompatibilities.
+      Be aware that this may miss security updates or bug fixes present in later versions.
+    -->
     <PackageReference Include="Appium.WebDriver" Version="4.4.5" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">


### PR DESCRIPTION
## Summary
- reference Appium.WebDriver 4.4.5 for Windows UI tests
- fix MainViewTests to use WindowsDriver<WindowsElement> with Appium namespaces

## Testing
- `dotnet restore tests/Wrecept.UI.AutomatedTests/Wrecept.UI.AutomatedTests.csproj -p:EnableWindowsTargeting=true`
- `dotnet test tests/Wrecept.UI.AutomatedTests/Wrecept.UI.AutomatedTests.csproj -p:EnableWindowsTargeting=true`

------
https://chatgpt.com/codex/tasks/task_e_689502e28f7c83228221a3897363c557