### PR TITLE
domain_agent: add core domain entities with validations

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -33,7 +33,7 @@
 - [x] `DONE` EF Core configuration (relationships, validation)
 
 ## domain_agent
-*(no open tasks)*
+- [x] `DONE` Initial core domain entities with validations
 
 ## ui_agent
 - [ ] `TODO NEEDS_REVIEW` Basic `MainView` + `InvoiceEditorView` XAML layout
@@ -43,6 +43,7 @@
 - [ ] `TODO NEEDS_REVIEW` Confirmation popups for all critical actions
 
 ## test_agent
+- [x] `DONE` Unit tests for domain layer
 - [ ] `TODO NEEDS_REVIEW` Unit tests for the Service layer
 - [ ] `TODO NEEDS_REVIEW` Database validations (error handling + rollback)
 - [ ] `TODO NEEDS_REVIEW` Testing keyboard navigation logic on different views

--- a/Wrecept.Core.sln
+++ b/Wrecept.Core.sln
@@ -7,6 +7,12 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Wrecept.Core", "Wrecept.Cor
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Wrecept.Core.Tests", "Wrecept.Core.Tests\Wrecept.Core.Tests.csproj", "{3E7FA333-5A11-40E6-879B-FB4FF3ED9F8B}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{671426C9-0B7C-4D80-BC16-79E8929B1DA0}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Wrecept.Domain", "src\Wrecept.Domain\Wrecept.Domain.csproj", "{1A3175E6-6CD3-41C0-9CA3-F1E36FDDDCED}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Wrecept.Domain.Tests", "Wrecept.Domain.Tests\Wrecept.Domain.Tests.csproj", "{F9FE5E15-4841-48EE-977C-8C363EF5EEBA}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -24,5 +30,16 @@ Global
 		{3E7FA333-5A11-40E6-879B-FB4FF3ED9F8B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3E7FA333-5A11-40E6-879B-FB4FF3ED9F8B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3E7FA333-5A11-40E6-879B-FB4FF3ED9F8B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1A3175E6-6CD3-41C0-9CA3-F1E36FDDDCED}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1A3175E6-6CD3-41C0-9CA3-F1E36FDDDCED}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1A3175E6-6CD3-41C0-9CA3-F1E36FDDDCED}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1A3175E6-6CD3-41C0-9CA3-F1E36FDDDCED}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F9FE5E15-4841-48EE-977C-8C363EF5EEBA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F9FE5E15-4841-48EE-977C-8C363EF5EEBA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F9FE5E15-4841-48EE-977C-8C363EF5EEBA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F9FE5E15-4841-48EE-977C-8C363EF5EEBA}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{1A3175E6-6CD3-41C0-9CA3-F1E36FDDDCED} = {671426C9-0B7C-4D80-BC16-79E8929B1DA0}
 	EndGlobalSection
 EndGlobal

--- a/Wrecept.Domain.Tests/CustomerTests.cs
+++ b/Wrecept.Domain.Tests/CustomerTests.cs
@@ -1,0 +1,29 @@
+using Wrecept.Domain;
+
+namespace Wrecept.Domain.Tests;
+
+public class CustomerTests
+{
+    [Fact]
+    public void Constructor_EmptyId_Throws()
+    {
+        Assert.Throws<ArgumentException>(() => new Customer(Guid.Empty, "Name"));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Constructor_EmptyName_Throws(string name)
+    {
+        Assert.Throws<ArgumentException>(() => new Customer(Guid.NewGuid(), name));
+    }
+
+    [Fact]
+    public void Constructor_Valid_SetsProperties()
+    {
+        var id = Guid.NewGuid();
+        var customer = new Customer(id, "Alice");
+        Assert.Equal(id, customer.Id);
+        Assert.Equal("Alice", customer.Name);
+    }
+}

--- a/Wrecept.Domain.Tests/GlobalUsings.cs
+++ b/Wrecept.Domain.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/Wrecept.Domain.Tests/InvoiceLineTests.cs
+++ b/Wrecept.Domain.Tests/InvoiceLineTests.cs
@@ -1,0 +1,49 @@
+using Wrecept.Domain;
+
+namespace Wrecept.Domain.Tests;
+
+public class InvoiceLineTests
+{
+    private static Product SampleProduct() => new(Guid.NewGuid(), "Prod", new Money("USD", 1m), new TaxRate(Guid.NewGuid(), "T", 0.2m));
+
+    [Fact]
+    public void Constructor_NullProduct_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => new InvoiceLine(null!, 1, new Money("USD", 1m)));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Constructor_NonPositiveQuantity_Throws(int qty)
+    {
+        var product = SampleProduct();
+        var price = new Money("USD", 1m);
+        Assert.Throws<ArgumentOutOfRangeException>(() => new InvoiceLine(product, qty, price));
+    }
+
+    [Fact]
+    public void Constructor_NullUnitPrice_Throws()
+    {
+        var product = SampleProduct();
+        Assert.Throws<ArgumentNullException>(() => new InvoiceLine(product, 1, null!));
+    }
+
+    [Fact]
+    public void Constructor_NonPositiveUnitPrice_Throws()
+    {
+        var product = SampleProduct();
+        var price = new Money("USD", 0m);
+        Assert.Throws<ArgumentException>(() => new InvoiceLine(product, 1, price));
+    }
+
+    [Fact]
+    public void Total_ReturnsQuantityTimesPrice()
+    {
+        var product = SampleProduct();
+        var price = new Money("USD", 2m);
+        var line = new InvoiceLine(product, 3, price);
+        Assert.Equal(6m, line.Total.Amount);
+        Assert.Equal("USD", line.Total.Currency);
+    }
+}

--- a/Wrecept.Domain.Tests/InvoiceTests.cs
+++ b/Wrecept.Domain.Tests/InvoiceTests.cs
@@ -1,0 +1,62 @@
+using Wrecept.Domain;
+
+namespace Wrecept.Domain.Tests;
+
+public class InvoiceTests
+{
+    private static Product SampleProduct(string currency = "USD") => new(Guid.NewGuid(), "Prod", new Money(currency, 1m), new TaxRate(Guid.NewGuid(), "T", 0.2m));
+    private static InvoiceLine SampleLine(string currency = "USD", int qty = 1, decimal price = 1m)
+    {
+        var product = SampleProduct(currency);
+        return new InvoiceLine(product, qty, new Money(currency, price));
+    }
+
+    [Fact]
+    public void Constructor_EmptyId_Throws()
+    {
+        var customer = new Customer(Guid.NewGuid(), "Cust");
+        var line = SampleLine();
+        Assert.Throws<ArgumentException>(() => new Invoice(Guid.Empty, customer, new[] { line }));
+    }
+
+    [Fact]
+    public void Constructor_NullCustomer_Throws()
+    {
+        var line = SampleLine();
+        Assert.Throws<ArgumentNullException>(() => new Invoice(Guid.NewGuid(), null!, new[] { line }));
+    }
+
+    [Fact]
+    public void Constructor_NullLines_Throws()
+    {
+        var customer = new Customer(Guid.NewGuid(), "Cust");
+        Assert.Throws<ArgumentNullException>(() => new Invoice(Guid.NewGuid(), customer, null!));
+    }
+
+    [Fact]
+    public void Constructor_EmptyLines_Throws()
+    {
+        var customer = new Customer(Guid.NewGuid(), "Cust");
+        Assert.Throws<ArgumentException>(() => new Invoice(Guid.NewGuid(), customer, Array.Empty<InvoiceLine>()));
+    }
+
+    [Fact]
+    public void Constructor_InconsistentCurrencies_Throws()
+    {
+        var customer = new Customer(Guid.NewGuid(), "Cust");
+        var line1 = SampleLine("USD");
+        var line2 = SampleLine("EUR");
+        Assert.Throws<InvalidOperationException>(() => new Invoice(Guid.NewGuid(), customer, new[] { line1, line2 }));
+    }
+
+    [Fact]
+    public void Total_EqualsSumOfLines()
+    {
+        var customer = new Customer(Guid.NewGuid(), "Cust");
+        var line1 = SampleLine("USD", 2, 5m); // total 10
+        var line2 = SampleLine("USD", 1, 7m); // total 7
+        var invoice = new Invoice(Guid.NewGuid(), customer, new[] { line1, line2 });
+        Assert.Equal(17m, invoice.Total.Amount);
+        Assert.Equal("USD", invoice.Total.Currency);
+    }
+}

--- a/Wrecept.Domain.Tests/MoneyTests.cs
+++ b/Wrecept.Domain.Tests/MoneyTests.cs
@@ -1,0 +1,65 @@
+using Wrecept.Domain;
+
+namespace Wrecept.Domain.Tests;
+
+public class MoneyTests
+{
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Constructor_EmptyCurrency_Throws(string currency)
+    {
+        Assert.Throws<ArgumentException>(() => new Money(currency!, 1m));
+    }
+
+    [Fact]
+    public void Constructor_NegativeAmount_Throws()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new Money("USD", -1m));
+    }
+
+    [Fact]
+    public void Add_SameCurrency_Sums()
+    {
+        var first = new Money("USD", 5m);
+        var second = new Money("USD", 7m);
+
+        var result = first.Add(second);
+
+        Assert.Equal(12m, result.Amount);
+        Assert.Equal("USD", result.Currency);
+    }
+
+    [Fact]
+    public void Add_DifferentCurrency_Throws()
+    {
+        var first = new Money("USD", 5m);
+        var second = new Money("EUR", 3m);
+
+        Assert.Throws<InvalidOperationException>(() => first.Add(second));
+    }
+
+    [Fact]
+    public void Add_Null_Throws()
+    {
+        var money = new Money("USD", 5m);
+        Assert.Throws<ArgumentNullException>(() => money.Add(null!));
+    }
+
+    [Fact]
+    public void Multiply_ByFactor_ReturnsProduct()
+    {
+        var money = new Money("USD", 5m);
+        var result = money.Multiply(3);
+        Assert.Equal(15m, result.Amount);
+        Assert.Equal("USD", result.Currency);
+    }
+
+    [Fact]
+    public void Multiply_NegativeFactor_Throws()
+    {
+        var money = new Money("USD", 5m);
+        Assert.Throws<ArgumentOutOfRangeException>(() => money.Multiply(-1));
+    }
+}

--- a/Wrecept.Domain.Tests/ProductTests.cs
+++ b/Wrecept.Domain.Tests/ProductTests.cs
@@ -1,0 +1,57 @@
+using Wrecept.Domain;
+
+namespace Wrecept.Domain.Tests;
+
+public class ProductTests
+{
+    private static TaxRate StandardTax => new(Guid.NewGuid(), "Standard", 0.2m);
+
+    [Fact]
+    public void Constructor_EmptyId_Throws()
+    {
+        var price = new Money("USD", 1m);
+        Assert.Throws<ArgumentException>(() => new Product(Guid.Empty, "Name", price, StandardTax));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Constructor_EmptyName_Throws(string name)
+    {
+        var price = new Money("USD", 1m);
+        Assert.Throws<ArgumentException>(() => new Product(Guid.NewGuid(), name, price, StandardTax));
+    }
+
+    [Fact]
+    public void Constructor_NullPrice_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => new Product(Guid.NewGuid(), "Name", null!, StandardTax));
+    }
+
+    [Fact]
+    public void Constructor_NonPositivePrice_Throws()
+    {
+        var price = new Money("USD", 0m);
+        Assert.Throws<ArgumentException>(() => new Product(Guid.NewGuid(), "Name", price, StandardTax));
+    }
+
+    [Fact]
+    public void Constructor_NullTaxRate_Throws()
+    {
+        var price = new Money("USD", 1m);
+        Assert.Throws<ArgumentNullException>(() => new Product(Guid.NewGuid(), "Name", price, null!));
+    }
+
+    [Fact]
+    public void Constructor_Valid_SetsProperties()
+    {
+        var id = Guid.NewGuid();
+        var price = new Money("USD", 1m);
+        var tax = StandardTax;
+        var product = new Product(id, "Bread", price, tax);
+        Assert.Equal(id, product.Id);
+        Assert.Equal("Bread", product.Name);
+        Assert.Equal(price, product.Price);
+        Assert.Equal(tax, product.TaxRate);
+    }
+}

--- a/Wrecept.Domain.Tests/TaxRateTests.cs
+++ b/Wrecept.Domain.Tests/TaxRateTests.cs
@@ -1,0 +1,38 @@
+using Wrecept.Domain;
+
+namespace Wrecept.Domain.Tests;
+
+public class TaxRateTests
+{
+    [Fact]
+    public void Constructor_EmptyId_Throws()
+    {
+        Assert.Throws<ArgumentException>(() => new TaxRate(Guid.Empty, "Standard", 0.2m));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Constructor_EmptyName_Throws(string name)
+    {
+        Assert.Throws<ArgumentException>(() => new TaxRate(Guid.NewGuid(), name, 0.2m));
+    }
+
+    [Theory]
+    [InlineData(-0.1)]
+    [InlineData(1.1)]
+    public void Constructor_RateOutOfRange_Throws(double rate)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new TaxRate(Guid.NewGuid(), "Standard", (decimal)rate));
+    }
+
+    [Fact]
+    public void Constructor_Valid_SetsProperties()
+    {
+        var id = Guid.NewGuid();
+        var tax = new TaxRate(id, "Standard", 0.27m);
+        Assert.Equal(id, tax.Id);
+        Assert.Equal("Standard", tax.Name);
+        Assert.Equal(0.27m, tax.Rate);
+    }
+}

--- a/Wrecept.Domain.Tests/Wrecept.Domain.Tests.csproj
+++ b/Wrecept.Domain.Tests/Wrecept.Domain.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <ProjectReference Include="../src/Wrecept.Domain/Wrecept.Domain.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Wrecept.Domain/Entities/Customer.cs
+++ b/src/Wrecept.Domain/Entities/Customer.cs
@@ -1,0 +1,18 @@
+namespace Wrecept.Domain;
+
+public sealed class Customer
+{
+    public Guid Id { get; }
+    public string Name { get; }
+
+    public Customer(Guid id, string name)
+    {
+        if (id == Guid.Empty)
+            throw new ArgumentException("Customer id cannot be empty.", nameof(id));
+        if (string.IsNullOrWhiteSpace(name))
+            throw new ArgumentException("Customer name cannot be empty.", nameof(name));
+
+        Id = id;
+        Name = name;
+    }
+}

--- a/src/Wrecept.Domain/Entities/Invoice.cs
+++ b/src/Wrecept.Domain/Entities/Invoice.cs
@@ -1,0 +1,35 @@
+namespace Wrecept.Domain;
+
+public sealed class Invoice
+{
+    public Guid Id { get; }
+    public Customer Customer { get; }
+    private readonly List<InvoiceLine> _lines;
+    public IReadOnlyCollection<InvoiceLine> Lines => _lines.AsReadOnly();
+    public Money Total { get; }
+
+    public Invoice(Guid id, Customer customer, IEnumerable<InvoiceLine> lines)
+    {
+        if (id == Guid.Empty)
+            throw new ArgumentException("Invoice id cannot be empty.", nameof(id));
+        Customer = customer ?? throw new ArgumentNullException(nameof(customer));
+        if (lines is null)
+            throw new ArgumentNullException(nameof(lines));
+
+        _lines = lines.ToList();
+        if (_lines.Count == 0)
+            throw new ArgumentException("Invoice must contain at least one line.", nameof(lines));
+
+        var currency = _lines[0].Total.Currency;
+        var total = Money.Zero(currency);
+        foreach (var line in _lines)
+        {
+            if (line.Total.Currency != currency)
+                throw new InvalidOperationException("All lines must use the same currency.");
+            total = total.Add(line.Total);
+        }
+
+        Total = total;
+        Id = id;
+    }
+}

--- a/src/Wrecept.Domain/Entities/InvoiceLine.cs
+++ b/src/Wrecept.Domain/Entities/InvoiceLine.cs
@@ -1,0 +1,21 @@
+namespace Wrecept.Domain;
+
+public sealed class InvoiceLine
+{
+    public Product Product { get; }
+    public int Quantity { get; }
+    public Money UnitPrice { get; }
+    public Money Total => UnitPrice.Multiply(Quantity);
+
+    public InvoiceLine(Product product, int quantity, Money unitPrice)
+    {
+        Product = product ?? throw new ArgumentNullException(nameof(product));
+        if (quantity <= 0)
+            throw new ArgumentOutOfRangeException(nameof(quantity), "Quantity must be greater than zero.");
+        UnitPrice = unitPrice ?? throw new ArgumentNullException(nameof(unitPrice));
+        if (unitPrice.Amount <= 0)
+            throw new ArgumentException("Unit price must be positive.", nameof(unitPrice));
+
+        Quantity = quantity;
+    }
+}

--- a/src/Wrecept.Domain/Entities/Product.cs
+++ b/src/Wrecept.Domain/Entities/Product.cs
@@ -1,0 +1,23 @@
+namespace Wrecept.Domain;
+
+public sealed class Product
+{
+    public Guid Id { get; }
+    public string Name { get; }
+    public Money Price { get; }
+    public TaxRate TaxRate { get; }
+
+    public Product(Guid id, string name, Money price, TaxRate taxRate)
+    {
+        if (id == Guid.Empty)
+            throw new ArgumentException("Product id cannot be empty.", nameof(id));
+        if (string.IsNullOrWhiteSpace(name))
+            throw new ArgumentException("Product name cannot be empty.", nameof(name));
+        Price = price ?? throw new ArgumentNullException(nameof(price));
+        if (price.Amount <= 0)
+            throw new ArgumentException("Product price must be positive.", nameof(price));
+        TaxRate = taxRate ?? throw new ArgumentNullException(nameof(taxRate));
+        Id = id;
+        Name = name;
+    }
+}

--- a/src/Wrecept.Domain/Entities/TaxRate.cs
+++ b/src/Wrecept.Domain/Entities/TaxRate.cs
@@ -1,0 +1,22 @@
+namespace Wrecept.Domain;
+
+public sealed class TaxRate
+{
+    public Guid Id { get; }
+    public string Name { get; }
+    public decimal Rate { get; }
+
+    public TaxRate(Guid id, string name, decimal rate)
+    {
+        if (id == Guid.Empty)
+            throw new ArgumentException("Tax rate id cannot be empty.", nameof(id));
+        if (string.IsNullOrWhiteSpace(name))
+            throw new ArgumentException("Tax rate name cannot be empty.", nameof(name));
+        if (rate < 0m || rate > 1m)
+            throw new ArgumentOutOfRangeException(nameof(rate), "Tax rate must be between 0 and 1.");
+
+        Id = id;
+        Name = name;
+        Rate = rate;
+    }
+}

--- a/src/Wrecept.Domain/ValueObjects/Money.cs
+++ b/src/Wrecept.Domain/ValueObjects/Money.cs
@@ -1,0 +1,34 @@
+namespace Wrecept.Domain;
+
+public sealed record Money
+{
+    public string Currency { get; }
+    public decimal Amount { get; }
+
+    public Money(string currency, decimal amount)
+    {
+        if (string.IsNullOrWhiteSpace(currency))
+            throw new ArgumentException("Currency must not be empty.", nameof(currency));
+        if (amount < 0)
+            throw new ArgumentOutOfRangeException(nameof(amount), "Amount cannot be negative.");
+
+        Currency = currency;
+        Amount = amount;
+    }
+
+    public Money Add(Money other)
+    {
+        if (other is null) throw new ArgumentNullException(nameof(other));
+        if (!string.Equals(Currency, other.Currency, StringComparison.OrdinalIgnoreCase))
+            throw new InvalidOperationException("Cannot add money with different currencies.");
+        return new Money(Currency, Amount + other.Amount);
+    }
+
+    public Money Multiply(int factor)
+    {
+        if (factor < 0) throw new ArgumentOutOfRangeException(nameof(factor), "Factor cannot be negative.");
+        return new Money(Currency, Amount * factor);
+    }
+
+    public static Money Zero(string currency) => new(currency, 0m);
+}

--- a/src/Wrecept.Domain/Wrecept.Domain.csproj
+++ b/src/Wrecept.Domain/Wrecept.Domain.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/wrecept.sln
+++ b/wrecept.sln
@@ -15,6 +15,12 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{1B01EA56
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Wrecept.UI.AutomatedTests", "tests\Wrecept.UI.AutomatedTests\Wrecept.UI.AutomatedTests.csproj", "{BED15137-2B71-4AD3-8A11-D7C2888DB6D2}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{FA2FB5A5-8369-47C7-8E73-BAA3B3F0814E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Wrecept.Domain", "src\Wrecept.Domain\Wrecept.Domain.csproj", "{FD9D35B1-918A-43E7-A5EC-6663C71852B1}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Wrecept.Domain.Tests", "Wrecept.Domain.Tests\Wrecept.Domain.Tests.csproj", "{6C2FFDA6-8D28-448B-98AD-359535A5398C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -44,8 +50,17 @@ Global
 		{BED15137-2B71-4AD3-8A11-D7C2888DB6D2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{BED15137-2B71-4AD3-8A11-D7C2888DB6D2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{BED15137-2B71-4AD3-8A11-D7C2888DB6D2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FD9D35B1-918A-43E7-A5EC-6663C71852B1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FD9D35B1-918A-43E7-A5EC-6663C71852B1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FD9D35B1-918A-43E7-A5EC-6663C71852B1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FD9D35B1-918A-43E7-A5EC-6663C71852B1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6C2FFDA6-8D28-448B-98AD-359535A5398C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6C2FFDA6-8D28-448B-98AD-359535A5398C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6C2FFDA6-8D28-448B-98AD-359535A5398C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6C2FFDA6-8D28-448B-98AD-359535A5398C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{BED15137-2B71-4AD3-8A11-D7C2888DB6D2} = {1B01EA56-DD75-47E7-BCF0-FAAFE4564226}
+		{FD9D35B1-918A-43E7-A5EC-6663C71852B1} = {FA2FB5A5-8369-47C7-8E73-BAA3B3F0814E}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
## Summary
- Introduce Money value object and core domain entities (Invoice, InvoiceLine, Customer, Product, TaxRate)
- Enforce business rules such as positive amounts, quantity validation, and invoice total consistency
- Add `Wrecept.Domain.Tests` project with unit tests for Money and entity constructors
- Track completion in TODO.md for domain tests

## Testing
- `dotnet build Wrecept.Core.sln`
- `dotnet test Wrecept.Core.sln --filter "Category!=UI"`


------
https://chatgpt.com/codex/tasks/task_e_689509536a20832293da41b7788ad3c3