### PR TITLE
doc_agent: sync README features with TODO tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,24 +6,26 @@ Wrecept is an offline-first invoicing desktop application built with C# (.NET 8)
 
 ## Features
 
+Features marked with *(planned)* are upcoming and not yet implemented.
+
 - **Offline-first architecture** – Works fully without internet connectivity and synchronizes data once a connection is restored.
-- **Keyboard-centric UI** – Every action is driven by keyboard shortcuts for maximum speed.
-- **Main menu navigation** – Quick-access categories (`Accounts`, `Stocks`, `Lists`, `Maintenance`, `Contacts`) streamline common tasks.
-- **Invoice editor** – Inline item entry with real-time calculations and row-by-row validation.
+- **Keyboard-centric UI** *(planned)* – Every action is driven by keyboard shortcuts for maximum speed.
+- **Main menu navigation** *(planned)* – Quick-access categories (`Accounts`, `Stocks`, `Lists`, `Maintenance`, `Contacts`) streamline common tasks.
+- **Invoice editor** *(planned)* – Inline item entry with real-time calculations and row-by-row validation.
 - **Model–Repository–Service (MRS) architecture** – Clear separation between domain models, persistence repositories, and business services.
 - **SQLite data storage** – Local persistence using a lightweight SQLite database via Entity Framework Core.
-- **Theme support** – Customisable themes with a dedicated Theme Editor.
+- **Theme support** *(planned)* – Customisable themes with a dedicated Theme Editor.
 - **Logging with Serilog** – Structured logging to help diagnose issues and maintain reliability.
-- **Localisation** – Hungarian user interface and error messages.
-- **Import/Export (planned)** – Upcoming database backup and migration support.
-## Smart Features
+- **Localisation** *(planned)* – Hungarian user interface and error messages.
+- **Import/Export** *(planned)* – Upcoming database backup and migration support.
+## Smart Features *(planned)*
 - **Auto-suggestions for recurring invoice items or frequently purchased products**
 - **Predictive text entry using local history** 
-## In-App Help & Support
+## In-App Help & Support *(planned)*
 - **Contextual tooltips** -
 - **Quick keyboard cheat sheet** -
 - **User onboarding tour** -
-## Reporting & Analytics
+## Reporting & Analytics *(planned)*
 - **Customizable financial and inventory dashboards** -
 - **Monthly/quarterly insights with charts for:** -
   - **Sales trends** -

--- a/TODO.md
+++ b/TODO.md
@@ -22,12 +22,16 @@
 - [x] `DONE` Write installation guide (`INSTALL.md`)
 - [x] `DONE` Update README.md (feature list, menu structure, etc...)
 - [x] `DONE` Expand README with detailed feature list and menu structure
+- [ ] `TODO` Create keyboard shortcut cheat sheet
 
 ## logic_agent
 - [x] `DONE` Set up MRS structure (Model → Repository → Service)
 - [x] `DONE` Data recording and saving in a working prototype
 - [x] `DONE` Introduction and configuration of Serilog
 - [x] `DONE` Load/save application settings to file (`wrecept.json`)
+- [ ] `TODO` Auto-suggestions for recurring invoice items or frequently purchased products
+- [ ] `TODO` Predictive text entry using local history
+- [ ] `TODO` Reporting analytics engine for sales trends, top customers/products, and tax breakdowns
 
 ## db_agent
 - [x] `DONE` Initialise SQLite database with migration
@@ -42,6 +46,10 @@
 - [ ] `TODO NEEDS_REVIEW` Introduction of themes (dark/light + customisation)
 - [ ] `TODO NEEDS_REVIEW` ThemeEditorView – theme management UI editor
 - [ ] `TODO NEEDS_REVIEW` Confirmation popups for all critical actions
+- [ ] `TODO` Implement contextual tooltips across the UI
+- [ ] `TODO` Provide quick keyboard cheat sheet within the application
+- [ ] `TODO` Display auto-suggestions and predictive text in `InvoiceEditorView`
+- [ ] `TODO` Develop customizable dashboard views for financial and inventory metrics
 
 ## test_agent
 - [ ] `TODO NEEDS_REVIEW` Unit tests for the Service layer
@@ -59,3 +67,4 @@
 - [ ] `TODO` Evaluate onboarding flow for first-time users
 - [ ] `TODO` Conduct user testing for invoice creation workflow with keyboard-only navigation
 - [ ] `TODO` Draft accessible color contrast and font guidelines
+- [ ] `TODO` Design user onboarding tour


### PR DESCRIPTION
## Summary
- clarify planned vs implemented features in README
- add TODO items for future features to keep roadmap synced

## Testing
- `dotnet test Wrecept.Core.sln --filter "Category!=UI"`


------
https://chatgpt.com/codex/tasks/task_e_68951a34cf908322aa88eca1d9f59b23