### PR TITLE
Fix UI Serilog configuration and align test targeting

### DIFF
--- a/Wrecept.UI.Tests/Wrecept.UI.Tests.csproj
+++ b/Wrecept.UI.Tests/Wrecept.UI.Tests.csproj
@@ -1,9 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <UseWPF>true</UseWPF>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>

--- a/Wrecept.UI/Wrecept.UI.csproj
+++ b/Wrecept.UI/Wrecept.UI.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <TargetFramework>net8.0-windows</TargetFramework>
@@ -14,6 +14,7 @@
     <PackageReference Include="Serilog" Version="3.1.1" />
     <PackageReference Include="Serilog.Extensions.Hosting" Version="8.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>
     <None Include="wrecept.json">

--- a/tests/Wrecept.UI.AutomatedTests/MainViewTests.cs
+++ b/tests/Wrecept.UI.AutomatedTests/MainViewTests.cs
@@ -4,6 +4,7 @@ using System.Runtime.InteropServices;
 using OpenQA.Selenium;
 using OpenQA.Selenium.Appium;
 using OpenQA.Selenium.Appium.Windows;
+using OpenQA.Selenium.Interactions;
 
 namespace Wrecept.UI.AutomatedTests;
 
@@ -72,7 +73,7 @@ public class MainViewTests : IDisposable
     public void AddInvoiceLine_WithF2_AddsEmptyRow()
     {
         Skip.If(_session is null, "Application session failed to start");
-        _session.Keyboard.PressKey(Keys.F2);
+        new Actions(_session).SendKeys(Keys.F2).Perform();
         var rows = _session.FindElementsByAccessibilityId("InvoiceLineRow");
         Assert.True(rows.Count > 0);
     }

--- a/tests/Wrecept.UI.AutomatedTests/Wrecept.UI.AutomatedTests.csproj
+++ b/tests/Wrecept.UI.AutomatedTests/Wrecept.UI.AutomatedTests.csproj
@@ -5,6 +5,7 @@
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />


### PR DESCRIPTION
## Summary
- switch Wrecept.UI to the standard SDK and add Serilog.Settings.Configuration for configuration-based logging
- target Wrecept.UI.Tests at net8.0-windows and enable WPF to resolve framework mismatch
- use Selenium Actions API instead of obsolete Keyboard property in automated UI tests

## Testing
- `dotnet test Wrecept.Core.sln --filter "Category!=UI"`
- `dotnet test tests/Wrecept.UI.AutomatedTests/Wrecept.UI.AutomatedTests.csproj --filter "Category!=UI"`

------
https://chatgpt.com/codex/tasks/task_e_68959c1457f483229f659a312dc84a90