### PR TITLE
Add data-driven UI views and invoice saving

### DIFF
--- a/Wrecept.Core/Services/ExportService.cs
+++ b/Wrecept.Core/Services/ExportService.cs
@@ -1,0 +1,54 @@
+using Microsoft.EntityFrameworkCore;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using Wrecept.Core.Data;
+using Wrecept.Core.Models;
+
+namespace Wrecept.Core.Services;
+
+public class ExportService : IExportService
+{
+    private readonly AppDbContext _db;
+    public ExportService(AppDbContext db)
+    {
+        _db = db;
+    }
+
+    public async Task ExportAsync(string path)
+    {
+        var dir = Path.GetDirectoryName(path);
+        if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir)) Directory.CreateDirectory(dir);
+        var data = new ExportData
+        {
+            Products = await _db.Products.AsNoTracking().ToListAsync(),
+            Suppliers = await _db.Suppliers.AsNoTracking().ToListAsync(),
+            Invoices = await _db.Invoices.Include(i => i.Items).AsNoTracking().ToListAsync()
+        };
+        var json = JsonSerializer.Serialize(data);
+        await File.WriteAllTextAsync(path, json);
+    }
+
+    public async Task ImportAsync(string path)
+    {
+        if (!File.Exists(path)) throw new FileNotFoundException(path);
+        var json = await File.ReadAllTextAsync(path);
+        var data = JsonSerializer.Deserialize<ExportData>(json);
+        if (data is null) return;
+        _db.Products.RemoveRange(_db.Products);
+        _db.Suppliers.RemoveRange(_db.Suppliers);
+        _db.Invoices.RemoveRange(_db.Invoices);
+        await _db.SaveChangesAsync();
+        if (data.Products != null) _db.Products.AddRange(data.Products);
+        if (data.Suppliers != null) _db.Suppliers.AddRange(data.Suppliers);
+        if (data.Invoices != null) _db.Invoices.AddRange(data.Invoices);
+        await _db.SaveChangesAsync();
+    }
+
+    private class ExportData
+    {
+        public List<Product>? Products { get; set; }
+        public List<Supplier>? Suppliers { get; set; }
+        public List<Invoice>? Invoices { get; set; }
+    }
+}

--- a/Wrecept.Core/Services/IExportService.cs
+++ b/Wrecept.Core/Services/IExportService.cs
@@ -1,0 +1,9 @@
+using System.Threading.Tasks;
+
+namespace Wrecept.Core.Services;
+
+public interface IExportService
+{
+    Task ExportAsync(string path);
+    Task ImportAsync(string path);
+}

--- a/Wrecept.UI/ViewModels/ContactsViewModel.cs
+++ b/Wrecept.UI/ViewModels/ContactsViewModel.cs
@@ -1,0 +1,41 @@
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using System.Windows.Input;
+using Wrecept.Core.Models;
+using Wrecept.Core.Repositories;
+
+namespace Wrecept.UI.ViewModels;
+
+public class ContactsViewModel : INotifyPropertyChanged
+{
+    private readonly IRepository<Supplier> _repo;
+    public ObservableCollection<Supplier> Suppliers { get; } = new();
+    private Supplier? _selectedSupplier;
+    public Supplier? SelectedSupplier
+    {
+        get => _selectedSupplier;
+        set { _selectedSupplier = value; OnPropertyChanged(); }
+    }
+
+    public ICommand RefreshCommand { get; }
+
+    public ContactsViewModel(IRepository<Supplier> repo)
+    {
+        _repo = repo;
+        RefreshCommand = new RelayCommand(async _ => await RefreshAsync());
+        _ = RefreshAsync();
+    }
+
+    private async Task RefreshAsync()
+    {
+        var items = await _repo.GetAllAsync();
+        Suppliers.Clear();
+        foreach (var s in items)
+            Suppliers.Add(s);
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+    protected void OnPropertyChanged([CallerMemberName] string? name = null) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+}

--- a/Wrecept.UI/ViewModels/InvoiceEditorViewModel.cs
+++ b/Wrecept.UI/ViewModels/InvoiceEditorViewModel.cs
@@ -1,30 +1,71 @@
+using System.Collections.ObjectModel;
 using System.ComponentModel;
+using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Windows;
 using System.Windows.Input;
+using Wrecept.Core.Models;
+using Wrecept.Core.Services;
 
 namespace Wrecept.UI.ViewModels;
 
 public class InvoiceEditorViewModel : INotifyPropertyChanged
 {
-    public ICommand EnterCommand { get; }
-    public ICommand EscapeCommand { get; }
-    public ICommand LeftCommand { get; }
-    public ICommand RightCommand { get; }
-    public ICommand UpCommand { get; }
-    public ICommand DownCommand { get; }
+    private readonly IInvoiceService _invoiceService;
 
-    public InvoiceEditorViewModel()
+    public ObservableCollection<InvoiceItem> Items { get; } = new();
+    private InvoiceItem? _selectedItem;
+    public InvoiceItem? SelectedItem
     {
-        EnterCommand = new RelayCommand(_ => { });
-        EscapeCommand = new RelayCommand(_ => { });
-        LeftCommand = new RelayCommand(_ => { });
-        RightCommand = new RelayCommand(_ => { });
-        UpCommand = new RelayCommand(_ => { });
-        DownCommand = new RelayCommand(_ => { });
+        get => _selectedItem;
+        set { _selectedItem = value; OnPropertyChanged(); }
+    }
+
+    public Invoice Invoice { get; } = new();
+
+    public ICommand AddItemCommand { get; }
+    public ICommand DeleteItemCommand { get; }
+    public ICommand SaveCommand { get; }
+
+    public InvoiceEditorViewModel(IInvoiceService invoiceService)
+    {
+        _invoiceService = invoiceService;
+        AddItemCommand = new RelayCommand(_ => AddItem());
+        DeleteItemCommand = new RelayCommand(_ => DeleteItem(), _ => SelectedItem != null);
+        SaveCommand = new RelayCommand(_ => SaveInvoice());
+    }
+
+    private void AddItem()
+    {
+        var item = new InvoiceItem();
+        Items.Add(item);
+        SelectedItem = item;
+    }
+
+    private void DeleteItem()
+    {
+        if (SelectedItem != null)
+        {
+            Items.Remove(SelectedItem);
+            SelectedItem = null;
+        }
+    }
+
+    private async void SaveInvoice()
+    {
+        Invoice.Items = Items.ToList();
+        Invoice.RecalculateTotals();
+        try
+        {
+            await _invoiceService.AddInvoiceAsync(Invoice);
+            MessageBox.Show("Számla elmentve.");
+        }
+        catch (Exception ex)
+        {
+            MessageBox.Show($"Mentési hiba: {ex.Message}");
+        }
     }
 
     public event PropertyChangedEventHandler? PropertyChanged;
-
-    protected void OnPropertyChanged([CallerMemberName] string? propertyName = null)
-        => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    protected void OnPropertyChanged([CallerMemberName] string? name = null) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
 }

--- a/Wrecept.UI/ViewModels/ListsViewModel.cs
+++ b/Wrecept.UI/ViewModels/ListsViewModel.cs
@@ -1,0 +1,44 @@
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using System.Windows.Input;
+using Wrecept.Core.Models;
+using Wrecept.Core.Services;
+
+namespace Wrecept.UI.ViewModels;
+
+public class ListsViewModel : INotifyPropertyChanged
+{
+    private readonly IInvoiceService _invoiceService;
+    public ObservableCollection<Invoice> Invoices { get; } = new();
+    private Invoice? _selectedInvoice;
+    public Invoice? SelectedInvoice
+    {
+        get => _selectedInvoice;
+        set { _selectedInvoice = value; OnPropertyChanged(); }
+    }
+
+    public ICommand RefreshCommand { get; }
+
+    public ListsViewModel(IInvoiceService invoiceService)
+    {
+        _invoiceService = invoiceService;
+        RefreshCommand = new RelayCommand(async _ => await RefreshAsync());
+        _ = RefreshAsync();
+    }
+
+    private async Task RefreshAsync()
+    {
+        var items = await _invoiceService.GetInvoicesAsync();
+        Invoices.Clear();
+        foreach (var i in items)
+        {
+            i.RecalculateTotals();
+            Invoices.Add(i);
+        }
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+    protected void OnPropertyChanged([CallerMemberName] string? name = null) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+}

--- a/Wrecept.UI/ViewModels/MainViewModel.cs
+++ b/Wrecept.UI/ViewModels/MainViewModel.cs
@@ -2,6 +2,7 @@ using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Windows.Controls;
 using System.Windows.Input;
+using Microsoft.Extensions.DependencyInjection;
 using Wrecept.UI.Views;
 
 namespace Wrecept.UI.ViewModels;
@@ -68,17 +69,26 @@ public class MainViewModel : INotifyPropertyChanged
         SetSection(MainSection.Accounts);
     }
 
+    private UserControl CreateView<TView, TViewModel>()
+        where TView : UserControl
+        where TViewModel : class
+    {
+        var view = App.ServiceProvider.GetRequiredService<TView>();
+        view.DataContext = App.ServiceProvider.GetRequiredService<TViewModel>();
+        return view;
+    }
+
     private void SetSection(MainSection section)
     {
         SelectedSection = section;
         CurrentView = section switch
         {
-            MainSection.Accounts => new InvoiceEditorView(),
-            MainSection.Stocks => new StocksView(),
-            MainSection.Lists => new ListsView(),
-            MainSection.Maintenance => new MaintenanceView(),
-            MainSection.Contacts => new ContactsView(),
-            _ => null
+            MainSection.Accounts => CreateView<InvoiceEditorView, InvoiceEditorViewModel>(),
+            MainSection.Stocks => CreateView<StocksView, StocksViewModel>(),
+            MainSection.Lists => CreateView<ListsView, ListsViewModel>(),
+            MainSection.Maintenance => CreateView<MaintenanceView, MaintenanceViewModel>(),
+            MainSection.Contacts => CreateView<ContactsView, ContactsViewModel>(),
+            _ => new UserControl()
         };
     }
 

--- a/Wrecept.UI/ViewModels/MaintenanceViewModel.cs
+++ b/Wrecept.UI/ViewModels/MaintenanceViewModel.cs
@@ -1,0 +1,62 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Input;
+using Microsoft.Extensions.DependencyInjection;
+using Wrecept.Core.Services;
+using Wrecept.UI.Views;
+
+namespace Wrecept.UI.ViewModels;
+
+public class MaintenanceViewModel
+{
+    private readonly IExportService _exportService;
+
+    public ICommand ExportCommand { get; }
+    public ICommand ImportCommand { get; }
+    public ICommand OpenThemeEditorCommand { get; }
+
+    public MaintenanceViewModel(IExportService exportService)
+    {
+        _exportService = exportService;
+        ExportCommand = new RelayCommand(async _ => await ExportAsync());
+        ImportCommand = new RelayCommand(async _ => await ImportAsync());
+        OpenThemeEditorCommand = new RelayCommand(_ => OpenThemeEditor());
+    }
+
+    private async Task ExportAsync()
+    {
+        var path = Path.Combine(AppContext.BaseDirectory, "Data", "export.json");
+        try
+        {
+            await _exportService.ExportAsync(path);
+            MessageBox.Show("Exportálás kész.");
+        }
+        catch (Exception ex)
+        {
+            MessageBox.Show($"Export hiba: {ex.Message}");
+        }
+    }
+
+    private async Task ImportAsync()
+    {
+        var path = Path.Combine(AppContext.BaseDirectory, "Data", "export.json");
+        try
+        {
+            await _exportService.ImportAsync(path);
+            MessageBox.Show("Importálás kész.");
+        }
+        catch (Exception ex)
+        {
+            MessageBox.Show($"Import hiba: {ex.Message}");
+        }
+    }
+
+    private void OpenThemeEditor()
+    {
+        var view = App.ServiceProvider.GetRequiredService<ThemeEditorView>();
+        view.DataContext = App.ServiceProvider.GetRequiredService<ThemeEditorViewModel>();
+        view.ShowDialog();
+    }
+}

--- a/Wrecept.UI/ViewModels/StocksViewModel.cs
+++ b/Wrecept.UI/ViewModels/StocksViewModel.cs
@@ -1,0 +1,41 @@
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using System.Windows.Input;
+using Wrecept.Core.Models;
+using Wrecept.Core.Repositories;
+
+namespace Wrecept.UI.ViewModels;
+
+public class StocksViewModel : INotifyPropertyChanged
+{
+    private readonly IRepository<Product> _repo;
+    public ObservableCollection<Product> Products { get; } = new();
+    private Product? _selectedProduct;
+    public Product? SelectedProduct
+    {
+        get => _selectedProduct;
+        set { _selectedProduct = value; OnPropertyChanged(); }
+    }
+
+    public ICommand RefreshCommand { get; }
+
+    public StocksViewModel(IRepository<Product> repo)
+    {
+        _repo = repo;
+        RefreshCommand = new RelayCommand(async _ => await RefreshAsync());
+        _ = RefreshAsync();
+    }
+
+    private async Task RefreshAsync()
+    {
+        var items = await _repo.GetAllAsync();
+        Products.Clear();
+        foreach (var p in items)
+            Products.Add(p);
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+    protected void OnPropertyChanged([CallerMemberName] string? name = null) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+}

--- a/Wrecept.UI/Views/ContactsView.xaml
+++ b/Wrecept.UI/Views/ContactsView.xaml
@@ -6,14 +6,21 @@
              KeyboardNavigation.TabNavigation="None"
              mc:Ignorable="d">
     <UserControl.InputBindings>
-        <KeyBinding Key="Enter" Command="{Binding EnterCommand}" />
-        <KeyBinding Key="Escape" Command="{Binding EscapeCommand}" />
-        <KeyBinding Key="Left" Command="{Binding LeftCommand}" />
-        <KeyBinding Key="Right" Command="{Binding RightCommand}" />
-        <KeyBinding Key="Up" Command="{Binding UpCommand}" />
-        <KeyBinding Key="Down" Command="{Binding DownCommand}" />
+        <KeyBinding Key="F5" Command="{Binding RefreshCommand}" />
     </UserControl.InputBindings>
-    <Grid>
-        <TextBlock Text="Contacts" HorizontalAlignment="Center" VerticalAlignment="Center" />
-    </Grid>
+    <DockPanel>
+        <StackPanel Orientation="Horizontal" DockPanel.Dock="Top" Margin="0,0,0,5">
+            <Button Content="Frissítés" Command="{Binding RefreshCommand}" Width="80"/>
+        </StackPanel>
+        <DataGrid ItemsSource="{Binding Suppliers}" SelectedItem="{Binding SelectedSupplier}" AutoGenerateColumns="False">
+            <DataGrid.Columns>
+                <DataGridTextColumn Header="Id" Binding="{Binding Id}" IsReadOnly="True" />
+                <DataGridTextColumn Header="Név" Binding="{Binding Name}" />
+                <DataGridTextColumn Header="Adószám" Binding="{Binding TaxId}" />
+                <DataGridTextColumn Header="Email" Binding="{Binding Email}" />
+                <DataGridTextColumn Header="Telefon" Binding="{Binding Phone}" />
+                <DataGridTextColumn Header="Létrehozva" Binding="{Binding CreatedAt}" />
+            </DataGrid.Columns>
+        </DataGrid>
+    </DockPanel>
 </UserControl>

--- a/Wrecept.UI/Views/InvoiceEditorView.xaml
+++ b/Wrecept.UI/Views/InvoiceEditorView.xaml
@@ -6,14 +6,28 @@
              KeyboardNavigation.TabNavigation="None"
              mc:Ignorable="d">
     <UserControl.InputBindings>
-        <KeyBinding Key="Enter" Command="{Binding EnterCommand}" />
-        <KeyBinding Key="Escape" Command="{Binding EscapeCommand}" />
-        <KeyBinding Key="Left" Command="{Binding LeftCommand}" />
-        <KeyBinding Key="Right" Command="{Binding RightCommand}" />
-        <KeyBinding Key="Up" Command="{Binding UpCommand}" />
-        <KeyBinding Key="Down" Command="{Binding DownCommand}" />
+        <KeyBinding Key="F2" Command="{Binding AddItemCommand}" />
     </UserControl.InputBindings>
-    <Grid>
-        <TextBlock Text="Invoice Editor" />
-    </Grid>
+    <DockPanel>
+        <DataGrid ItemsSource="{Binding Items}" SelectedItem="{Binding SelectedItem}" AutoGenerateColumns="True"/>
+        <Grid DockPanel.Dock="Bottom" Margin="0,5,0,0">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition />
+                <ColumnDefinition />
+            </Grid.ColumnDefinitions>
+            <StackPanel Orientation="Horizontal" Grid.Column="0" Margin="5,0,0,0">
+                <TextBlock Text="Nettó:" Margin="0,0,5,0"/>
+                <TextBlock Text="{Binding Invoice.TotalNet}" Margin="0,0,10,0"/>
+                <TextBlock Text="ÁFA:" Margin="0,0,5,0"/>
+                <TextBlock Text="{Binding Invoice.TotalVat}" Margin="0,0,10,0"/>
+                <TextBlock Text="Bruttó:" Margin="0,0,5,0"/>
+                <TextBlock Text="{Binding Invoice.TotalGross}"/>
+            </StackPanel>
+            <StackPanel Orientation="Horizontal" Grid.Column="1" HorizontalAlignment="Right">
+                <Button Content="Új sor" Command="{Binding AddItemCommand}" Margin="0,0,5,0"/>
+                <Button Content="Törlés" Command="{Binding DeleteItemCommand}" Margin="0,0,5,0"/>
+                <Button Content="Mentés" Command="{Binding SaveCommand}"/>
+            </StackPanel>
+        </Grid>
+    </DockPanel>
 </UserControl>

--- a/Wrecept.UI/Views/ListsView.xaml
+++ b/Wrecept.UI/Views/ListsView.xaml
@@ -6,14 +6,21 @@
              KeyboardNavigation.TabNavigation="None"
              mc:Ignorable="d">
     <UserControl.InputBindings>
-        <KeyBinding Key="Enter" Command="{Binding EnterCommand}" />
-        <KeyBinding Key="Escape" Command="{Binding EscapeCommand}" />
-        <KeyBinding Key="Left" Command="{Binding LeftCommand}" />
-        <KeyBinding Key="Right" Command="{Binding RightCommand}" />
-        <KeyBinding Key="Up" Command="{Binding UpCommand}" />
-        <KeyBinding Key="Down" Command="{Binding DownCommand}" />
+        <KeyBinding Key="F5" Command="{Binding RefreshCommand}" />
     </UserControl.InputBindings>
-    <Grid>
-        <TextBlock Text="Lists" HorizontalAlignment="Center" VerticalAlignment="Center" />
-    </Grid>
+    <DockPanel>
+        <StackPanel Orientation="Horizontal" DockPanel.Dock="Top" Margin="0,0,0,5">
+            <Button Content="Frissítés" Command="{Binding RefreshCommand}" Width="80"/>
+        </StackPanel>
+        <DataGrid ItemsSource="{Binding Invoices}" SelectedItem="{Binding SelectedInvoice}" AutoGenerateColumns="False">
+            <DataGrid.Columns>
+                <DataGridTextColumn Header="Id" Binding="{Binding Id}" IsReadOnly="True" />
+                <DataGridTextColumn Header="Beszállító" Binding="{Binding Supplier.Name}" />
+                <DataGridTextColumn Header="Dátum" Binding="{Binding Date}" />
+                <DataGridTextColumn Header="Nettó" Binding="{Binding TotalNet}" />
+                <DataGridTextColumn Header="ÁFA" Binding="{Binding TotalVat}" />
+                <DataGridTextColumn Header="Bruttó" Binding="{Binding TotalGross}" />
+            </DataGrid.Columns>
+        </DataGrid>
+    </DockPanel>
 </UserControl>

--- a/Wrecept.UI/Views/MaintenanceView.xaml
+++ b/Wrecept.UI/Views/MaintenanceView.xaml
@@ -5,15 +5,9 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              KeyboardNavigation.TabNavigation="None"
              mc:Ignorable="d">
-    <UserControl.InputBindings>
-        <KeyBinding Key="Enter" Command="{Binding EnterCommand}" />
-        <KeyBinding Key="Escape" Command="{Binding EscapeCommand}" />
-        <KeyBinding Key="Left" Command="{Binding LeftCommand}" />
-        <KeyBinding Key="Right" Command="{Binding RightCommand}" />
-        <KeyBinding Key="Up" Command="{Binding UpCommand}" />
-        <KeyBinding Key="Down" Command="{Binding DownCommand}" />
-    </UserControl.InputBindings>
-    <Grid>
-        <TextBlock Text="Maintenance" HorizontalAlignment="Center" VerticalAlignment="Center" />
-    </Grid>
+    <StackPanel Margin="10">
+        <Button Content="Export" Command="{Binding ExportCommand}" Margin="0,0,0,5" Width="100"/>
+        <Button Content="Import" Command="{Binding ImportCommand}" Margin="0,0,0,5" Width="100"/>
+        <Button Content="Theme Editor" Command="{Binding OpenThemeEditorCommand}" Width="100"/>
+    </StackPanel>
 </UserControl>

--- a/Wrecept.UI/Views/StocksView.xaml
+++ b/Wrecept.UI/Views/StocksView.xaml
@@ -6,14 +6,19 @@
              KeyboardNavigation.TabNavigation="None"
              mc:Ignorable="d">
     <UserControl.InputBindings>
-        <KeyBinding Key="Enter" Command="{Binding EnterCommand}" />
-        <KeyBinding Key="Escape" Command="{Binding EscapeCommand}" />
-        <KeyBinding Key="Left" Command="{Binding LeftCommand}" />
-        <KeyBinding Key="Right" Command="{Binding RightCommand}" />
-        <KeyBinding Key="Up" Command="{Binding UpCommand}" />
-        <KeyBinding Key="Down" Command="{Binding DownCommand}" />
+        <KeyBinding Key="F5" Command="{Binding RefreshCommand}" />
     </UserControl.InputBindings>
-    <Grid>
-        <TextBlock Text="Stocks" HorizontalAlignment="Center" VerticalAlignment="Center" />
-    </Grid>
+    <DockPanel>
+        <StackPanel Orientation="Horizontal" DockPanel.Dock="Top" Margin="0,0,0,5">
+            <Button Content="Frissítés" Command="{Binding RefreshCommand}" Width="80"/>
+        </StackPanel>
+        <DataGrid ItemsSource="{Binding Products}" SelectedItem="{Binding SelectedProduct}" AutoGenerateColumns="False">
+            <DataGrid.Columns>
+                <DataGridTextColumn Header="Id" Binding="{Binding Id}" IsReadOnly="True" />
+                <DataGridTextColumn Header="Név" Binding="{Binding Name}" />
+                <DataGridTextColumn Header="Egységár" Binding="{Binding UnitPrice}" />
+                <DataGridTextColumn Header="ÁFA" Binding="{Binding VatRate}" />
+            </DataGrid.Columns>
+        </DataGrid>
+    </DockPanel>
 </UserControl>

--- a/docs/keyboard-map.md
+++ b/docs/keyboard-map.md
@@ -1,0 +1,6 @@
+# Keyboard Map
+
+| Shortcut | Művelet |
+| --- | --- |
+| F2 / Ctrl+I | Új tételsor hozzáadása |
+| Ctrl+T | Theme Editor megnyitása |


### PR DESCRIPTION
## Summary
- configure Serilog from host services and ensure SQLite path creation
- implement invoice editor saving with totals and shortcuts
- add data-driven Stocks, Contacts, Lists, Maintenance views with export/import service
- document F2 shortcut and theme editor key
- display supplier tax ID, email, phone and created date in contacts grid

## Testing
- `dotnet test Wrecept.Core.sln --filter "Category!=UI"`


------
https://chatgpt.com/codex/tasks/task_e_6895b3dc8dec8322a5922d6406ebfb48