### PR TITLE
[ui_agent] Wrap ThemeEditorView in modal window

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -44,7 +44,7 @@
 - [ ] `TODO NEEDS_REVIEW` Basic `MainView` + `InvoiceEditorView` XAML layout
 - [ ] `TODO NEEDS_REVIEW` Implement keyboard-only navigation (Enter, Escape, arrows, Tab)
 - [ ] `TODO NEEDS_REVIEW` Introduction of themes (dark/light + customisation)
-- [ ] `TODO NEEDS_REVIEW` ThemeEditorView – theme management UI editor
+ - [ ] `IN_PROGRESS` ThemeEditorView – theme management UI editor
 - [ ] `TODO NEEDS_REVIEW` Confirmation popups for all critical actions
 - [ ] `TODO` Implement contextual tooltips across the UI
 - [ ] `TODO` Provide quick keyboard cheat sheet within the application

--- a/Wrecept.UI/App.xaml.cs
+++ b/Wrecept.UI/App.xaml.cs
@@ -65,6 +65,7 @@ public partial class App : Application
                 services.AddTransient<MaintenanceView>();
                 services.AddSingleton<ThemeEditorViewModel>();
                 services.AddTransient<ThemeEditorView>();
+                services.AddTransient<ThemeEditorWindow>();
                 services.AddSingleton<IExportService, ExportService>();
                 services.AddSingleton<MainViewModel>();
                 services.AddTransient<MainView>();

--- a/Wrecept.UI/ViewModels/MaintenanceViewModel.cs
+++ b/Wrecept.UI/ViewModels/MaintenanceViewModel.cs
@@ -55,8 +55,7 @@ public class MaintenanceViewModel
 
     private void OpenThemeEditor()
     {
-        var view = App.ServiceProvider.GetRequiredService<ThemeEditorView>();
-        view.DataContext = App.ServiceProvider.GetRequiredService<ThemeEditorViewModel>();
-        view.ShowDialog();
+        var window = App.ServiceProvider.GetRequiredService<ThemeEditorWindow>();
+        window.ShowDialog();
     }
 }

--- a/Wrecept.UI/Views/ThemeEditorWindow.xaml
+++ b/Wrecept.UI/Views/ThemeEditorWindow.xaml
@@ -1,0 +1,5 @@
+<Window x:Class="Wrecept.UI.Views.ThemeEditorWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Theme Editor" Height="450" Width="800">
+</Window>

--- a/Wrecept.UI/Views/ThemeEditorWindow.xaml.cs
+++ b/Wrecept.UI/Views/ThemeEditorWindow.xaml.cs
@@ -1,0 +1,12 @@
+using System.Windows;
+
+namespace Wrecept.UI.Views;
+
+public partial class ThemeEditorWindow : Window
+{
+    public ThemeEditorWindow(ThemeEditorView view)
+    {
+        InitializeComponent();
+        Content = view;
+    }
+}


### PR DESCRIPTION
## Summary
- expose ThemeEditorView via new ThemeEditorWindow and register it for DI
- call the new window from MaintenanceViewModel so theme editor opens modally
- mark theme editor UI task as in-progress

## Testing
- `dotnet restore wrecept.sln`
- `dotnet test wrecept.sln --filter "Category!=UI"` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*
- `dotnet test Wrecept.Core.sln --filter "Category!=UI"`


------
https://chatgpt.com/codex/tasks/task_e_6895f41eff108322bbe495638915a7bf