### PR TITLE
ui_agent: add confirmation dialogs for critical actions

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -45,7 +45,7 @@
 - [ ] `TODO NEEDS_REVIEW` Implement keyboard-only navigation (Enter, Escape, arrows, Tab)
 - [ ] `TODO NEEDS_REVIEW` Introduction of themes (dark/light + customisation)
  - [ ] `IN_PROGRESS` ThemeEditorView – theme management UI editor
-- [ ] `TODO NEEDS_REVIEW` Confirmation popups for all critical actions
+- [x] `DONE` Confirmation popups for all critical actions
 - [ ] `TODO` Implement contextual tooltips across the UI
 - [ ] `TODO` Provide quick keyboard cheat sheet within the application
 - [ ] `TODO` Display auto-suggestions and predictive text in `InvoiceEditorView`

--- a/Wrecept.UI/MainWindow.xaml.cs
+++ b/Wrecept.UI/MainWindow.xaml.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using System.Windows;
 
 namespace Wrecept.UI;
@@ -7,5 +8,19 @@ public partial class MainWindow : Window
     public MainWindow()
     {
         InitializeComponent();
+        Closing += OnClosing;
+    }
+
+    private void OnClosing(object? sender, CancelEventArgs e)
+    {
+        var confirm = MessageBox.Show(
+            "Biztosan kilép a programból?",
+            "Megerősítés",
+            MessageBoxButton.YesNo,
+            MessageBoxImage.Question);
+        if (confirm != MessageBoxResult.Yes)
+        {
+            e.Cancel = true;
+        }
     }
 }

--- a/Wrecept.UI/MainWindow.xaml.cs
+++ b/Wrecept.UI/MainWindow.xaml.cs
@@ -14,8 +14,8 @@ public partial class MainWindow : Window
     private void OnClosing(object? sender, CancelEventArgs e)
     {
         var confirm = MessageBox.Show(
-            "Biztosan kilép a programból?",
-            "Megerősítés",
+            Resources.ConfirmExitMessage,
+            Resources.ConfirmationTitle,
             MessageBoxButton.YesNo,
             MessageBoxImage.Question);
         if (confirm != MessageBoxResult.Yes)

--- a/Wrecept.UI/ViewModels/InvoiceEditorViewModel.cs
+++ b/Wrecept.UI/ViewModels/InvoiceEditorViewModel.cs
@@ -47,7 +47,7 @@ public class InvoiceEditorViewModel : INotifyPropertyChanged
         if (SelectedItem != null)
         {
             var confirm = _dialogService.ShowConfirmation(
-                "Biztosan törli a tételt?",
+                Resources.BiztosanTorliATetelt,
                 "Megerősítés");
             if (!confirm) return;
 

--- a/Wrecept.UI/ViewModels/InvoiceEditorViewModel.cs
+++ b/Wrecept.UI/ViewModels/InvoiceEditorViewModel.cs
@@ -59,8 +59,8 @@ public class InvoiceEditorViewModel : INotifyPropertyChanged
     private async void SaveInvoice()
     {
         var confirm = MessageBox.Show(
-            "Biztosan menti a számlát?",
-            "Megerősítés",
+            Resources.ConfirmSaveInvoice,
+            Resources.Confirmation,
             MessageBoxButton.YesNo,
             MessageBoxImage.Question);
         if (confirm != MessageBoxResult.Yes) return;

--- a/Wrecept.UI/ViewModels/InvoiceEditorViewModel.cs
+++ b/Wrecept.UI/ViewModels/InvoiceEditorViewModel.cs
@@ -46,6 +46,13 @@ public class InvoiceEditorViewModel : INotifyPropertyChanged
     {
         if (SelectedItem != null)
         {
+            var confirm = MessageBox.Show(
+                "Biztosan törli a tételt?",
+                "Megerősítés",
+                MessageBoxButton.YesNo,
+                MessageBoxImage.Question);
+            if (confirm != MessageBoxResult.Yes) return;
+
             Items.Remove(SelectedItem);
             SelectedItem = null;
         }
@@ -53,6 +60,13 @@ public class InvoiceEditorViewModel : INotifyPropertyChanged
 
     private async void SaveInvoice()
     {
+        var confirm = MessageBox.Show(
+            "Biztosan menti a számlát?",
+            "Megerősítés",
+            MessageBoxButton.YesNo,
+            MessageBoxImage.Question);
+        if (confirm != MessageBoxResult.Yes) return;
+
         Invoice.Items = Items.ToList();
         Invoice.RecalculateTotals();
         try

--- a/Wrecept.UI/ViewModels/InvoiceEditorViewModel.cs
+++ b/Wrecept.UI/ViewModels/InvoiceEditorViewModel.cs
@@ -46,12 +46,10 @@ public class InvoiceEditorViewModel : INotifyPropertyChanged
     {
         if (SelectedItem != null)
         {
-            var confirm = MessageBox.Show(
+            var confirm = _dialogService.ShowConfirmation(
                 "Biztosan törli a tételt?",
-                "Megerősítés",
-                MessageBoxButton.YesNo,
-                MessageBoxImage.Question);
-            if (confirm != MessageBoxResult.Yes) return;
+                "Megerősítés");
+            if (!confirm) return;
 
             Items.Remove(SelectedItem);
             SelectedItem = null;


### PR DESCRIPTION
## Summary
- prompt user before exiting the application
- ask confirmation before saving or removing invoice items
- mark confirmation dialogs task as done

## Testing
- `dotnet test Wrecept.Core.sln --filter "Category!=UI"`


------
https://chatgpt.com/codex/tasks/task_e_68965a9deae48322abeb4213888fc09a