### PR TITLE
ui_agent: add confirmation resources and fix invoice editor dialogs

### DIFF
--- a/Wrecept.UI/App.xaml
+++ b/Wrecept.UI/App.xaml
@@ -5,6 +5,7 @@
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="Themes/LightTheme.xaml" />
+                <ResourceDictionary Source="StringResources.xaml" />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </Application.Resources>

--- a/Wrecept.UI/MainWindow.xaml.cs
+++ b/Wrecept.UI/MainWindow.xaml.cs
@@ -14,8 +14,8 @@ public partial class MainWindow : Window
     private void OnClosing(object? sender, CancelEventArgs e)
     {
         var confirm = MessageBox.Show(
-            Resources.ConfirmExitMessage,
-            Resources.ConfirmationTitle,
+            (string)FindResource("ConfirmExitMessage"),
+            (string)FindResource("ConfirmationTitle"),
             MessageBoxButton.YesNo,
             MessageBoxImage.Question);
         if (confirm != MessageBoxResult.Yes)

--- a/Wrecept.UI/StringResources.xaml
+++ b/Wrecept.UI/StringResources.xaml
@@ -5,5 +5,4 @@
     <sys:String x:Key="ConfirmationTitle">Confirmation</sys:String>
     <sys:String x:Key="BiztosanTorliATetelt">Are you sure you want to delete the item?</sys:String>
     <sys:String x:Key="ConfirmSaveInvoice">Are you sure you want to save the invoice?</sys:String>
-    <sys:String x:Key="Confirmation">Confirmation</sys:String>
 </ResourceDictionary>

--- a/Wrecept.UI/StringResources.xaml
+++ b/Wrecept.UI/StringResources.xaml
@@ -1,0 +1,9 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:sys="clr-namespace:System;assembly=mscorlib">
+    <sys:String x:Key="ConfirmExitMessage">Are you sure you want to exit?</sys:String>
+    <sys:String x:Key="ConfirmationTitle">Confirmation</sys:String>
+    <sys:String x:Key="BiztosanTorliATetelt">Are you sure you want to delete the item?</sys:String>
+    <sys:String x:Key="ConfirmSaveInvoice">Are you sure you want to save the invoice?</sys:String>
+    <sys:String x:Key="Confirmation">Confirmation</sys:String>
+</ResourceDictionary>

--- a/Wrecept.UI/ViewModels/InvoiceEditorViewModel.cs
+++ b/Wrecept.UI/ViewModels/InvoiceEditorViewModel.cs
@@ -66,7 +66,7 @@ public class InvoiceEditorViewModel : INotifyPropertyChanged
     {
         var confirm = MessageBox.Show(
             (string)Application.Current.FindResource("ConfirmSaveInvoice"),
-            (string)Application.Current.FindResource("Confirmation"),
+            (string)(Application.Current.TryFindResource("Confirmation") ?? "Confirmation"),
             MessageBoxButton.YesNo,
             MessageBoxImage.Question);
         if (confirm != MessageBoxResult.Yes) return;

--- a/Wrecept.UI/ViewModels/InvoiceEditorViewModel.cs
+++ b/Wrecept.UI/ViewModels/InvoiceEditorViewModel.cs
@@ -46,10 +46,12 @@ public class InvoiceEditorViewModel : INotifyPropertyChanged
     {
         if (SelectedItem != null)
         {
-            var confirm = _dialogService.ShowConfirmation(
-                Resources.BiztosanTorliATetelt,
-                "Megerősítés");
-            if (!confirm) return;
+            var confirm = MessageBox.Show(
+                (string)Application.Current.FindResource("BiztosanTorliATetelt"),
+                (string)Application.Current.FindResource("Confirmation"),
+                MessageBoxButton.YesNo,
+                MessageBoxImage.Question);
+            if (confirm != MessageBoxResult.Yes) return;
 
             Items.Remove(SelectedItem);
             SelectedItem = null;
@@ -59,8 +61,8 @@ public class InvoiceEditorViewModel : INotifyPropertyChanged
     private async void SaveInvoice()
     {
         var confirm = MessageBox.Show(
-            Resources.ConfirmSaveInvoice,
-            Resources.Confirmation,
+            (string)Application.Current.FindResource("ConfirmSaveInvoice"),
+            (string)Application.Current.FindResource("Confirmation"),
             MessageBoxButton.YesNo,
             MessageBoxImage.Question);
         if (confirm != MessageBoxResult.Yes) return;

--- a/Wrecept.UI/ViewModels/InvoiceEditorViewModel.cs
+++ b/Wrecept.UI/ViewModels/InvoiceEditorViewModel.cs
@@ -46,9 +46,13 @@ public class InvoiceEditorViewModel : INotifyPropertyChanged
     {
         if (SelectedItem != null)
         {
+            var messageObj = Application.Current.TryFindResource("BiztosanTorliATetelt");
+            var captionObj = Application.Current.TryFindResource("Confirmation");
+            var message = messageObj as string ?? "Biztosan törli a tételt?";
+            var caption = captionObj as string ?? "Megerősítés";
             var confirm = MessageBox.Show(
-                (string)Application.Current.FindResource("BiztosanTorliATetelt"),
-                (string)Application.Current.FindResource("Confirmation"),
+                message,
+                caption,
                 MessageBoxButton.YesNo,
                 MessageBoxImage.Question);
             if (confirm != MessageBoxResult.Yes) return;


### PR DESCRIPTION
## Summary
- Add shared string resource dictionary for confirmation messages
- Use FindResource in `MainWindow` to lookup exit confirmation strings
- Replace dialog service in `InvoiceEditorViewModel` with MessageBox calls using application resources

## Testing
- `dotnet test wrecept.sln --filter "Category!=UI"` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*
- `dotnet test Wrecept.Core.sln --filter "Category!=UI"`


------
https://chatgpt.com/codex/tasks/task_e_68965d028a988322beb3ea898487edd9