### PR TITLE
[ui] centralize exit confirmation resources

### DIFF
--- a/Wrecept.UI/App.xaml
+++ b/Wrecept.UI/App.xaml
@@ -5,7 +5,7 @@
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="Themes/LightTheme.xaml" />
-                <ResourceDictionary Source="StringResources.xaml" />
+                <ResourceDictionary Source="Resources/Strings.xaml" />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </Application.Resources>

--- a/Wrecept.UI/MainWindow.xaml.cs
+++ b/Wrecept.UI/MainWindow.xaml.cs
@@ -13,9 +13,13 @@ public partial class MainWindow : Window
 
     private void OnClosing(object? sender, CancelEventArgs e)
     {
+        string msg = Application.Current.TryFindResource("ConfirmExitMessage") as string
+                      ?? "Biztosan kilépsz az alkalmazásból?";
+        string title = Application.Current.TryFindResource("ConfirmExitTitle") as string
+                        ?? "Kilépés megerősítése";
         var confirm = MessageBox.Show(
-            (string)FindResource("ConfirmExitMessage"),
-            (string)FindResource("ConfirmationTitle"),
+            msg,
+            title,
             MessageBoxButton.YesNo,
             MessageBoxImage.Question);
         if (confirm != MessageBoxResult.Yes)

--- a/Wrecept.UI/Resources/Strings.xaml
+++ b/Wrecept.UI/Resources/Strings.xaml
@@ -1,0 +1,10 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:sys="clr-namespace:System;assembly=mscorlib">
+  <!-- Alap magyar sztringek -->
+  <sys:String x:Key="ConfirmExitTitle">Kilépés megerősítése</sys:String>
+  <sys:String x:Key="ConfirmExitMessage">Biztosan kilépsz az alkalmazásból?</sys:String>
+  <sys:String x:Key="BiztosanTorliATetelt">Are you sure you want to delete the item?</sys:String>
+  <sys:String x:Key="ConfirmSaveInvoice">Are you sure you want to save the invoice?</sys:String>
+  <sys:String x:Key="Confirmation">Megerősítés</sys:String>
+</ResourceDictionary>

--- a/Wrecept.UI/Resources/Strings.xaml
+++ b/Wrecept.UI/Resources/Strings.xaml
@@ -5,6 +5,6 @@
   <sys:String x:Key="ConfirmExitTitle">Kilépés megerősítése</sys:String>
   <sys:String x:Key="ConfirmExitMessage">Biztosan kilépsz az alkalmazásból?</sys:String>
   <sys:String x:Key="BiztosanTorliATetelt">Biztosan törli a tételt?</sys:String>
-  <sys:String x:Key="ConfirmSaveInvoice">Are you sure you want to save the invoice?</sys:String>
+  <sys:String x:Key="ConfirmSaveInvoice">Biztosan el szeretné menteni a számlát?</sys:String>
   <sys:String x:Key="Confirmation">Megerősítés</sys:String>
 </ResourceDictionary>

--- a/Wrecept.UI/Resources/Strings.xaml
+++ b/Wrecept.UI/Resources/Strings.xaml
@@ -4,7 +4,7 @@
   <!-- Alap magyar sztringek -->
   <sys:String x:Key="ConfirmExitTitle">Kilépés megerősítése</sys:String>
   <sys:String x:Key="ConfirmExitMessage">Biztosan kilépsz az alkalmazásból?</sys:String>
-  <sys:String x:Key="BiztosanTorliATetelt">Are you sure you want to delete the item?</sys:String>
+  <sys:String x:Key="BiztosanTorliATetelt">Biztosan törli a tételt?</sys:String>
   <sys:String x:Key="ConfirmSaveInvoice">Are you sure you want to save the invoice?</sys:String>
   <sys:String x:Key="Confirmation">Megerősítés</sys:String>
 </ResourceDictionary>

--- a/Wrecept.UI/StringResources.xaml
+++ b/Wrecept.UI/StringResources.xaml
@@ -1,8 +1,0 @@
-<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:sys="clr-namespace:System;assembly=mscorlib">
-    <sys:String x:Key="ConfirmExitMessage">Are you sure you want to exit?</sys:String>
-    <sys:String x:Key="ConfirmationTitle">Confirmation</sys:String>
-    <sys:String x:Key="BiztosanTorliATetelt">Are you sure you want to delete the item?</sys:String>
-    <sys:String x:Key="ConfirmSaveInvoice">Are you sure you want to save the invoice?</sys:String>
-</ResourceDictionary>

--- a/Wrecept.UI/ViewModels/InvoiceEditorViewModel.cs
+++ b/Wrecept.UI/ViewModels/InvoiceEditorViewModel.cs
@@ -64,9 +64,13 @@ public class InvoiceEditorViewModel : INotifyPropertyChanged
 
     private async void SaveInvoice()
     {
+        string saveMsg = Application.Current.TryFindResource("ConfirmSaveInvoice") as string
+                          ?? "Biztosan menti a számlát?";
+        string caption = Application.Current.TryFindResource("Confirmation") as string
+                          ?? "Megerősítés";
         var confirm = MessageBox.Show(
-            (string)Application.Current.FindResource("ConfirmSaveInvoice"),
-            (string)(Application.Current.TryFindResource("Confirmation") ?? "Confirmation"),
+            saveMsg,
+            caption,
             MessageBoxButton.YesNo,
             MessageBoxImage.Question);
         if (confirm != MessageBoxResult.Yes) return;


### PR DESCRIPTION
## Summary
- centralize exit confirmation strings in application-level resource dictionary
- wire up dictionary in App.xaml and add safe fallbacks for MessageBox dialogs
- harden invoice editor confirmations with TryFindResource

## Testing
- `dotnet test Wrecept.Core.sln --filter "Category!=UI"`

------
https://chatgpt.com/codex/tasks/task_e_68966fa13ffc83229dfb012a17ca12ac