### PR TITLE
ui_agent: add invoice search suggestions

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -48,7 +48,7 @@
 - [x] `DONE` Confirmation popups for all critical actions
 - [ ] `TODO` Implement contextual tooltips across the UI
 - [ ] `TODO` Provide quick keyboard cheat sheet within the application
-- [ ] `TODO` Display auto-suggestions and predictive text in `InvoiceEditorView`
+- [ ] `IN_PROGRESS` Display auto-suggestions and predictive text in `InvoiceEditorView`
 - [ ] `TODO` Develop customizable dashboard views for financial and inventory metrics
 
 ## test_agent

--- a/Wrecept.UI/ViewModels/InvoiceEditorViewModel.cs
+++ b/Wrecept.UI/ViewModels/InvoiceEditorViewModel.cs
@@ -1,4 +1,5 @@
 using System.Collections.ObjectModel;
+using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -23,9 +24,35 @@ public class InvoiceEditorViewModel : INotifyPropertyChanged
 
     public Invoice Invoice { get; } = new();
 
+    public ObservableCollection<string> Suggestions { get; } = new();
+    private string _searchTerm = string.Empty;
+    public string SearchTerm
+    {
+        get => _searchTerm;
+        set
+        {
+            if (_searchTerm != value)
+            {
+                _searchTerm = value;
+                OnPropertyChanged();
+                UpdateSuggestions();
+            }
+        }
+    }
+
+    private string? _selectedSuggestion;
+    public string? SelectedSuggestion
+    {
+        get => _selectedSuggestion;
+        set { _selectedSuggestion = value; OnPropertyChanged(); }
+    }
+
+    public bool HasSuggestions => Suggestions.Any();
+
     public ICommand AddItemCommand { get; }
     public ICommand DeleteItemCommand { get; }
     public ICommand SaveCommand { get; }
+    public ICommand SelectSuggestionCommand { get; }
 
     public InvoiceEditorViewModel(IInvoiceService invoiceService)
     {
@@ -33,6 +60,8 @@ public class InvoiceEditorViewModel : INotifyPropertyChanged
         AddItemCommand = new RelayCommand(_ => AddItem());
         DeleteItemCommand = new RelayCommand(_ => DeleteItem(), _ => SelectedItem != null);
         SaveCommand = new RelayCommand(_ => SaveInvoice());
+        SelectSuggestionCommand = new RelayCommand(p => SelectSuggestion(p as string));
+        Suggestions.CollectionChanged += (_, __) => OnPropertyChanged(nameof(HasSuggestions));
     }
 
     private void AddItem()
@@ -86,6 +115,23 @@ public class InvoiceEditorViewModel : INotifyPropertyChanged
         {
             MessageBox.Show($"Mentési hiba: {ex.Message}");
         }
+    }
+
+    private void SelectSuggestion(string? suggestion)
+    {
+        if (suggestion == null) return;
+        SearchTerm = suggestion;
+        Suggestions.Clear();
+    }
+
+    private void UpdateSuggestions()
+    {
+        Suggestions.Clear();
+        if (string.IsNullOrWhiteSpace(SearchTerm)) return;
+
+        // Placeholder suggestion logic
+        Suggestions.Add(SearchTerm + " 1");
+        Suggestions.Add(SearchTerm + " 2");
     }
 
     public event PropertyChangedEventHandler? PropertyChanged;

--- a/Wrecept.UI/ViewModels/InvoiceEditorViewModel.cs
+++ b/Wrecept.UI/ViewModels/InvoiceEditorViewModel.cs
@@ -47,7 +47,7 @@ public class InvoiceEditorViewModel : INotifyPropertyChanged
         set { _selectedSuggestion = value; OnPropertyChanged(); }
     }
 
-    public bool HasSuggestions => Suggestions.Any();
+    public bool HasSuggestions => _hasSuggestions;
 
     public ICommand AddItemCommand { get; }
     public ICommand DeleteItemCommand { get; }

--- a/Wrecept.UI/ViewModels/InvoiceEditorViewModel.cs
+++ b/Wrecept.UI/ViewModels/InvoiceEditorViewModel.cs
@@ -129,9 +129,16 @@ public class InvoiceEditorViewModel : INotifyPropertyChanged
         Suggestions.Clear();
         if (string.IsNullOrWhiteSpace(SearchTerm)) return;
 
-        // Placeholder suggestion logic
-        Suggestions.Add(SearchTerm + " 1");
-        Suggestions.Add(SearchTerm + " 2");
+        // Suggest items from existing invoice data that match the search term
+        var matchingItems = Items
+            .Where(item => !string.IsNullOrWhiteSpace(item.Name) && item.Name.Contains(SearchTerm, StringComparison.OrdinalIgnoreCase))
+            .Select(item => item.Name)
+            .Distinct()
+            .ToList();
+        foreach (var suggestion in matchingItems)
+        {
+            Suggestions.Add(suggestion);
+        }
     }
 
     public event PropertyChangedEventHandler? PropertyChanged;

--- a/Wrecept.UI/Views/InvoiceEditorView.xaml
+++ b/Wrecept.UI/Views/InvoiceEditorView.xaml
@@ -5,18 +5,35 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              KeyboardNavigation.TabNavigation="None"
              mc:Ignorable="d">
+    <UserControl.Resources>
+        <BooleanToVisibilityConverter x:Key="BoolToVisibility" />
+    </UserControl.Resources>
     <UserControl.InputBindings>
         <KeyBinding Key="I" Modifiers="Control" Command="{Binding AddItemCommand}" />
+        <KeyBinding Key="Insert" Command="{Binding AddItemCommand}" />
+        <KeyBinding Key="Enter" Command="{Binding AddItemCommand}" />
         <KeyBinding Key="Delete" Command="{Binding DeleteItemCommand}" />
         <KeyBinding Key="S" Modifiers="Control" Command="{Binding SaveCommand}" />
     </UserControl.InputBindings>
     <Grid>
         <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
             <RowDefinition />
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
+        <StackPanel Grid.Row="0" Margin="0,0,0,5">
+            <TextBox x:Name="tbSearch" Text="{Binding SearchTerm, UpdateSourceTrigger=PropertyChanged}" />
+            <ListBox x:Name="lstSuggestions"
+                     ItemsSource="{Binding Suggestions}"
+                     SelectedItem="{Binding SelectedSuggestion}"
+                     Visibility="{Binding HasSuggestions, Converter={StaticResource BoolToVisibility}}">
+                <ListBox.InputBindings>
+                    <KeyBinding Key="Enter" Command="{Binding SelectSuggestionCommand}" CommandParameter="{Binding SelectedItem, RelativeSource={RelativeSource AncestorType=ListBox}}" />
+                </ListBox.InputBindings>
+            </ListBox>
+        </StackPanel>
         <DataGrid x:Name="dgInvoiceItems"
-                  Grid.Row="0"
+                  Grid.Row="1"
                   ItemsSource="{Binding Items}"
                   SelectedItem="{Binding SelectedItem}"
                   AutoGenerateColumns="False">
@@ -28,7 +45,7 @@
                 <DataGridTextColumn Header="Összesen" Binding="{Binding TotalGross}" Width="*" IsReadOnly="True" />
             </DataGrid.Columns>
         </DataGrid>
-        <Grid Grid.Row="1" Margin="0,5,0,0">
+        <Grid Grid.Row="2" Margin="0,5,0,0">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition />
                 <ColumnDefinition />

--- a/Wrecept.UI/Views/InvoiceEditorView.xaml
+++ b/Wrecept.UI/Views/InvoiceEditorView.xaml
@@ -26,9 +26,10 @@
             <ListBox x:Name="lstSuggestions"
                      ItemsSource="{Binding Suggestions}"
                      SelectedItem="{Binding SelectedSuggestion}"
+                     DisplayMemberPath="Name"
                      Visibility="{Binding HasSuggestions, Converter={StaticResource BoolToVisibility}}">
                 <ListBox.InputBindings>
-                    <KeyBinding Key="Enter" Command="{Binding SelectSuggestionCommand}" CommandParameter="{Binding SelectedItem, RelativeSource={RelativeSource AncestorType=ListBox}}" />
+                    <KeyBinding Key="Enter" Command="{Binding SelectSuggestionCommand}" CommandParameter="{Binding SelectedSuggestion.Name}" />
                 </ListBox.InputBindings>
             </ListBox>
         </StackPanel>


### PR DESCRIPTION
## Summary
- add basic search box with suggestion list to InvoiceEditor
- wire up suggestion properties and command in `InvoiceEditorViewModel`
- track auto-suggestion feature progress in `TODO.md`

## Testing
- `dotnet test Wrecept.Core.sln --filter "Category!=UI"`


------
https://chatgpt.com/codex/tasks/task_e_6896770dc0c48322bea27fa0993a1030