### PR TITLE
ui_agent: add invoice search suggestions

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -48,7 +48,7 @@
 - [x] `DONE` Confirmation popups for all critical actions
 - [ ] `TODO` Implement contextual tooltips across the UI
 - [ ] `TODO` Provide quick keyboard cheat sheet within the application
-- [ ] `TODO` Display auto-suggestions and predictive text in `InvoiceEditorView`
+- [ ] `IN_PROGRESS` Display auto-suggestions and predictive text in `InvoiceEditorView`
 - [ ] `TODO` Develop customizable dashboard views for financial and inventory metrics
 
 ## test_agent

--- a/Wrecept.UI/ViewModels/InvoiceEditorViewModel.cs
+++ b/Wrecept.UI/ViewModels/InvoiceEditorViewModel.cs
@@ -1,4 +1,5 @@
 using System.Collections.ObjectModel;
+using System;
 using System.ComponentModel;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -23,9 +24,48 @@ public class InvoiceEditorViewModel : INotifyPropertyChanged
 
     public Invoice Invoice { get; } = new();
 
+    public ObservableCollection<string> Suggestions { get; } = new();
+    private string _searchTerm = string.Empty;
+    public string SearchTerm
+    {
+        get => _searchTerm;
+        set
+        {
+            if (_searchTerm != value)
+            {
+                _searchTerm = value;
+                OnPropertyChanged();
+                UpdateSuggestions();
+            }
+        }
+    }
+
+    private string? _selectedSuggestion;
+    public string? SelectedSuggestion
+    {
+        get => _selectedSuggestion;
+        set { _selectedSuggestion = value; OnPropertyChanged(); }
+    }
+
+    private bool _hasSuggestions;
+    public bool HasSuggestions
+    {
+        get => _hasSuggestions;
+        private set
+        {
+            if (_hasSuggestions != value)
+            {
+                _hasSuggestions = value;
+                OnPropertyChanged();
+            }
+        }
+    }
+
     public ICommand AddItemCommand { get; }
     public ICommand DeleteItemCommand { get; }
     public ICommand SaveCommand { get; }
+    public ICommand SelectSuggestionCommand { get; }
+    public ICommand CloseSuggestionsCommand { get; }
 
     public InvoiceEditorViewModel(IInvoiceService invoiceService)
     {
@@ -33,6 +73,8 @@ public class InvoiceEditorViewModel : INotifyPropertyChanged
         AddItemCommand = new RelayCommand(_ => AddItem());
         DeleteItemCommand = new RelayCommand(_ => DeleteItem(), _ => SelectedItem != null);
         SaveCommand = new RelayCommand(_ => SaveInvoice());
+        SelectSuggestionCommand = new RelayCommand(p => SelectSuggestion(p as string));
+        CloseSuggestionsCommand = new RelayCommand(_ => CloseSuggestions());
     }
 
     private void AddItem()
@@ -86,6 +128,42 @@ public class InvoiceEditorViewModel : INotifyPropertyChanged
         {
             MessageBox.Show($"Mentési hiba: {ex.Message}");
         }
+    }
+
+    private void SelectSuggestion(string? suggestion)
+    {
+        if (suggestion == null) return;
+        SearchTerm = suggestion;
+        CloseSuggestions();
+    }
+
+    private void UpdateSuggestions()
+    {
+        Suggestions.Clear();
+        if (string.IsNullOrWhiteSpace(SearchTerm))
+        {
+            HasSuggestions = false;
+            return;
+        }
+
+        var matches = Items
+            .Select(i => i.Product?.Name ?? string.Empty)
+            .Where(n => n.Contains(SearchTerm, StringComparison.InvariantCultureIgnoreCase))
+            .Distinct();
+
+        foreach (var match in matches)
+        {
+            Suggestions.Add(match);
+        }
+
+        HasSuggestions = Suggestions.Any();
+    }
+
+    private void CloseSuggestions()
+    {
+        Suggestions.Clear();
+        SelectedSuggestion = null;
+        HasSuggestions = false;
     }
 
     public event PropertyChangedEventHandler? PropertyChanged;

--- a/Wrecept.UI/Views/InvoiceEditorView.xaml
+++ b/Wrecept.UI/Views/InvoiceEditorView.xaml
@@ -5,18 +5,34 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              KeyboardNavigation.TabNavigation="None"
              mc:Ignorable="d">
+    <UserControl.Resources>
+        <BooleanToVisibilityConverter x:Key="BoolToVisibility" />
+    </UserControl.Resources>
     <UserControl.InputBindings>
         <KeyBinding Key="I" Modifiers="Control" Command="{Binding AddItemCommand}" />
+        <KeyBinding Key="Insert" Command="{Binding AddItemCommand}" />
+        <KeyBinding Key="Enter" Command="{Binding AddItemCommand}" />
         <KeyBinding Key="Delete" Command="{Binding DeleteItemCommand}" />
         <KeyBinding Key="S" Modifiers="Control" Command="{Binding SaveCommand}" />
     </UserControl.InputBindings>
     <Grid>
         <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
             <RowDefinition />
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
+        <StackPanel Grid.Row="0" Margin="0,0,0,5">
+            <TextBox x:Name="tbSearch"
+                     Text="{Binding SearchTerm, UpdateSourceTrigger=PropertyChanged}"
+                     PreviewKeyDown="TbSearch_PreviewKeyDown" />
+            <ListBox x:Name="lstSuggestions"
+                     ItemsSource="{Binding Suggestions}"
+                     SelectedItem="{Binding SelectedSuggestion}"
+                     Visibility="{Binding HasSuggestions, Converter={StaticResource BoolToVisibility}}"
+                     PreviewKeyDown="LstSuggestions_PreviewKeyDown" />
+        </StackPanel>
         <DataGrid x:Name="dgInvoiceItems"
-                  Grid.Row="0"
+                  Grid.Row="1"
                   ItemsSource="{Binding Items}"
                   SelectedItem="{Binding SelectedItem}"
                   AutoGenerateColumns="False">
@@ -28,7 +44,7 @@
                 <DataGridTextColumn Header="Összesen" Binding="{Binding TotalGross}" Width="*" IsReadOnly="True" />
             </DataGrid.Columns>
         </DataGrid>
-        <Grid Grid.Row="1" Margin="0,5,0,0">
+        <Grid Grid.Row="2" Margin="0,5,0,0">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition />
                 <ColumnDefinition />

--- a/Wrecept.UI/Views/InvoiceEditorView.xaml.cs
+++ b/Wrecept.UI/Views/InvoiceEditorView.xaml.cs
@@ -1,4 +1,8 @@
+using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Input;
+using System.Linq;
+using Wrecept.UI.ViewModels;
 
 namespace Wrecept.UI.Views;
 
@@ -7,5 +11,87 @@ public partial class InvoiceEditorView : UserControl
     public InvoiceEditorView()
     {
         InitializeComponent();
+    }
+
+    private InvoiceEditorViewModel? Vm => DataContext as InvoiceEditorViewModel;
+
+    private void TbSearch_PreviewKeyDown(object sender, KeyEventArgs e)
+    {
+        if (Vm == null) return;
+
+        if (e.Key == Key.Down && Vm.HasSuggestions)
+        {
+            lstSuggestions.SelectedIndex = 0;
+            lstSuggestions.Focus();
+            e.Handled = true;
+        }
+        else if (e.Key == Key.Up && Vm.HasSuggestions)
+        {
+            if (lstSuggestions.Items.Count > 0)
+            {
+                lstSuggestions.SelectedIndex = lstSuggestions.Items.Count - 1;
+                lstSuggestions.Focus();
+                e.Handled = true;
+            }
+        }
+        else if (e.Key == Key.Enter)
+        {
+            if (Vm.HasSuggestions)
+            {
+                var suggestion = lstSuggestions.SelectedItem as string ?? lstSuggestions.Items.Cast<object>().FirstOrDefault() as string;
+                if (suggestion != null)
+                {
+                    Vm.SelectSuggestionCommand.Execute(suggestion);
+                }
+                dgInvoiceItems.Focus();
+            }
+            else
+            {
+                Vm.AddItemCommand.Execute(null);
+                dgInvoiceItems.Focus();
+            }
+            e.Handled = true;
+        }
+        else if (e.Key == Key.Escape)
+        {
+            if (Vm.HasSuggestions)
+            {
+                Vm.CloseSuggestionsCommand.Execute(null);
+            }
+            dgInvoiceItems.Focus();
+            e.Handled = true;
+        }
+    }
+
+    private void LstSuggestions_PreviewKeyDown(object sender, KeyEventArgs e)
+    {
+        if (Vm == null) return;
+
+        if (e.Key == Key.Enter)
+        {
+            var suggestion = lstSuggestions.SelectedItem as string;
+            if (suggestion != null)
+            {
+                Vm.SelectSuggestionCommand.Execute(suggestion);
+            }
+            dgInvoiceItems.Focus();
+            e.Handled = true;
+        }
+        else if (e.Key == Key.Up && lstSuggestions.SelectedIndex == 0)
+        {
+            tbSearch.Focus();
+            e.Handled = true;
+        }
+        else if (e.Key == Key.Down && lstSuggestions.SelectedIndex == lstSuggestions.Items.Count - 1)
+        {
+            tbSearch.Focus();
+            e.Handled = true;
+        }
+        else if (e.Key == Key.Escape)
+        {
+            Vm.CloseSuggestionsCommand.Execute(null);
+            dgInvoiceItems.Focus();
+            e.Handled = true;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add command to close invoice item suggestions
- route arrow keys and Enter/Escape between search box, suggestion list, and grid

## Testing
- `dotnet build wrecept.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*
- `dotnet build Wrecept.Core.sln`
- `dotnet test Wrecept.Core.sln --filter "Category!=UI"`


------
https://chatgpt.com/codex/tasks/task_e_6896770dc0c48322bea27fa0993a1030