### PR TITLE
Fix InvoiceEditorView grid layout

### DIFF
--- a/Wrecept.UI/Views/InvoiceEditorView.xaml
+++ b/Wrecept.UI/Views/InvoiceEditorView.xaml
@@ -32,7 +32,6 @@
                      PreviewKeyDown="LstSuggestions_PreviewKeyDown" />
         </StackPanel>
         <DataGrid x:Name="dgInvoiceItems"
-                  Grid.Row="0"
                   Grid.Row="1"
                   ItemsSource="{Binding Items}"
                   SelectedItem="{Binding SelectedItem}"
@@ -45,7 +44,6 @@
                 <DataGridTextColumn Header="Összesen" Binding="{Binding TotalGross}" Width="*" IsReadOnly="True" />
             </DataGrid.Columns>
         </DataGrid>
-        <Grid Grid.Row="1" Margin="0,5,0,0">
         <Grid Grid.Row="2" Margin="0,5,0,0">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition />


### PR DESCRIPTION
## Summary
- fix duplicate Grid.Row attribute and mismatched Grid tags in InvoiceEditorView

## Testing
- `dotnet test --filter "Category!=UI" Wrecept.Core.sln`

------
https://chatgpt.com/codex/tasks/task_e_68967f7bb62883228c54b8ed8be87996