### PR TITLE
Add dashboard view, theme toggle, and keyboard navigation

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -42,14 +42,14 @@
 
 ## ui_agent
  - [ ] `IN_PROGRESS` Basic `MainView` + `InvoiceEditorView` XAML layout
-- [ ] `TODO NEEDS_REVIEW` Implement keyboard-only navigation (Enter, Escape, arrows, Tab)
-- [ ] `TODO NEEDS_REVIEW` Introduction of themes (dark/light + customisation)
+ - [ ] `IN_PROGRESS` Implement keyboard-only navigation (Enter, Escape, arrows, Tab)
+ - [ ] `IN_PROGRESS` Introduction of themes (dark/light + customisation)
  - [ ] `IN_PROGRESS` ThemeEditorView – theme management UI editor
 - [x] `DONE` Confirmation popups for all critical actions
 - [ ] `IN_PROGRESS` Implement contextual tooltips across the UI
 - [ ] `TODO` Provide quick keyboard cheat sheet within the application
 - [ ] `IN_PROGRESS` Display auto-suggestions and predictive text in `InvoiceEditorView`
-- [ ] `TODO` Develop customizable dashboard views for financial and inventory metrics
+ - [ ] `IN_PROGRESS` Develop customizable dashboard views for financial and inventory metrics
 
 ## test_agent
 - [ ] `TODO NEEDS_REVIEW` Unit tests for the Service layer

--- a/Wrecept.UI/App.xaml.cs
+++ b/Wrecept.UI/App.xaml.cs
@@ -68,6 +68,8 @@ public partial class App : Application
                 services.AddSingleton<ThemeEditorViewModel>();
                 services.AddTransient<ThemeEditorView>();
                 services.AddTransient<ThemeEditorWindow>();
+                services.AddSingleton<DashboardViewModel>();
+                services.AddTransient<DashboardView>();
                 services.AddSingleton<IExportService, ExportService>();
                 services.AddSingleton<MainViewModel>();
                 services.AddTransient<MainView>();
@@ -101,6 +103,10 @@ public partial class App : Application
         Resources.MergedDictionaries.Add(new ResourceDictionary
         {
             Source = new Uri($"Themes/{theme}Theme.xaml", UriKind.Relative)
+        });
+        Resources.MergedDictionaries.Add(new ResourceDictionary
+        {
+            Source = new Uri("Resources/Strings.xaml", UriKind.Relative)
         });
     }
 

--- a/Wrecept.UI/ViewModels/DashboardViewModel.cs
+++ b/Wrecept.UI/ViewModels/DashboardViewModel.cs
@@ -1,0 +1,12 @@
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace Wrecept.UI.ViewModels;
+
+public class DashboardViewModel : INotifyPropertyChanged
+{
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    protected void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+        => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+}

--- a/Wrecept.UI/Views/DashboardView.xaml
+++ b/Wrecept.UI/Views/DashboardView.xaml
@@ -1,0 +1,11 @@
+<UserControl x:Class="Wrecept.UI.Views.DashboardView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d">
+    <Grid>
+        <TextBlock Text="Dashboard coming soon..."
+                   HorizontalAlignment="Center" VerticalAlignment="Center"/>
+    </Grid>
+</UserControl>

--- a/Wrecept.UI/Views/DashboardView.xaml.cs
+++ b/Wrecept.UI/Views/DashboardView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace Wrecept.UI.Views;
+
+public partial class DashboardView : UserControl
+{
+    public DashboardView()
+    {
+        InitializeComponent();
+    }
+}

--- a/Wrecept.UI/Views/InvoiceEditorView.xaml
+++ b/Wrecept.UI/Views/InvoiceEditorView.xaml
@@ -60,9 +60,12 @@
                 <TextBlock Text="{Binding Invoice.TotalGross}" />
             </StackPanel>
             <StackPanel Orientation="Horizontal" Grid.Column="1" HorizontalAlignment="Right">
-                <Button x:Name="btnAddItem" Content="Elem hozzáadása" Command="{Binding AddItemCommand}" Margin="0,0,5,0" />
-                <Button x:Name="btnDeleteItem" Content="Elem eltávolítása" Command="{Binding DeleteItemCommand}" Margin="0,0,5,0" />
-                <Button x:Name="btnSave" Content="Mentés" Command="{Binding SaveCommand}" />
+                <Button x:Name="btnAddItem" Content="Elem hozzáadása" Command="{Binding AddItemCommand}" Margin="0,0,5,0"
+                        ToolTipService.ToolTip="Új tétel hozzáadása (Insert)" />
+                <Button x:Name="btnDeleteItem" Content="Elem eltávolítása" Command="{Binding DeleteItemCommand}" Margin="0,0,5,0"
+                        ToolTipService.ToolTip="Kijelölt tétel törlése (Delete)" />
+                <Button x:Name="btnSave" Content="Mentés" Command="{Binding SaveCommand}"
+                        ToolTipService.ToolTip="Számla mentése (Ctrl+S)" />
             </StackPanel>
         </Grid>
     </Grid>

--- a/Wrecept.UI/Views/MainView.xaml
+++ b/Wrecept.UI/Views/MainView.xaml
@@ -13,9 +13,11 @@
         <KeyBinding Key="Up" Command="{Binding UpCommand}" />
         <KeyBinding Key="Down" Command="{Binding DownCommand}" />
         <KeyBinding Key="F1" Command="{Binding ShowShortcutHelpCommand}" />
+        <KeyBinding Key="F2" Command="{Binding ToggleThemeCommand}" />
     </UserControl.InputBindings>
     <DockPanel>
         <Menu DockPanel.Dock="Top">
+            <MenuItem Header="_Dashboard" ToolTip="Áttekintés" Command="{Binding DashboardCommand}" InputGestureText="Ctrl+0"/>
             <MenuItem Header="_Accounts" ToolTip="Fiókok" Command="{Binding AccountsCommand}" InputGestureText="Ctrl+1"/>
             <MenuItem Header="_Stocks" ToolTip="Készletek" Command="{Binding StocksCommand}" InputGestureText="Ctrl+2"/>
             <MenuItem Header="_Lists" ToolTip="Listák" Command="{Binding ListsCommand}" InputGestureText="Ctrl+3"/>

--- a/docs/progress/2025-08-09_0000_ui_agent.md
+++ b/docs/progress/2025-08-09_0000_ui_agent.md
@@ -1,0 +1,6 @@
+# Progress Log - ui_agent
+
+- Added basic Dashboard view and integrated into main menu.
+- Enabled arrow-key navigation between main sections.
+- Introduced F2 theme toggle and preserved resource dictionaries during theme switch.
+- Extended tooltip coverage for invoice editor actions.


### PR DESCRIPTION
## Summary
- add dashboard view and integrate into main menu
- enable arrow-key navigation and F2 theme toggle
- expand tooltip coverage in invoice editor

## Testing
- `dotnet test Wrecept.Core.sln --filter "Category!=UI"`


------
https://chatgpt.com/codex/tasks/task_e_68968ef7ac488322b437f8674db35559