### PR TITLE
ui_agent: populate dashboard with analytics data

### DIFF
--- a/Wrecept.UI/ViewModels/DashboardViewModel.cs
+++ b/Wrecept.UI/ViewModels/DashboardViewModel.cs
@@ -1,10 +1,41 @@
+using System;
+using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Wrecept.Core.Services;
+using Wrecept.Core.Services.Dtos;
 
 namespace Wrecept.UI.ViewModels;
 
 public class DashboardViewModel : INotifyPropertyChanged
 {
+    private readonly IAnalyticsService _analyticsService;
+
+    public ObservableCollection<MonthlyRevenueDto> MonthlyRevenue { get; } = new();
+    public ObservableCollection<TopSupplierDto> TopSuppliers { get; } = new();
+
+    public DashboardViewModel(IAnalyticsService analyticsService)
+    {
+        _analyticsService = analyticsService;
+        _ = LoadAsync();
+    }
+
+    private async Task LoadAsync()
+    {
+        var year = DateTime.Now.Year;
+
+        var revenue = await _analyticsService.GetMonthlyRevenueAsync(year);
+        MonthlyRevenue.Clear();
+        foreach (var r in revenue)
+            MonthlyRevenue.Add(r);
+
+        var suppliers = await _analyticsService.GetTopSuppliersAsync(5);
+        TopSuppliers.Clear();
+        foreach (var s in suppliers)
+            TopSuppliers.Add(s);
+    }
+
     public event PropertyChangedEventHandler? PropertyChanged;
 
     protected void OnPropertyChanged([CallerMemberName] string? propertyName = null)

--- a/Wrecept.UI/Views/DashboardView.xaml
+++ b/Wrecept.UI/Views/DashboardView.xaml
@@ -4,8 +4,36 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="d">
-    <Grid>
-        <TextBlock Text="Dashboard coming soon..."
-                   HorizontalAlignment="Center" VerticalAlignment="Center"/>
+    <Grid Margin="10">
+        <Grid.RowDefinitions>
+            <RowDefinition />
+            <RowDefinition />
+        </Grid.RowDefinitions>
+
+        <GroupBox Header="Havi bevétel">
+            <DataGrid x:Name="dgMonthlyRevenue"
+                      ItemsSource="{Binding MonthlyRevenue}"
+                      AutoGenerateColumns="False"
+                      IsReadOnly="True">
+                <DataGrid.Columns>
+                    <DataGridTextColumn Header="Hónap" Binding="{Binding Month}" />
+                    <DataGridTextColumn Header="Nettó" Binding="{Binding TotalNet}" />
+                    <DataGridTextColumn Header="ÁFA" Binding="{Binding TotalVat}" />
+                    <DataGridTextColumn Header="Bruttó" Binding="{Binding TotalGross}" />
+                </DataGrid.Columns>
+            </DataGrid>
+        </GroupBox>
+
+        <GroupBox Grid.Row="1" Header="Top beszállítók">
+            <DataGrid x:Name="dgTopSuppliers"
+                      ItemsSource="{Binding TopSuppliers}"
+                      AutoGenerateColumns="False"
+                      IsReadOnly="True">
+                <DataGrid.Columns>
+                    <DataGridTextColumn Header="Beszállító" Binding="{Binding SupplierName}" />
+                    <DataGridTextColumn Header="Bruttó összeg" Binding="{Binding TotalGross}" />
+                </DataGrid.Columns>
+            </DataGrid>
+        </GroupBox>
     </Grid>
 </UserControl>

--- a/docs/progress/2025-08-09_0011_ui_agent.md
+++ b/docs/progress/2025-08-09_0011_ui_agent.md
@@ -1,0 +1,5 @@
+# Progress Log 2025-08-09
+
+## ui_agent
+
+- Added data-driven dashboard showing monthly revenue and top suppliers using analytics service. Ref: TODO ui_agent.


### PR DESCRIPTION
## Summary
- show monthly revenue and top suppliers on dashboard using AnalyticsService
- document dashboard progress

## Testing
- `dotnet test Wrecept.Core.sln --filter "Category!=UI"`


------
https://chatgpt.com/codex/tasks/task_e_68969198430083229a2b93475c3106ca