### PR TITLE
Async theme loading and refined main view layout

### DIFF
--- a/Wrecept.UI/MainWindow.xaml
+++ b/Wrecept.UI/MainWindow.xaml
@@ -5,7 +5,9 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:views="clr-namespace:Wrecept.UI.Views"
         mc:Ignorable="d"
-        Title="Wrecept" Height="450" Width="800"
+        Title="Wrecept" Width="1024" Height="768" MinWidth="800" MinHeight="600"
+        FontFamily="Segoe UI" FontSize="14"
+        WindowStartupLocation="CenterScreen"
         Background="{DynamicResource WindowBackgroundBrush}"
         Foreground="{DynamicResource WindowForegroundBrush}">
     <views:MainView />

--- a/Wrecept.UI/ViewModels/MainViewModel.cs
+++ b/Wrecept.UI/ViewModels/MainViewModel.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
 using System.Windows.Controls;
 using System.Windows.Input;
 using Microsoft.Extensions.DependencyInjection;
@@ -51,12 +52,12 @@ public class MainViewModel : INotifyPropertyChanged
     }
 
     private readonly ISettingsService _settingsService;
-    private string _currentTheme;
+    private string _currentTheme = "Light";
 
     public MainViewModel(ISettingsService settingsService)
     {
         _settingsService = settingsService;
-        _currentTheme = _settingsService.LoadAsync().Result.Theme;
+        _ = LoadThemeAsync();
 
         DashboardCommand = new RelayCommand(_ => SetSection(MainSection.Dashboard));
         AccountsCommand = new RelayCommand(_ => SetSection(MainSection.Accounts));
@@ -83,6 +84,12 @@ public class MainViewModel : INotifyPropertyChanged
         });
 
         SetSection(MainSection.Dashboard);
+    }
+
+    private async Task LoadThemeAsync()
+    {
+        var settings = await _settingsService.LoadAsync();
+        _currentTheme = string.IsNullOrEmpty(settings.Theme) ? "Light" : settings.Theme;
     }
 
     private UserControl CreateView<TView, TViewModel>()

--- a/Wrecept.UI/Views/MainView.xaml
+++ b/Wrecept.UI/Views/MainView.xaml
@@ -16,7 +16,7 @@
         <KeyBinding Key="F2" Command="{Binding ToggleThemeCommand}" />
     </UserControl.InputBindings>
     <DockPanel>
-        <Menu DockPanel.Dock="Top">
+        <Menu DockPanel.Dock="Top" FontSize="14" FontFamily="Segoe UI">
             <MenuItem Header="_Dashboard" ToolTip="Áttekintés" Command="{Binding DashboardCommand}" InputGestureText="Ctrl+0"/>
             <MenuItem Header="_Accounts" ToolTip="Fiókok" Command="{Binding AccountsCommand}" InputGestureText="Ctrl+1"/>
             <MenuItem Header="_Stocks" ToolTip="Készletek" Command="{Binding StocksCommand}" InputGestureText="Ctrl+2"/>
@@ -24,6 +24,11 @@
             <MenuItem Header="_Maintenance" ToolTip="Karbantartás" Command="{Binding MaintenanceCommand}" InputGestureText="Ctrl+4"/>
             <MenuItem Header="_Contacts" ToolTip="Kapcsolatok" Command="{Binding ContactsCommand}" InputGestureText="Ctrl+5"/>
         </Menu>
-        <ContentControl Content="{Binding CurrentView}"/>
+        <StatusBar DockPanel.Dock="Bottom" FontSize="12" FontFamily="Segoe UI">
+            <StatusBarItem Content="Ready" />
+        </StatusBar>
+        <Border Padding="10" Background="{DynamicResource WindowBackgroundBrush}">
+            <ContentControl Content="{Binding CurrentView}"/>
+        </Border>
     </DockPanel>
 </UserControl>


### PR DESCRIPTION
## Summary
- load application theme asynchronously to avoid blocking in MainViewModel
- polish main window and view layout with consistent fonts, padding, and status bar

## Testing
- `dotnet test Wrecept.Core.sln --filter "Category!=UI"`


------
https://chatgpt.com/codex/tasks/task_e_6896a663241c8322acf6ad9bc90f4a0a