### PR TITLE
ui: add keyboard navigation commands

### DIFF
--- a/Wrecept.UI/ViewModels/IKeyboardNavigable.cs
+++ b/Wrecept.UI/ViewModels/IKeyboardNavigable.cs
@@ -1,0 +1,7 @@
+namespace Wrecept.UI.ViewModels;
+
+public interface IKeyboardNavigable
+{
+    void OnEnter();
+    void OnEscape();
+}

--- a/Wrecept.UI/ViewModels/InvoiceEditorViewModel.cs
+++ b/Wrecept.UI/ViewModels/InvoiceEditorViewModel.cs
@@ -11,7 +11,7 @@ using System.Threading.Tasks;
 
 namespace Wrecept.UI.ViewModels;
 
-public class InvoiceEditorViewModel : INotifyPropertyChanged
+public class InvoiceEditorViewModel : INotifyPropertyChanged, IKeyboardNavigable
 {
     private readonly IInvoiceService _invoiceService;
     private readonly ISuggestionIndexService _suggestionIndexService;
@@ -167,6 +167,10 @@ public class InvoiceEditorViewModel : INotifyPropertyChanged
         SelectedSuggestion = null;
         HasSuggestions = false;
     }
+
+    public void OnEnter() => AddItem();
+
+    public void OnEscape() => CloseSuggestions();
 
     public event PropertyChangedEventHandler? PropertyChanged;
     protected void OnPropertyChanged([CallerMemberName] string? name = null)

--- a/Wrecept.UI/ViewModels/MainViewModel.cs
+++ b/Wrecept.UI/ViewModels/MainViewModel.cs
@@ -71,12 +71,20 @@ public class MainViewModel : INotifyPropertyChanged
             view.Show();
         });
 
-        EnterCommand = new RelayCommand(_ => { });
-        EscapeCommand = new RelayCommand(_ => { });
+        EnterCommand = new RelayCommand(_ =>
+        {
+            if (CurrentView?.DataContext is IKeyboardNavigable nav)
+                nav.OnEnter();
+        });
+        EscapeCommand = new RelayCommand(_ =>
+        {
+            if (CurrentView?.DataContext is IKeyboardNavigable nav)
+                nav.OnEscape();
+        });
         LeftCommand = new RelayCommand(_ => Navigate(-1));
         RightCommand = new RelayCommand(_ => Navigate(1));
-        UpCommand = new RelayCommand(_ => { });
-        DownCommand = new RelayCommand(_ => { });
+        UpCommand = new RelayCommand(_ => Navigate(-1));
+        DownCommand = new RelayCommand(_ => Navigate(1));
         ToggleThemeCommand = new RelayCommand(_ =>
         {
             _currentTheme = _currentTheme == "Light" ? "Dark" : "Light";

--- a/Wrecept.UI/Views/InvoiceEditorView.xaml
+++ b/Wrecept.UI/Views/InvoiceEditorView.xaml
@@ -11,7 +11,6 @@
     <UserControl.InputBindings>
         <KeyBinding Key="I" Modifiers="Control" Command="{Binding AddItemCommand}" />
         <KeyBinding Key="Insert" Command="{Binding AddItemCommand}" />
-        <KeyBinding Key="Enter" Command="{Binding AddItemCommand}" />
         <KeyBinding Key="Delete" Command="{Binding DeleteItemCommand}" />
         <KeyBinding Key="S" Modifiers="Control" Command="{Binding SaveCommand}" />
     </UserControl.InputBindings>

--- a/docs/progress/2025-08-09_0145_ui_agent.md
+++ b/docs/progress/2025-08-09_0145_ui_agent.md
@@ -1,0 +1,5 @@
+# Progress Log 2025-08-09
+
+## ui_agent
+
+- Implemented global keyboard navigation: Enter/Escape delegate to active view and arrows navigate sections; Invoice editor supports Insert/Delete. Ref: TODO ui_agent.


### PR DESCRIPTION
## Summary
- wire up Enter, Escape, and arrow key commands through `MainViewModel`
- add `IKeyboardNavigable` for views to respond to global key presses
- streamline invoice editor bindings to rely on global Insert/Delete and navigation

## Testing
- `dotnet test Wrecept.Core.sln --filter "Category!=UI"`


------
https://chatgpt.com/codex/tasks/task_e_6896a7b97640832292c760730b3087de