### PR TITLE
doc_agent: refresh README, ui_agent: async theme loading, test_agent: settings test

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,28 +9,28 @@ Wrecept is an offline-first invoicing desktop application built with C# (.NET 8)
 Features marked with *(planned)* are upcoming and not yet implemented.
 
 - **Offline-first architecture** – Works fully without internet connectivity and synchronizes data once a connection is restored.
-- **Keyboard-centric UI** *(planned)* – Every action is driven by keyboard shortcuts for maximum speed.
-- **Main menu navigation** *(planned)* – Quick-access categories (`Accounts`, `Stocks`, `Lists`, `Maintenance`, `Contacts`) streamline common tasks.
-- **Invoice editor** *(planned)* – Inline item entry with real-time calculations and row-by-row validation.
+- **Keyboard-centric UI** – Every action is driven by keyboard shortcuts for maximum speed.
+- **Main menu navigation** – Quick-access categories (`Accounts`, `Stocks`, `Lists`, `Maintenance`, `Contacts`) streamline common tasks.
+- **Invoice editor** – Inline item entry with real-time calculations and row-by-row validation.
 - **Model–Repository–Service (MRS) architecture** – Clear separation between domain models, persistence repositories, and business services.
 - **SQLite data storage** – Local persistence using a lightweight SQLite database via Entity Framework Core.
-- **Theme support** *(planned)* – Customisable themes with a dedicated Theme Editor.
+- **Theme support** – Customisable themes with a dedicated Theme Editor.
 - **Logging with Serilog** – Structured logging to help diagnose issues and maintain reliability.
 - **Localisation** *(planned)* – Hungarian user interface and error messages.
-- **Import/Export** *(planned)* – Upcoming database backup and migration support.
+- **Import/Export** – Database backup and migration support.
 ## Smart Features
 - **Auto-suggestions for recurring invoice items or frequently purchased products**
 - **Predictive text entry using local history**
-## In-App Help & Support *(planned)*
-- **Contextual tooltips** -
-- **Quick keyboard cheat sheet** -
-- **User onboarding tour** -
+## In-App Help & Support
+- **Contextual tooltips** – Inline help throughout the interface.
+- **Quick keyboard cheat sheet** *(planned)* –
+- **User onboarding tour** *(planned)* –
 ## Reporting & Analytics
-- **Customizable financial and inventory dashboards** *(partial)* -
-- **Monthly insights with charts for:** -
-  - **Sales trends** -
-  - **Top customers/products** -
-  - **Tax breakdowns** -
+- **Customizable financial and inventory dashboards** *(partial)*
+- **Monthly insights with charts for:**
+  - **Sales trends**
+  - **Top customers/products**
+  - **Tax breakdowns**
 
 ## Menu Structure
 

--- a/TODO.md
+++ b/TODO.md
@@ -23,6 +23,7 @@
 - [x] `DONE` Update README.md (feature list, menu structure, etc...)
 - [x] `DONE` Expand README with detailed feature list and menu structure
 - [ ] `TODO` Create keyboard shortcut cheat sheet
+- [x] `DONE` Update README to reflect implemented features
 
 ## logic_agent
 - [x] `DONE` Set up MRS structure (Model → Repository → Service)
@@ -50,12 +51,15 @@
 - [ ] `TODO` Provide quick keyboard cheat sheet within the application
 - [x] `DONE` Display auto-suggestions and predictive text in `InvoiceEditorView`
 - [ ] `IN_PROGRESS` Develop customizable dashboard views for financial and inventory metrics
+- [x] `DONE` Replace blocking call in `ThemeEditorViewModel` with async initialization
 
 ## test_agent
 - [x] `DONE` Unit tests for the Service layer
 - [x] `DONE` Database validations (error handling + rollback)
 - [ ] `TODO NEEDS_REVIEW` Testing keyboard navigation logic on different views
 - [x] `DONE` Setup `Wrecept.UI.Tests` with UI category and OS skip
+- [x] `DONE` Add unit test for settings theme update
+- [ ] `TODO` Add unit test for `ThemeEditorViewModel` initialization
 
 ## integration_agent
 - [x] `DONE` Database export/import function

--- a/Wrecept.Core.Tests/SettingsServiceTests.cs
+++ b/Wrecept.Core.Tests/SettingsServiceTests.cs
@@ -20,4 +20,21 @@ public class SettingsServiceTests
         Assert.Equal(settings.Language, loaded.Language);
         File.Delete(tempFile);
     }
+
+    [Fact]
+    public async Task UpdateThemeAsync_Persists_And_RaisesEvent()
+    {
+        var tempFile = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid()}.json");
+        var service = new SettingsService(tempFile);
+        await service.LoadAsync();
+        string? changedTheme = null;
+        service.SettingsChanged += (_, s) => changedTheme = s.Theme;
+
+        await service.UpdateThemeAsync("Dark");
+
+        Assert.Equal("Dark", changedTheme);
+        var reloaded = await service.LoadAsync();
+        Assert.Equal("Dark", reloaded.Theme);
+        File.Delete(tempFile);
+    }
 }

--- a/Wrecept.UI/ViewModels/ThemeEditorViewModel.cs
+++ b/Wrecept.UI/ViewModels/ThemeEditorViewModel.cs
@@ -31,18 +31,24 @@ public class ThemeEditorViewModel : INotifyPropertyChanged
     public ThemeEditorViewModel(ISettingsService settingsService)
     {
         _settingsService = settingsService;
-        SelectedTheme = _settingsService.LoadAsync().Result.Theme;
+        _ = LoadThemeAsync();
 
-        EnterCommand = new RelayCommand(_ => Save());
+        EnterCommand = new RelayCommand(_ => SaveAsync());
         EscapeCommand = new RelayCommand(_ => { });
         LeftCommand = new RelayCommand(_ => { });
         RightCommand = new RelayCommand(_ => { });
         UpCommand = new RelayCommand(_ => { });
         DownCommand = new RelayCommand(_ => { });
-        SaveCommand = new RelayCommand(_ => Save());
+        SaveCommand = new RelayCommand(_ => SaveAsync());
     }
 
-    private async void Save()
+    private async Task LoadThemeAsync()
+    {
+        var settings = await _settingsService.LoadAsync();
+        SelectedTheme = settings.Theme;
+    }
+
+    private async void SaveAsync()
     {
         await _settingsService.UpdateThemeAsync(SelectedTheme);
         MessageBox.Show("Téma elmentve.");


### PR DESCRIPTION
## Summary
- remove blocking settings load in ThemeEditorViewModel
- add unit test for SettingsService.UpdateThemeAsync
- refresh README feature list

## Testing
- `dotnet test Wrecept.Core.sln --filter "Category!=UI"`
- `dotnet test Wrecept.UI.Tests/Wrecept.UI.Tests.csproj --filter "Category!=UI"` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_6896ab51f2f08322b8a236b5993dafb3