### PR TITLE
ui: redesign invoice view with product lookup and totals

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,23 @@ The main menu provides the following sections:
 
 See the [installation guide](docs/INSTALL.md) for prerequisites and step-by-step setup instructions. In short, ensure the .NET 8 SDK is installed and run the application by building the solution.
 
+## Invoice View Keyboard Map
+
+| Key | Action |
+|-----|--------|
+| Ins | Add item |
+| Del | Remove item |
+| Enter | Save invoice |
+| Esc | Cancel |
+| Ctrl+K / typing | Product search |
+
+### Acceptance Checklist
+- [ ] Inline item editing with keyboard navigation
+- [ ] Totals update automatically
+- [ ] Invalid fields prevent saving
+- [ ] Product lookup fills item data
+- [ ] Status bar shows hotkeys and errors
+
 ## Progress Logs
 
 Ongoing development milestones are recorded in [`docs/progress/`](docs/progress/).

--- a/Wrecept.Core.Tests/InvoiceTotalsServiceTests.cs
+++ b/Wrecept.Core.Tests/InvoiceTotalsServiceTests.cs
@@ -1,0 +1,30 @@
+using System.Linq;
+using Wrecept.Core.Models;
+using Wrecept.Core.Services;
+using Xunit;
+
+namespace Wrecept.Core.Tests;
+
+public class InvoiceTotalsServiceTests
+{
+    [Fact]
+    public void Calculates_totals_and_vat_breakdown()
+    {
+        var service = new InvoiceTotalsService();
+        var items = new[]
+        {
+            new InvoiceItem { Quantity = 2, UnitPrice = 100m, VatRate = 0.27m },
+            new InvoiceItem { Quantity = 1, UnitPrice = 50m, VatRate = 0.05m }
+        };
+
+        var totals = service.Calculate(items);
+
+        Assert.Equal(250m, totals.Net);
+        var expectedVat = 2 * 100m * 0.27m + 50m * 0.05m;
+        Assert.Equal(expectedVat, totals.Vat);
+        Assert.Equal(totals.Net + expectedVat, totals.Gross);
+        Assert.Equal(2, totals.ByRate.Count);
+        var vat27 = totals.ByRate.Single(v => v.Rate == 0.27m).Vat;
+        Assert.Equal(2 * 100m * 0.27m, vat27);
+    }
+}

--- a/Wrecept.Core/Services/IInvoiceTotalsService.cs
+++ b/Wrecept.Core/Services/IInvoiceTotalsService.cs
@@ -1,0 +1,11 @@
+using Wrecept.Core.Models;
+
+namespace Wrecept.Core.Services;
+
+public interface IInvoiceTotalsService
+{
+    InvoiceTotals Calculate(IEnumerable<InvoiceItem> items);
+}
+
+public record VatTotal(decimal Rate, decimal Vat);
+public record InvoiceTotals(decimal Net, decimal Vat, decimal Gross, IReadOnlyList<VatTotal> ByRate);

--- a/Wrecept.Core/Services/IProductLookupService.cs
+++ b/Wrecept.Core/Services/IProductLookupService.cs
@@ -1,0 +1,8 @@
+using Wrecept.Core.Models;
+
+namespace Wrecept.Core.Services;
+
+public interface IProductLookupService
+{
+    Task<IReadOnlyList<Product>> SearchAsync(string term);
+}

--- a/Wrecept.Core/Services/ITaxService.cs
+++ b/Wrecept.Core/Services/ITaxService.cs
@@ -1,0 +1,6 @@
+namespace Wrecept.Core.Services;
+
+public interface ITaxService
+{
+    Task<IReadOnlyList<decimal>> GetRatesAsync();
+}

--- a/Wrecept.Core/Services/InvoiceTotalsService.cs
+++ b/Wrecept.Core/Services/InvoiceTotalsService.cs
@@ -1,0 +1,20 @@
+using System.Linq;
+using Wrecept.Core.Models;
+
+namespace Wrecept.Core.Services;
+
+public class InvoiceTotalsService : IInvoiceTotalsService
+{
+    public InvoiceTotals Calculate(IEnumerable<InvoiceItem> items)
+    {
+        var list = items.ToList();
+        var net = list.Sum(i => i.TotalNet);
+        var vat = list.Sum(i => i.TotalVat);
+        var gross = list.Sum(i => i.TotalGross);
+        var byRate = list
+            .GroupBy(i => i.VatRate)
+            .Select(g => new VatTotal(g.Key, g.Sum(i => i.TotalVat)))
+            .ToList();
+        return new InvoiceTotals(net, vat, gross, byRate);
+    }
+}

--- a/Wrecept.Core/Services/ProductLookupService.cs
+++ b/Wrecept.Core/Services/ProductLookupService.cs
@@ -1,0 +1,27 @@
+using Microsoft.EntityFrameworkCore;
+using Wrecept.Core.Data;
+using Wrecept.Core.Models;
+
+namespace Wrecept.Core.Services;
+
+public class ProductLookupService : IProductLookupService
+{
+    private readonly AppDbContext _context;
+
+    public ProductLookupService(AppDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<IReadOnlyList<Product>> SearchAsync(string term)
+    {
+        if (string.IsNullOrWhiteSpace(term))
+            return Array.Empty<Product>();
+
+        return await _context.Products
+            .Where(p => p.Name.Contains(term))
+            .OrderBy(p => p.Name)
+            .Take(20)
+            .ToListAsync();
+    }
+}

--- a/Wrecept.Core/Services/TaxService.cs
+++ b/Wrecept.Core/Services/TaxService.cs
@@ -1,0 +1,23 @@
+using Microsoft.EntityFrameworkCore;
+using Wrecept.Core.Data;
+
+namespace Wrecept.Core.Services;
+
+public class TaxService : ITaxService
+{
+    private readonly AppDbContext _context;
+
+    public TaxService(AppDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<IReadOnlyList<decimal>> GetRatesAsync()
+    {
+        return await _context.Products
+            .Select(p => p.VatRate)
+            .Distinct()
+            .OrderBy(r => r)
+            .ToListAsync();
+    }
+}

--- a/Wrecept.UI/App.xaml.cs
+++ b/Wrecept.UI/App.xaml.cs
@@ -54,6 +54,11 @@ public partial class App : Application
                 services.AddScoped<IAnalyticsService, AnalyticsService>();
                 services.AddSingleton<ISettingsService, SettingsService>();
                 services.AddScoped<IDemoDataService, DemoDataService>();
+                services.AddScoped<IProductLookupService, ProductLookupService>();
+                services.AddScoped<ITaxService, TaxService>();
+                services.AddScoped<IInvoiceTotalsService, InvoiceTotalsService>();
+                services.AddSingleton<InvoiceViewModel>();
+                services.AddTransient<InvoiceView>();
                 services.AddSingleton<StartupOrchestrator>();
                 services.AddSingleton<InvoiceEditorViewModel>();
                 services.AddTransient<InvoiceEditorView>();

--- a/Wrecept.UI/ViewModels/InvoiceItemVM.cs
+++ b/Wrecept.UI/ViewModels/InvoiceItemVM.cs
@@ -1,0 +1,71 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Collections;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace Wrecept.UI.ViewModels;
+
+public class InvoiceItemVM : INotifyPropertyChanged, INotifyDataErrorInfo
+{
+    private string _code = string.Empty;
+    private string _description = string.Empty;
+    private decimal _quantity = 1m;
+    private string _unit = "db";
+    private decimal _unitPrice;
+    private decimal _taxRate;
+    private decimal _lineNet;
+    private decimal _lineVat;
+    private decimal _lineGross;
+
+    public string Code { get => _code; set { _code = value; OnPropertyChanged(); Validate(); } }
+    public string Description { get => _description; set { _description = value; OnPropertyChanged(); Validate(); } }
+    public decimal Quantity { get => _quantity; set { _quantity = value; OnPropertyChanged(); Recalculate(); Validate(); } }
+    public string Unit { get => _unit; set { _unit = value; OnPropertyChanged(); } }
+    public decimal UnitPrice { get => _unitPrice; set { _unitPrice = value; OnPropertyChanged(); Recalculate(); Validate(); } }
+    public decimal TaxRate { get => _taxRate; set { _taxRate = value; OnPropertyChanged(); Recalculate(); } }
+
+    public decimal LineNet { get => _lineNet; private set { _lineNet = value; OnPropertyChanged(); } }
+    public decimal LineVat { get => _lineVat; private set { _lineVat = value; OnPropertyChanged(); } }
+    public decimal LineGross { get => _lineGross; private set { _lineGross = value; OnPropertyChanged(); } }
+
+    private void Recalculate()
+    {
+        LineNet = UnitPrice * Quantity;
+        LineVat = LineNet * TaxRate;
+        LineGross = LineNet + LineVat;
+    }
+
+    private readonly Dictionary<string, List<string>> _errors = new();
+    public bool HasErrors => _errors.Any();
+    public event EventHandler<DataErrorsChangedEventArgs>? ErrorsChanged;
+    public IEnumerable GetErrors(string? propertyName)
+        => propertyName != null && _errors.TryGetValue(propertyName, out var list) ? list : Enumerable.Empty<string>();
+
+    private void Validate([CallerMemberName] string? propertyName = null)
+    {
+        if (propertyName == null) return;
+        _errors.Remove(propertyName);
+        var list = new List<string>();
+        switch (propertyName)
+        {
+            case nameof(Code):
+            case nameof(Description):
+                if (string.IsNullOrWhiteSpace(propertyName == nameof(Code) ? Code : Description))
+                    list.Add("Required");
+                break;
+            case nameof(Quantity):
+                if (Quantity <= 0) list.Add("Quantity must be > 0");
+                break;
+            case nameof(UnitPrice):
+                if (UnitPrice < 0) list.Add("Price must be >= 0");
+                break;
+        }
+        if (list.Any()) _errors[propertyName] = list;
+        ErrorsChanged?.Invoke(this, new DataErrorsChangedEventArgs(propertyName));
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+    protected void OnPropertyChanged([CallerMemberName] string? name = null)
+        => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+}

--- a/Wrecept.UI/ViewModels/InvoiceViewModel.cs
+++ b/Wrecept.UI/ViewModels/InvoiceViewModel.cs
@@ -1,0 +1,277 @@
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows;
+using System;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using Wrecept.Core.Models;
+using Wrecept.Core.Services;
+
+namespace Wrecept.UI.ViewModels;
+
+public class InvoiceViewModel : INotifyPropertyChanged
+{
+    private readonly IInvoiceService _invoiceService;
+    private readonly IProductLookupService _productLookupService;
+    private readonly ITaxService _taxService;
+    private readonly ISettingsService _settingsService;
+
+    private readonly ObservableCollection<InvoiceItemVM> _items = new();
+    public ObservableCollection<InvoiceItemVM> Items => _items;
+
+    public ObservableCollection<decimal> TaxRates { get; } = new();
+    public ObservableCollection<Product> ProductResults { get; } = new();
+
+    private InvoiceItemVM? _selectedItem;
+    public InvoiceItemVM? SelectedItem
+    {
+        get => _selectedItem;
+        set { _selectedItem = value; OnPropertyChanged(); }
+    }
+
+    private Product? _selectedProduct;
+    public Product? SelectedProduct
+    {
+        get => _selectedProduct;
+        set
+        {
+            if (_selectedProduct != value)
+            {
+                _selectedProduct = value;
+                OnPropertyChanged();
+                if (value != null && SelectedItem != null)
+                {
+                    SelectedItem.Code = value.Id.ToString();
+                    SelectedItem.Description = value.Name;
+                    SelectedItem.UnitPrice = value.UnitPrice;
+                    SelectedItem.TaxRate = value.VatRate;
+                    IsProductSearchOpen = false;
+                    ProductResults.Clear();
+                    RecalculateTotals();
+                }
+            }
+        }
+    }
+
+    public string Customer { get; set; } = string.Empty;
+    public string InvoiceNumber { get; set; } = string.Empty;
+    public DateTime InvoiceDate { get; set; } = DateTime.Today;
+    public ObservableCollection<string> PaymentMethods { get; } = new() { "Cash", "Card" };
+    private string? _selectedPaymentMethod;
+    public string? SelectedPaymentMethod { get => _selectedPaymentMethod; set { _selectedPaymentMethod = value; OnPropertyChanged(); } }
+
+    private bool _isProductSearchOpen;
+    public bool IsProductSearchOpen
+    {
+        get => _isProductSearchOpen;
+        private set { _isProductSearchOpen = value; OnPropertyChanged(); }
+    }
+
+    private CancellationTokenSource? _searchCts;
+
+    private decimal _totalNet;
+    public decimal TotalNet { get => _totalNet; private set { _totalNet = value; OnPropertyChanged(); } }
+    private decimal _totalVat;
+    public decimal TotalVat { get => _totalVat; private set { _totalVat = value; OnPropertyChanged(); } }
+    private decimal _totalGross;
+    public decimal TotalGross { get => _totalGross; private set { _totalGross = value; OnPropertyChanged(); } }
+
+    public ObservableCollection<VatTotal> VatTotals { get; } = new();
+
+    private string _statusMessage = "Ready";
+    public string StatusMessage { get => _statusMessage; private set { _statusMessage = value; OnPropertyChanged(); } }
+
+    private bool _isBusy;
+    public bool IsBusy { get => _isBusy; private set { _isBusy = value; OnPropertyChanged(); } }
+
+    public RelayCommand AddItemCommand { get; }
+    public RelayCommand RemoveItemCommand { get; }
+    public AsyncRelayCommand SaveInvoiceCommand { get; }
+    public RelayCommand CancelCommand { get; }
+    public RelayCommand ShowVatBreakdownCommand { get; }
+    public RelayCommand ApplyDiscountCommand { get; }
+
+    public InvoiceViewModel(IInvoiceService invoiceService,
+                            IProductLookupService productLookupService,
+                            ITaxService taxService,
+                            ISettingsService settingsService)
+    {
+        _invoiceService = invoiceService;
+        _productLookupService = productLookupService;
+        _taxService = taxService;
+        _settingsService = settingsService;
+
+        AddItemCommand = new RelayCommand(_ => AddItem());
+        RemoveItemCommand = new RelayCommand(_ => RemoveItem(), _ => SelectedItem != null);
+        SaveInvoiceCommand = new AsyncRelayCommand(_ => SaveAsync(), _ => CanSave());
+        CancelCommand = new RelayCommand(_ => Cancel());
+        ShowVatBreakdownCommand = new RelayCommand(_ => ShowVatBreakdown());
+        ApplyDiscountCommand = new RelayCommand(p => ApplyDiscount(Convert.ToDecimal(p ?? 0m)));
+
+        _items.CollectionChanged += ItemsChanged;
+    }
+
+    public async Task InitializeAsync()
+    {
+        var settings = await _settingsService.LoadAsync();
+        if (string.IsNullOrWhiteSpace(settings.Theme))
+            settings.Theme = "Light";
+        var rates = await _taxService.GetRatesAsync();
+        foreach (var r in rates) TaxRates.Add(r);
+        StatusMessage = "Ready";
+    }
+
+    private void ItemsChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        if (e.NewItems != null)
+        {
+            foreach (InvoiceItemVM item in e.NewItems)
+            {
+                item.PropertyChanged += ItemChanged;
+                item.ErrorsChanged += (_, __) => UpdateValidation();
+            }
+        }
+        if (e.OldItems != null)
+        {
+            foreach (InvoiceItemVM item in e.OldItems)
+            {
+                item.PropertyChanged -= ItemChanged;
+            }
+        }
+        RecalculateTotals();
+        UpdateValidation();
+    }
+
+    private void ItemChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(InvoiceItemVM.Code) || e.PropertyName == nameof(InvoiceItemVM.Description))
+        {
+            var term = e.PropertyName == nameof(InvoiceItemVM.Code) ? SelectedItem?.Code : SelectedItem?.Description;
+            if (term != null)
+                _ = OpenProductSearchAsync(term);
+        }
+        RecalculateTotals();
+        UpdateValidation();
+    }
+
+    public async Task OpenProductSearchAsync(string term)
+    {
+        _searchCts?.Cancel();
+        if (string.IsNullOrWhiteSpace(term))
+        {
+            ProductResults.Clear();
+            IsProductSearchOpen = false;
+            return;
+        }
+
+        var cts = _searchCts = new CancellationTokenSource();
+        try
+        {
+            await Task.Delay(300, cts.Token);
+            var results = await _productLookupService.SearchAsync(term);
+            ProductResults.Clear();
+            foreach (var p in results) ProductResults.Add(p);
+            IsProductSearchOpen = ProductResults.Any();
+        }
+        catch (TaskCanceledException) { }
+    }
+
+    private void AddItem()
+    {
+        var item = new InvoiceItemVM();
+        _items.Add(item);
+        SelectedItem = item;
+    }
+
+    private void RemoveItem()
+    {
+        if (SelectedItem == null) return;
+        _items.Remove(SelectedItem);
+        SelectedItem = null;
+    }
+
+    private bool CanSave() => Items.Any() && Items.All(i => !i.HasErrors);
+
+    private async Task SaveAsync()
+    {
+        if (!CanSave())
+        {
+            StatusMessage = "Validation errors";
+            return;
+        }
+        var confirm = MessageBox.Show("Mented a számlát?", "Megerősítés", MessageBoxButton.YesNo);
+        if (confirm != MessageBoxResult.Yes) return;
+
+        IsBusy = true;
+        try
+        {
+            var invoice = new Invoice
+            {
+                Items = Items.Select(i => new InvoiceItem
+                {
+                    Quantity = (int)i.Quantity,
+                    UnitPrice = i.UnitPrice,
+                    VatRate = i.TaxRate
+                }).ToList()
+            };
+            await _invoiceService.AddInvoiceAsync(invoice);
+            StatusMessage = "Ready";
+        }
+        catch (Exception ex)
+        {
+            StatusMessage = ex.Message;
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+
+    private void Cancel()
+    {
+        _items.Clear();
+        RecalculateTotals();
+        StatusMessage = "Cancelled";
+    }
+
+    private void ShowVatBreakdown()
+    {
+        var msg = string.Join("\n", VatTotals.Select(v => $"{v.Rate:P0}: {v.Vat:N2}"));
+        MessageBox.Show(msg.Length == 0 ? "Nincs ÁFA" : msg, "ÁFA összesítés");
+    }
+
+    private void ApplyDiscount(decimal percent)
+    {
+        foreach (var item in Items)
+        {
+            item.UnitPrice -= item.UnitPrice * percent / 100m;
+        }
+        RecalculateTotals();
+    }
+
+    public void RecalculateTotals()
+    {
+        TotalNet = Items.Sum(i => i.LineNet);
+        TotalVat = Items.Sum(i => i.LineVat);
+        TotalGross = TotalNet + TotalVat;
+        VatTotals.Clear();
+        foreach (var g in Items.GroupBy(i => i.TaxRate))
+        {
+            VatTotals.Add(new VatTotal(g.Key, g.Sum(x => x.LineVat)));
+        }
+    }
+
+    private void UpdateValidation()
+    {
+        var errors = Items.SelectMany(i => i.HasErrors ? new[] { i } : Array.Empty<InvoiceItemVM>()).Count();
+        StatusMessage = errors > 0 ? $"{errors} validation error(s)" : "Ready";
+        SaveInvoiceCommand.RaiseCanExecuteChanged();
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+    protected void OnPropertyChanged([CallerMemberName] string? name = null)
+        => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+}

--- a/Wrecept.UI/Views/InvoiceView.xaml
+++ b/Wrecept.UI/Views/InvoiceView.xaml
@@ -1,0 +1,87 @@
+<UserControl x:Class="Wrecept.UI.Views.InvoiceView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             mc:Ignorable="d">
+    <UserControl.InputBindings>
+        <KeyBinding Key="Insert" Command="{Binding AddItemCommand}"/>
+        <KeyBinding Key="Delete" Command="{Binding RemoveItemCommand}"/>
+        <KeyBinding Key="Enter" Command="{Binding SaveInvoiceCommand}"/>
+        <KeyBinding Key="Escape" Command="{Binding CancelCommand}"/>
+    </UserControl.InputBindings>
+    <Grid Background="{DynamicResource WindowBackgroundBrush}" Foreground="{DynamicResource WindowForegroundBrush}">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+        <!-- Header -->
+        <StackPanel Orientation="Horizontal" Margin="5" Grid.Row="0" >
+            <TextBox Width="200" Margin="0,0,5,0" Text="{Binding Customer}"/>
+            <TextBox Width="120" Margin="0,0,5,0" Text="{Binding InvoiceNumber}"/>
+            <DatePicker Width="120" SelectedDate="{Binding InvoiceDate}"/>
+            <ComboBox Width="120" Margin="5,0,0,0" ItemsSource="{Binding PaymentMethods}" SelectedItem="{Binding SelectedPaymentMethod}"/>
+        </StackPanel>
+        <!-- DataGrid -->
+        <DataGrid x:Name="InvoiceGrid" Grid.Row="1" ItemsSource="{Binding Items}" SelectedItem="{Binding SelectedItem}"
+                  AutoGenerateColumns="False" CanUserAddRows="False" CanUserDeleteRows="False"
+                  HeadersVisibility="Column" RowHeaderWidth="0">
+            <DataGrid.Columns>
+                <DataGridTemplateColumn Header="Kód">
+                    <DataGridTemplateColumn.CellTemplate>
+                        <DataTemplate>
+                            <TextBox Text="{Binding Code, UpdateSourceTrigger=PropertyChanged}"/>
+                        </DataTemplate>
+                    </DataGridTemplateColumn.CellTemplate>
+                </DataGridTemplateColumn>
+                <DataGridTemplateColumn Header="Megnevezés">
+                    <DataGridTemplateColumn.CellTemplate>
+                        <DataTemplate>
+                            <TextBox Text="{Binding Description, UpdateSourceTrigger=PropertyChanged}"/>
+                        </DataTemplate>
+                    </DataGridTemplateColumn.CellTemplate>
+                </DataGridTemplateColumn>
+                <DataGridTextColumn Header="Menny." Binding="{Binding Quantity, UpdateSourceTrigger=PropertyChanged}"/>
+                <DataGridTextColumn Header="Egység" Binding="{Binding Unit}" IsReadOnly="True"/>
+                <DataGridTextColumn Header="Egységár" Binding="{Binding UnitPrice, UpdateSourceTrigger=PropertyChanged}"/>
+                <DataGridComboBoxColumn Header="ÁFA%" ItemsSource="{Binding DataContext.TaxRates, RelativeSource={RelativeSource AncestorType=DataGrid}}" SelectedItem="{Binding TaxRate}"/>
+                <DataGridTextColumn Header="Nettó" Binding="{Binding LineNet}" IsReadOnly="True"/>
+                <DataGridTextColumn Header="ÁFA" Binding="{Binding LineVat}" IsReadOnly="True"/>
+                <DataGridTextColumn Header="Bruttó" Binding="{Binding LineGross}" IsReadOnly="True"/>
+            </DataGrid.Columns>
+        </DataGrid>
+        <!-- Totals -->
+        <Grid Grid.Row="2" Margin="5">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
+            </Grid.ColumnDefinitions>
+            <StackPanel Grid.Column="1" Orientation="Vertical" HorizontalAlignment="Right">
+                <TextBlock Text="{Binding TotalNet, StringFormat=N2}"/>
+                <TextBlock Text="{Binding TotalVat, StringFormat=N2}"/>
+                <TextBlock Text="{Binding TotalGross, StringFormat=N2}" FontWeight="Bold"/>
+            </StackPanel>
+        </Grid>
+        <!-- Buttons -->
+        <StackPanel Grid.Row="3" Orientation="Horizontal" HorizontalAlignment="Right" Margin="5">
+            <Button Content="Mentés" Command="{Binding SaveInvoiceCommand}" Margin="5,0"/>
+            <Button Content="Mégse" Command="{Binding CancelCommand}"/>
+        </StackPanel>
+        <!-- Status Bar -->
+        <StatusBar Grid.Row="4" Background="{DynamicResource WindowBackgroundBrush}" Foreground="{DynamicResource WindowForegroundBrush}">
+            <StatusBarItem Content="{Binding StatusMessage}"/>
+            <StatusBarItem HorizontalAlignment="Right">
+                <TextBlock Text="Ins Add • Del Remove • Enter Save • Esc Cancel • Type Search"/>
+            </StatusBarItem>
+        </StatusBar>
+        <!-- Product search popup -->
+        <Popup IsOpen="{Binding IsProductSearchOpen}" PlacementTarget="{Binding ElementName=InvoiceGrid}" StaysOpen="False">
+            <Border Background="{DynamicResource WindowBackgroundBrush}" BorderBrush="{DynamicResource WindowForegroundBrush}" BorderThickness="1">
+                <ListBox ItemsSource="{Binding ProductResults}" SelectedItem="{Binding SelectedProduct}" DisplayMemberPath="Name" Width="300"/>
+            </Border>
+        </Popup>
+    </Grid>
+</UserControl>

--- a/Wrecept.UI/Views/InvoiceView.xaml.cs
+++ b/Wrecept.UI/Views/InvoiceView.xaml.cs
@@ -1,0 +1,14 @@
+using System.Windows.Controls;
+using Wrecept.UI.ViewModels;
+
+namespace Wrecept.UI.Views;
+
+public partial class InvoiceView : UserControl
+{
+    public InvoiceView(InvoiceViewModel vm)
+    {
+        InitializeComponent();
+        DataContext = vm;
+        Loaded += async (_, __) => await vm.InitializeAsync();
+    }
+}


### PR DESCRIPTION
## Summary
- add product lookup, tax, and invoice totals services
- implement new keyboard-first invoice view and viewmodel
- document invoice shortcuts and validation checklist

## Testing
- `dotnet test Wrecept.Core.sln --filter "Category!=UI"`


------
https://chatgpt.com/codex/tasks/task_e_6896b09e41bc83228bbcba635437614b