### PR TITLE
refactor: introduce UI message service and theme tests

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -61,7 +61,7 @@
 - [ ] `TODO NEEDS_REVIEW` Testing keyboard navigation logic on different views
 - [x] `DONE` Setup `Wrecept.UI.Tests` with UI category and OS skip
 - [x] `DONE` Add unit test for settings theme update
-- [ ] `TODO` Add unit test for `ThemeEditorViewModel` initialization
+- [x] `DONE` Add unit test for `ThemeEditorViewModel` initialization
 
 ## integration_agent
 - [x] `DONE` Database export/import function

--- a/Wrecept.UI.Tests/ThemeEditorViewModelTests.cs
+++ b/Wrecept.UI.Tests/ThemeEditorViewModelTests.cs
@@ -1,0 +1,41 @@
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using Wrecept.Core.Models;
+using Wrecept.Core.Services;
+using Wrecept.UI.Services;
+using Wrecept.UI.ViewModels;
+
+namespace Wrecept.UI.Tests;
+
+public class ThemeEditorViewModelTests
+{
+    [SkippableFact]
+    [Trait("Category", "UI")]
+    public async Task InitializeAsync_LoadsTheme()
+    {
+        Skip.IfNot(RuntimeInformation.IsOSPlatform(OSPlatform.Windows), "UI tests require Windows");
+
+        var settingsService = new TestSettingsService();
+        var messageService = new TestMessageService();
+        var vm = new ThemeEditorViewModel(settingsService, messageService);
+
+        await vm.InitializeAsync();
+
+        Assert.Equal("Dark", vm.SelectedTheme);
+    }
+
+    private class TestSettingsService : ISettingsService
+    {
+        public event EventHandler<ApplicationSettings>? SettingsChanged;
+        public Task<ApplicationSettings> LoadAsync() => Task.FromResult(new ApplicationSettings { Theme = "Dark" });
+        public Task SaveAsync(ApplicationSettings settings) => Task.CompletedTask;
+        public Task UpdateThemeAsync(string theme) => Task.CompletedTask;
+        public Task UpdateLanguageAsync(string language) => Task.CompletedTask;
+    }
+
+    private class TestMessageService : IMessageService
+    {
+        public void Show(string message, string caption = "Information") { }
+        public bool Confirm(string message, string caption = "Confirm") => true;
+    }
+}

--- a/Wrecept.UI/App.xaml.cs
+++ b/Wrecept.UI/App.xaml.cs
@@ -12,6 +12,7 @@ using Wrecept.Core.Repositories;
 using Wrecept.Core.Services;
 using Wrecept.UI.ViewModels;
 using Wrecept.UI.Views;
+using Wrecept.UI.Services;
 
 namespace Wrecept.UI;
 
@@ -57,6 +58,7 @@ public partial class App : Application
                 services.AddScoped<IProductLookupService, ProductLookupService>();
                 services.AddScoped<ITaxService, TaxService>();
                 services.AddScoped<IInvoiceTotalsService, InvoiceTotalsService>();
+                services.AddSingleton<IMessageService, MessageService>();
                 services.AddSingleton<InvoiceViewModel>();
                 services.AddTransient<InvoiceView>();
                 services.AddSingleton<StartupOrchestrator>();

--- a/Wrecept.UI/Services/IMessageService.cs
+++ b/Wrecept.UI/Services/IMessageService.cs
@@ -1,0 +1,7 @@
+namespace Wrecept.UI.Services;
+
+public interface IMessageService
+{
+    void Show(string message, string caption = "Information");
+    bool Confirm(string message, string caption = "Confirm");
+}

--- a/Wrecept.UI/Services/MessageService.cs
+++ b/Wrecept.UI/Services/MessageService.cs
@@ -1,0 +1,17 @@
+using System.Windows;
+
+namespace Wrecept.UI.Services;
+
+public class MessageService : IMessageService
+{
+    public void Show(string message, string caption = "Information")
+    {
+        MessageBox.Show(message, caption);
+    }
+
+    public bool Confirm(string message, string caption = "Confirm")
+    {
+        var result = MessageBox.Show(message, caption, MessageBoxButton.YesNo, MessageBoxImage.Question);
+        return result == MessageBoxResult.Yes;
+    }
+}

--- a/Wrecept.UI/ViewModels/ThemeEditorViewModel.cs
+++ b/Wrecept.UI/ViewModels/ThemeEditorViewModel.cs
@@ -2,15 +2,16 @@ using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
-using System.Windows;
 using System.Windows.Input;
 using Wrecept.Core.Services;
+using Wrecept.UI.Services;
 
 namespace Wrecept.UI.ViewModels;
 
 public class ThemeEditorViewModel : INotifyPropertyChanged
 {
     private readonly ISettingsService _settingsService;
+    private readonly IMessageService _messageService;
 
     public ObservableCollection<string> AvailableThemes { get; } = new() { "Light", "Dark" };
 
@@ -29,10 +30,10 @@ public class ThemeEditorViewModel : INotifyPropertyChanged
     public ICommand DownCommand { get; }
     public ICommand SaveCommand { get; }
 
-    public ThemeEditorViewModel(ISettingsService settingsService)
+    public ThemeEditorViewModel(ISettingsService settingsService, IMessageService messageService)
     {
         _settingsService = settingsService;
-        _ = LoadThemeAsync();
+        _messageService = messageService;
 
         EnterCommand = new AsyncRelayCommand(_ => SaveAsync());
         EscapeCommand = new RelayCommand(_ => { });
@@ -43,7 +44,7 @@ public class ThemeEditorViewModel : INotifyPropertyChanged
         SaveCommand = new AsyncRelayCommand(_ => SaveAsync());
     }
 
-    private async Task LoadThemeAsync()
+    public async Task InitializeAsync()
     {
         var settings = await _settingsService.LoadAsync();
         SelectedTheme = settings.Theme;
@@ -52,7 +53,7 @@ public class ThemeEditorViewModel : INotifyPropertyChanged
     private async Task SaveAsync()
     {
         await _settingsService.UpdateThemeAsync(SelectedTheme);
-        MessageBox.Show("Téma elmentve.");
+        _messageService.Show("Téma elmentve.");
     }
 
     public event PropertyChangedEventHandler? PropertyChanged;

--- a/Wrecept.UI/Views/ThemeEditorView.xaml.cs
+++ b/Wrecept.UI/Views/ThemeEditorView.xaml.cs
@@ -9,6 +9,8 @@ public partial class ThemeEditorView : UserControl
     public ThemeEditorView()
     {
         InitializeComponent();
-        DataContext = App.ServiceProvider.GetRequiredService<ThemeEditorViewModel>();
+        var vm = App.ServiceProvider.GetRequiredService<ThemeEditorViewModel>();
+        DataContext = vm;
+        Loaded += async (_, __) => await vm.InitializeAsync();
     }
 }

--- a/docs/progress/2025-08-09_0238_test_agent.md
+++ b/docs/progress/2025-08-09_0238_test_agent.md
@@ -1,0 +1,3 @@
+# Progress Log – test_agent – 2025-08-09 02:38
+
+- Added unit test for ThemeEditorViewModel initialization. Ref: TODO test_agent.

--- a/docs/styleguide.md
+++ b/docs/styleguide.md
@@ -177,6 +177,7 @@ Ref: TODO #42, Milestone: stage-3
 * `Enter` confirms and advances; `Escape` cancels or moves back. `Tab` is disabled.
 * No console output allowed in production builds.
 * All messages must be in **Hungarian**, and shown in dialog if user-facing.
+* Use `IMessageService` for user dialogs; avoid direct `MessageBox` calls in view models.
 * Do not block UI thread (use async where needed).
 * Use `AsyncRelayCommand` for asynchronous operations in commands; avoid `async void`.
 


### PR DESCRIPTION
## Summary
- inject IMessageService to decouple dialogs from view models
- add ThemeEditorViewModel initialization method and use message service
- add unit test for ThemeEditorViewModel initialization

## Testing
- `dotnet test Wrecept.Core.sln --filter "Category!=UI"`
- `dotnet test Wrecept.UI.Tests/Wrecept.UI.Tests.csproj` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_6896b3b1ade0832290ff3b55ffb6fa00