### PR TITLE
Harden settings file handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Features marked with *(planned)* are upcoming and not yet implemented.
 - **SQLite data storage** – Local persistence using a lightweight SQLite database via Entity Framework Core.
 - **Theme support** – Customisable themes with a dedicated Theme Editor.
 - **Logging with Serilog** – Structured logging to help diagnose issues and maintain reliability.
+- **Self-healing configuration** – Settings file is automatically created and reset if corrupted.
 - **Localisation** *(planned)* – Hungarian user interface and error messages.
 - **Import/Export** – Database backup and migration support.
 ## Smart Features

--- a/TODO.md
+++ b/TODO.md
@@ -34,6 +34,7 @@
 - [x] `DONE` Auto-suggestions for recurring invoice items or frequently purchased products
 - [x] `DONE` Predictive text entry using local history
 - [x] `DONE` Reporting analytics engine for sales trends, top customers/products, and tax breakdowns
+- [x] `DONE` Handle corrupted settings file gracefully
 
 ## db_agent
 - [x] `DONE` Initialise SQLite database with migration

--- a/Wrecept.Core.Tests/SettingsServiceTests.cs
+++ b/Wrecept.Core.Tests/SettingsServiceTests.cs
@@ -37,4 +37,26 @@ public class SettingsServiceTests
         Assert.Equal("Dark", reloaded.Theme);
         File.Delete(tempFile);
     }
+
+    [Fact]
+    public async Task LoadAsync_InvalidJson_ReturnsDefaults()
+    {
+        var tempFile = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid()}.json");
+        await File.WriteAllTextAsync(tempFile, "{ invalid json }");
+        var service = new SettingsService(tempFile);
+        var loaded = await service.LoadAsync();
+        Assert.Equal("Data/wrecept.db", loaded.DatabasePath);
+        File.Delete(tempFile);
+    }
+
+    [Fact]
+    public async Task SaveAsync_CreatesDirectory()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        var tempFile = Path.Combine(dir, "settings.json");
+        var service = new SettingsService(tempFile);
+        await service.SaveAsync(new ApplicationSettings());
+        Assert.True(File.Exists(tempFile));
+        Directory.Delete(dir, true);
+    }
 }


### PR DESCRIPTION
## Summary
- Handle corrupted wrecept.json gracefully and recreate defaults
- Ensure settings directory exists before saving
- Document self-healing configuration in README and TODO

## Testing
- `dotnet test Wrecept.Core.sln --filter "Category!=UI"`


------
https://chatgpt.com/codex/tasks/task_e_6896b83892d08322990aa4887b87c409