### PR TITLE
Improve invoice editing with live totals and VAT tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -179,3 +179,13 @@ Motivation: self-reliance, learning, system building and financial management.
 
 ---
 
+### Keyboard Map
+Ins Add • Del Remove • Enter Save • Esc Cancel • Typing Search
+
+### Acceptance Checklist
+- [ ] Inline item editing with keyboard navigation
+- [ ] Totals update automatically
+- [ ] Invalid fields prevent saving
+- [ ] Product lookup fills item data
+- [ ] Status bar shows hotkeys and errors
+

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ See the [installation guide](docs/INSTALL.md) for prerequisites and step-by-step
 | Del | Remove item |
 | Enter | Save invoice |
 | Esc | Cancel |
-| Ctrl+K / typing | Product search |
+| Typing | Product search |
 
 ### Acceptance Checklist
 - [ ] Inline item editing with keyboard navigation

--- a/TODO.md
+++ b/TODO.md
@@ -22,7 +22,7 @@
 - [x] `DONE` Write installation guide (`INSTALL.md`)
 - [x] `DONE` Update README.md (feature list, menu structure, etc...)
 - [x] `DONE` Expand README with detailed feature list and menu structure
-- [ ] `TODO` Create keyboard shortcut cheat sheet
+ - [x] `DONE` Create keyboard shortcut cheat sheet
  - [x] `DONE` Update README to reflect implemented features
 - [x] `DONE` Document AsyncRelayCommand usage in style guide
 

--- a/Wrecept.UI.Tests/InvoiceViewModelTotalsTests.cs
+++ b/Wrecept.UI.Tests/InvoiceViewModelTotalsTests.cs
@@ -1,0 +1,76 @@
+using System.Linq;
+using Wrecept.Core.Models;
+using Wrecept.Core.Services;
+using Wrecept.UI.Services;
+using Wrecept.UI.ViewModels;
+
+namespace Wrecept.UI.Tests;
+
+public class InvoiceViewModelTotalsTests
+{
+    private class StubInvoiceService : IInvoiceService
+    {
+        public Task AddInvoiceAsync(Invoice invoice) => Task.CompletedTask;
+        public Task<IEnumerable<Invoice>> GetInvoicesAsync() => Task.FromResult<IEnumerable<Invoice>>(Array.Empty<Invoice>());
+    }
+
+    private class StubProductLookupService : IProductLookupService
+    {
+        public Task<IReadOnlyList<Product>> SearchAsync(string term) => Task.FromResult<IReadOnlyList<Product>>(Array.Empty<Product>());
+    }
+
+    private class StubTaxService : ITaxService
+    {
+        public Task<IReadOnlyList<decimal>> GetRatesAsync() => Task.FromResult<IReadOnlyList<decimal>>(new[] { 0.27m, 0.05m });
+    }
+
+    private class StubSettingsService : ISettingsService
+    {
+        public event EventHandler<ApplicationSettings>? SettingsChanged;
+        public Task<ApplicationSettings> LoadAsync() => Task.FromResult(new ApplicationSettings());
+        public Task SaveAsync(ApplicationSettings settings) => Task.CompletedTask;
+        public Task UpdateThemeAsync(string theme) => Task.CompletedTask;
+        public Task UpdateLanguageAsync(string language) => Task.CompletedTask;
+    }
+
+    private class StubMessageService : IMessageService
+    {
+        public void Show(string message, string? title = null) { }
+        public bool Confirm(string message, string? title = null) => true;
+    }
+
+    private InvoiceViewModel CreateVm()
+        => new(new StubInvoiceService(), new StubProductLookupService(), new StubTaxService(), new StubSettingsService(), new StubMessageService());
+
+    [Fact]
+    public void RecalculateTotals_ComputesValues()
+    {
+        var vm = CreateVm();
+        vm.Items.Add(new InvoiceItemVM { Quantity = 2m, UnitPrice = 100m, TaxRate = 0.27m });
+        vm.Items.Add(new InvoiceItemVM { Quantity = 1m, UnitPrice = 50m, TaxRate = 0.05m });
+
+        vm.RecalculateTotals();
+
+        Assert.Equal(250m, vm.TotalNet);
+        Assert.Equal(56.5m, vm.TotalVat);
+        Assert.Equal(306.5m, vm.TotalGross);
+    }
+
+    [Fact]
+    public void VatTotals_GroupedByRate()
+    {
+        var vm = CreateVm();
+        vm.Items.Add(new InvoiceItemVM { Quantity = 1m, UnitPrice = 100m, TaxRate = 0.27m });
+        vm.Items.Add(new InvoiceItemVM { Quantity = 1m, UnitPrice = 50m, TaxRate = 0.27m });
+        vm.Items.Add(new InvoiceItemVM { Quantity = 1m, UnitPrice = 20m, TaxRate = 0.05m });
+
+        vm.RecalculateTotals();
+
+        var rate27 = vm.VatTotals.First(v => v.Rate == 0.27m);
+        var rate5 = vm.VatTotals.First(v => v.Rate == 0.05m);
+
+        Assert.Equal(40.5m, rate27.Vat);
+        Assert.Equal(1m, rate5.Vat);
+    }
+}
+

--- a/Wrecept.UI/ViewModels/InvoiceViewModel.cs
+++ b/Wrecept.UI/ViewModels/InvoiceViewModel.cs
@@ -85,6 +85,9 @@ public class InvoiceViewModel : INotifyPropertyChanged
     private string _statusMessage = "Ready";
     public string StatusMessage { get => _statusMessage; private set { _statusMessage = value; OnPropertyChanged(); } }
 
+    private string _validationSummary = string.Empty;
+    public string ValidationSummary { get => _validationSummary; private set { _validationSummary = value; OnPropertyChanged(); } }
+
     private bool _isBusy;
     public bool IsBusy { get => _isBusy; private set { _isBusy = value; OnPropertyChanged(); } }
 
@@ -269,7 +272,8 @@ public class InvoiceViewModel : INotifyPropertyChanged
     private void UpdateValidation()
     {
         var errors = Items.SelectMany(i => i.HasErrors ? new[] { i } : Array.Empty<InvoiceItemVM>()).Count();
-        StatusMessage = errors > 0 ? $"{errors} validation error(s)" : "Ready";
+        ValidationSummary = errors > 0 ? $"{errors} validation error(s)" : string.Empty;
+        StatusMessage = string.IsNullOrEmpty(ValidationSummary) ? "Ready" : ValidationSummary;
         SaveInvoiceCommand.RaiseCanExecuteChanged();
     }
 

--- a/Wrecept.UI/Views/InvoiceView.xaml
+++ b/Wrecept.UI/Views/InvoiceView.xaml
@@ -34,21 +34,33 @@
                 <DataGridTemplateColumn Header="Kód">
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate>
-                            <TextBox Text="{Binding Code, UpdateSourceTrigger=PropertyChanged}"/>
+                            <TextBox Text="{Binding Code, UpdateSourceTrigger=PropertyChanged, ValidatesOnDataErrors=True}"/>
                         </DataTemplate>
                     </DataGridTemplateColumn.CellTemplate>
                 </DataGridTemplateColumn>
                 <DataGridTemplateColumn Header="Megnevezés">
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate>
-                            <TextBox Text="{Binding Description, UpdateSourceTrigger=PropertyChanged}"/>
+                            <TextBox Text="{Binding Description, UpdateSourceTrigger=PropertyChanged, ValidatesOnDataErrors=True}"/>
                         </DataTemplate>
                     </DataGridTemplateColumn.CellTemplate>
                 </DataGridTemplateColumn>
-                <DataGridTextColumn Header="Menny." Binding="{Binding Quantity, UpdateSourceTrigger=PropertyChanged}"/>
+                <DataGridTemplateColumn Header="Menny.">
+                    <DataGridTemplateColumn.CellTemplate>
+                        <DataTemplate>
+                            <TextBox Text="{Binding Quantity, UpdateSourceTrigger=PropertyChanged, ValidatesOnDataErrors=True}"/>
+                        </DataTemplate>
+                    </DataGridTemplateColumn.CellTemplate>
+                </DataGridTemplateColumn>
                 <DataGridTextColumn Header="Egység" Binding="{Binding Unit}" IsReadOnly="True"/>
-                <DataGridTextColumn Header="Egységár" Binding="{Binding UnitPrice, UpdateSourceTrigger=PropertyChanged}"/>
-                <DataGridComboBoxColumn Header="ÁFA%" ItemsSource="{Binding DataContext.TaxRates, RelativeSource={RelativeSource AncestorType=DataGrid}}" SelectedItemBinding="{Binding TaxRate}"/>
+                <DataGridTemplateColumn Header="Egységár">
+                    <DataGridTemplateColumn.CellTemplate>
+                        <DataTemplate>
+                            <TextBox Text="{Binding UnitPrice, UpdateSourceTrigger=PropertyChanged, ValidatesOnDataErrors=True}"/>
+                        </DataTemplate>
+                    </DataGridTemplateColumn.CellTemplate>
+                </DataGridTemplateColumn>
+                <DataGridComboBoxColumn Header="ÁFA%" ItemsSource="{Binding DataContext.TaxRates, RelativeSource={RelativeSource AncestorType=DataGrid}}" SelectedItemBinding="{Binding TaxRate, UpdateSourceTrigger=PropertyChanged}"/>
                 <DataGridTextColumn Header="Nettó" Binding="{Binding LineNet}" IsReadOnly="True"/>
                 <DataGridTextColumn Header="ÁFA" Binding="{Binding LineVat}" IsReadOnly="True"/>
                 <DataGridTextColumn Header="Bruttó" Binding="{Binding LineGross}" IsReadOnly="True"/>
@@ -62,6 +74,18 @@
             </Grid.ColumnDefinitions>
             <StackPanel Grid.Column="1" Orientation="Vertical" HorizontalAlignment="Right">
                 <TextBlock Text="{Binding TotalNet, StringFormat=N2}"/>
+                <ItemsControl ItemsSource="{Binding VatTotals}">
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate>
+                            <TextBlock>
+                                <Run Text="ÁFA "/>
+                                <Run Text="{Binding Rate, StringFormat={}{0:P0}}"/>
+                                <Run Text=": "/>
+                                <Run Text="{Binding Vat, StringFormat=N2}"/>
+                            </TextBlock>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
                 <TextBlock Text="{Binding TotalVat, StringFormat=N2}"/>
                 <TextBlock Text="{Binding TotalGross, StringFormat=N2}" FontWeight="Bold"/>
             </StackPanel>


### PR DESCRIPTION
## Summary
- Redesign invoice grid with validation, VAT breakdown and status bar hints
- Expose validation summary and VAT totals in view model
- Document keyboard shortcuts and acceptance checklist
- Add unit tests for totals and VAT grouping

## Testing
- `dotnet test wrecept.sln --filter "Category!=UI"` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_6896bee50c00832283937dbba0aca334