### PR TITLE
Enable case-insensitive product lookup with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Features marked with *(planned)* are upcoming and not yet implemented.
 - **Model–Repository–Service (MRS) architecture** – Clear separation between domain models, persistence repositories, and business services.
 - **SQLite data storage** – Local persistence using a lightweight SQLite database via Entity Framework Core.
 - **Theme support** – Customisable themes with a dedicated Theme Editor.
+- **Case-insensitive product lookup** – Faster searches regardless of text casing.
 - **Logging with Serilog** – Structured logging to help diagnose issues and maintain reliability.
 - **Self-healing configuration** – Settings file is automatically created and reset if corrupted.
 - **Localisation** *(planned)* – Hungarian user interface and error messages.

--- a/TODO.md
+++ b/TODO.md
@@ -25,6 +25,7 @@
  - [x] `DONE` Create keyboard shortcut cheat sheet
  - [x] `DONE` Update README to reflect implemented features
 - [x] `DONE` Document AsyncRelayCommand usage in style guide
+- [x] `DONE` Document case-insensitive product search in README
 
 ## logic_agent
 - [x] `DONE` Set up MRS structure (Model → Repository → Service)
@@ -35,10 +36,12 @@
 - [x] `DONE` Predictive text entry using local history
 - [x] `DONE` Reporting analytics engine for sales trends, top customers/products, and tax breakdowns
 - [x] `DONE` Handle corrupted settings file gracefully
+- [x] `DONE` Make product lookup case-insensitive using EF.Functions.Like
 
 ## db_agent
 - [x] `DONE` Initialise SQLite database with migration
 - [x] `DONE` EF Core configuration (relationships, validation)
+- [x] `DONE` Add NOCASE collation and indexes for product and supplier names
 
 ## domain_agent
 - [x] `DONE` Initial core domain entities with validations
@@ -63,6 +66,7 @@
 - [x] `DONE` Setup `Wrecept.UI.Tests` with UI category and OS skip
 - [x] `DONE` Add unit test for settings theme update
 - [x] `DONE` Add unit test for `ThemeEditorViewModel` initialization
+- [x] `DONE` Add unit test for case-insensitive product lookup
 
 ## integration_agent
 - [x] `DONE` Database export/import function

--- a/Wrecept.Core.Tests/ProductLookupServiceTests.cs
+++ b/Wrecept.Core.Tests/ProductLookupServiceTests.cs
@@ -1,0 +1,36 @@
+using Microsoft.EntityFrameworkCore;
+using Wrecept.Core.Data;
+using Wrecept.Core.Models;
+using Wrecept.Core.Services;
+
+namespace Wrecept.Core.Tests;
+
+public class ProductLookupServiceTests
+{
+    private static AppDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseSqlite("Filename=:memory:")
+            .Options;
+        var ctx = new AppDbContext(options);
+        ctx.Database.OpenConnection();
+        ctx.Database.EnsureCreated();
+        return ctx;
+    }
+
+    [Fact]
+    public async Task SearchAsync_IsCaseInsensitive()
+    {
+        using var ctx = CreateContext();
+        ctx.Products.AddRange(
+            new Product { Name = "Coffee" },
+            new Product { Name = "Tea" }
+        );
+        ctx.SaveChanges();
+
+        var svc = new ProductLookupService(ctx);
+        var results = await svc.SearchAsync("coffee");
+        Assert.Single(results);
+        Assert.Equal("Coffee", results[0].Name);
+    }
+}

--- a/Wrecept.Core/Data/AppDbContext.cs
+++ b/Wrecept.Core/Data/AppDbContext.cs
@@ -79,6 +79,17 @@ public class AppDbContext : DbContext
             .Property(p => p.UnitPrice).HasColumnType("decimal(18,2)");
         modelBuilder.Entity<Product>()
             .Property(p => p.VatRate).HasColumnType("decimal(5,4)");
+        modelBuilder.Entity<Product>()
+            .Property(p => p.Name)
+            .UseCollation("NOCASE");
+        modelBuilder.Entity<Product>()
+            .HasIndex(p => p.Name);
+
+        modelBuilder.Entity<Supplier>()
+            .Property(s => s.Name)
+            .UseCollation("NOCASE");
+        modelBuilder.Entity<Supplier>()
+            .HasIndex(s => s.Name);
 
         modelBuilder.Entity<SuggestionTerm>()
             .Property(s => s.Term)

--- a/Wrecept.Core/Data/Migrations/20250809035836_AddNameCollation.Designer.cs
+++ b/Wrecept.Core/Data/Migrations/20250809035836_AddNameCollation.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Wrecept.Core.Data;
 
@@ -10,9 +11,11 @@ using Wrecept.Core.Data;
 namespace Wrecept.Core.Data.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250809035836_AddNameCollation")]
+    partial class AddNameCollation
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "8.0.0");

--- a/Wrecept.Core/Data/Migrations/20250809035836_AddNameCollation.cs
+++ b/Wrecept.Core/Data/Migrations/20250809035836_AddNameCollation.cs
@@ -1,0 +1,72 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Wrecept.Core.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddNameCollation : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "Suppliers",
+                type: "TEXT",
+                nullable: false,
+                collation: "NOCASE",
+                oldClrType: typeof(string),
+                oldType: "TEXT");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "Products",
+                type: "TEXT",
+                nullable: false,
+                collation: "NOCASE",
+                oldClrType: typeof(string),
+                oldType: "TEXT");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Suppliers_Name",
+                table: "Suppliers",
+                column: "Name");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Products_Name",
+                table: "Products",
+                column: "Name");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Suppliers_Name",
+                table: "Suppliers");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Products_Name",
+                table: "Products");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "Suppliers",
+                type: "TEXT",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "TEXT",
+                oldCollation: "NOCASE");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "Products",
+                type: "TEXT",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "TEXT",
+                oldCollation: "NOCASE");
+        }
+    }
+}

--- a/Wrecept.Core/Services/ProductLookupService.cs
+++ b/Wrecept.Core/Services/ProductLookupService.cs
@@ -19,7 +19,7 @@ public class ProductLookupService : IProductLookupService
             return Array.Empty<Product>();
 
         return await _context.Products
-            .Where(p => p.Name.Contains(term))
+            .Where(p => EF.Functions.Like(p.Name, $"%{term}%"))
             .OrderBy(p => p.Name)
             .Take(20)
             .ToListAsync();

--- a/docs/migrations/20250809035836_AddNameCollation.md
+++ b/docs/migrations/20250809035836_AddNameCollation.md
@@ -1,0 +1,3 @@
+# AddNameCollation Migration
+
+Adds NOCASE collation and indexes to product and supplier names to enable case-insensitive searches.

--- a/docs/progress/2025-08-09_1200_logic_agent.md
+++ b/docs/progress/2025-08-09_1200_logic_agent.md
@@ -1,0 +1,3 @@
+- Improved product lookup to use EF.Functions.Like for case-insensitive searching.
+- Added NOCASE collation and indexes for product and supplier names with db_agent.
+Ref: TODO logic_agent.

--- a/docs/progress/2025-08-09_1201_db_agent.md
+++ b/docs/progress/2025-08-09_1201_db_agent.md
@@ -1,0 +1,2 @@
+- Configured NOCASE collation and indexes on product and supplier names to accelerate lookups.
+Ref: TODO db_agent.

--- a/docs/progress/2025-08-09_1202_test_agent.md
+++ b/docs/progress/2025-08-09_1202_test_agent.md
@@ -1,0 +1,2 @@
+- Added unit test ensuring product lookup is case-insensitive.
+Ref: TODO test_agent.

--- a/docs/progress/2025-08-09_1203_doc_agent.md
+++ b/docs/progress/2025-08-09_1203_doc_agent.md
@@ -1,0 +1,2 @@
+- Updated README to mention case-insensitive product lookup.
+Ref: TODO doc_agent.


### PR DESCRIPTION
## Summary
- Make product search use EF.Functions.Like and add NOCASE collations with indexes
- Document and test case-insensitive product lookup

## Testing
- `dotnet test Wrecept.Core.sln --filter "Category!=UI"`
- `dotnet test Wrecept.UI.Tests/Wrecept.UI.Tests.csproj --filter "Category=UI"` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets was not found)*

------
https://chatgpt.com/codex/tasks/task_e_6896c659f4fc8322b409403453dc9834