### PR TITLE
ui_agent: make IsProductSearchOpen writable

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -59,6 +59,7 @@
 - [x] `DONE` Replace blocking call in `ThemeEditorViewModel` with async initialization
 - [x] `DONE` Replace async void commands with `AsyncRelayCommand`
 - [x] `DONE` Consolidate invoice view by removing `InvoiceEditorView`
+- [x] `DONE` Fix product search popup binding error
 
 ## test_agent
 - [x] `DONE` Unit tests for the Service layer

--- a/Wrecept.UI/ViewModels/InvoiceViewModel.cs
+++ b/Wrecept.UI/ViewModels/InvoiceViewModel.cs
@@ -68,7 +68,14 @@ public class InvoiceViewModel : INotifyPropertyChanged
     public bool IsProductSearchOpen
     {
         get => _isProductSearchOpen;
-        private set { _isProductSearchOpen = value; OnPropertyChanged(); }
+        set
+        {
+            if (_isProductSearchOpen != value)
+            {
+                _isProductSearchOpen = value;
+                OnPropertyChanged();
+            }
+        }
     }
 
     private CancellationTokenSource? _searchCts;


### PR DESCRIPTION
## Summary
- allow `IsProductSearchOpen` to be updated by UI by adding a public setter with change guard
- record completion of product search popup binding fix in TODO list

## Testing
- `dotnet test Wrecept.Core.sln --filter "Category!=UI"`


------
https://chatgpt.com/codex/tasks/task_e_68971d002b5c8322bafb0a2f07c854fc