### PR TITLE
logic_agent: cast supplier totals to double for SQLite ordering

### DIFF
--- a/Wrecept.Core/Services/AnalyticsService.cs
+++ b/Wrecept.Core/Services/AnalyticsService.cs
@@ -33,11 +33,14 @@ public class AnalyticsService : IAnalyticsService
         var query = await _ctx.Invoices
             .Include(i => i.Supplier)
             .GroupBy(i => i.Supplier.Name)
-            .Select(g => new TopSupplierDto(g.Key, g.Sum(i => i.TotalGross)))
-            .OrderByDescending(r => r.TotalGross)
+            .Select(g => new { Name = g.Key, Total = g.Sum(i => (double)i.TotalGross) })
+            .OrderByDescending(r => r.Total)
             .Take(topN)
             .ToListAsync();
-        return query;
+
+        return query
+            .Select(x => new TopSupplierDto(x.Name, (decimal)x.Total))
+            .ToList();
     }
 
     public async Task<IReadOnlyList<TopProductDto>> GetTopProductsAsync(int topN)


### PR DESCRIPTION
## Summary
- cast supplier gross totals to double before ordering in AnalyticsService to avoid SQLite decimal ORDER BY issue

## Testing
- `dotnet test Wrecept.Core.sln --filter "Category!=UI"`


------
https://chatgpt.com/codex/tasks/task_e_68972db91e748322a59fa6ad3966fc9d