### PR TITLE
domain: add unit tests for Money and TaxRate

### DIFF
--- a/tests/Wrecept.Domain.Tests/GlobalUsings.cs
+++ b/tests/Wrecept.Domain.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/tests/Wrecept.Domain.Tests/ValueObjects/MoneyTests.cs
+++ b/tests/Wrecept.Domain.Tests/ValueObjects/MoneyTests.cs
@@ -1,0 +1,53 @@
+using Wrecept.Domain;
+
+namespace Wrecept.Domain.Tests.ValueObjects;
+
+public class MoneyTests
+{
+    [Fact]
+    public void Constructor_Sets_Properties()
+    {
+        // Arrange & Act
+        var money = new Money("HUF", 10m);
+
+        // Assert
+        Assert.Equal("HUF", money.Currency);
+        Assert.Equal(10m, money.Amount);
+    }
+
+    [Fact]
+    public void Add_SameCurrency_ReturnsSum()
+    {
+        // Arrange
+        var first = new Money("HUF", 10m);
+        var second = new Money("HUF", 5m);
+
+        // Act
+        var result = first.Add(second);
+
+        // Assert
+        Assert.Equal(15m, result.Amount);
+        Assert.Equal("HUF", result.Currency);
+    }
+
+    [Fact]
+    public void Add_DifferentCurrency_Throws()
+    {
+        // Arrange
+        var first = new Money("HUF", 10m);
+        var second = new Money("USD", 5m);
+
+        // Act & Assert
+        Assert.Throws<InvalidOperationException>(() => first.Add(second));
+    }
+
+    [Fact]
+    public void Multiply_Negative_Throws()
+    {
+        // Arrange
+        var money = new Money("HUF", 10m);
+
+        // Act & Assert
+        Assert.Throws<ArgumentOutOfRangeException>(() => money.Multiply(-1));
+    }
+}

--- a/tests/Wrecept.Domain.Tests/ValueObjects/TaxRateTests.cs
+++ b/tests/Wrecept.Domain.Tests/ValueObjects/TaxRateTests.cs
@@ -1,0 +1,28 @@
+using Wrecept.Domain;
+
+namespace Wrecept.Domain.Tests.ValueObjects;
+
+public class TaxRateTests
+{
+    [Fact]
+    public void Constructor_InvalidRate_Throws()
+    {
+        // Act & Assert
+        Assert.Throws<ArgumentOutOfRangeException>(() => new TaxRate(1.5m));
+    }
+
+    [Fact]
+    public void ApplyTo_CalculatesTaxAmount()
+    {
+        // Arrange
+        var rate = new TaxRate(0.27m);
+        var net = new Money("HUF", 100m);
+
+        // Act
+        var tax = rate.ApplyTo(net);
+
+        // Assert
+        Assert.Equal(27m, tax.Amount);
+        Assert.Equal("HUF", tax.Currency);
+    }
+}

--- a/tests/Wrecept.Domain.Tests/Wrecept.Domain.Tests.csproj
+++ b/tests/Wrecept.Domain.Tests/Wrecept.Domain.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <ProjectReference Include="../../src/Wrecept.Domain/Wrecept.Domain.csproj" />
+  </ItemGroup>
+</Project>

--- a/wrecept.sln
+++ b/wrecept.sln
@@ -11,6 +11,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Wrecept.Core.Tests", "Wrece
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Wrecept.UI.Tests", "Wrecept.UI.Tests\Wrecept.UI.Tests.csproj", "{FBE85F9F-B312-454C-88CB-3E62727594B6}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Wrecept.Domain.Tests", "tests\Wrecept.Domain.Tests\Wrecept.Domain.Tests.csproj", "{4EC8900C-077F-434E-84A5-878C18D0D12F}"
+EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{1B01EA56-DD75-47E7-BCF0-FAAFE4564226}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Wrecept.UI.AutomatedTests", "tests\Wrecept.UI.AutomatedTests\Wrecept.UI.AutomatedTests.csproj", "{BED15137-2B71-4AD3-8A11-D7C2888DB6D2}"
@@ -44,6 +46,10 @@ Global
 		{FBE85F9F-B312-454C-88CB-3E62727594B6}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FBE85F9F-B312-454C-88CB-3E62727594B6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FBE85F9F-B312-454C-88CB-3E62727594B6}.Release|Any CPU.Build.0 = Release|Any CPU
+                {4EC8900C-077F-434E-84A5-878C18D0D12F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {4EC8900C-077F-434E-84A5-878C18D0D12F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {4EC8900C-077F-434E-84A5-878C18D0D12F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {4EC8900C-077F-434E-84A5-878C18D0D12F}.Release|Any CPU.Build.0 = Release|Any CPU
 		{BED15137-2B71-4AD3-8A11-D7C2888DB6D2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{BED15137-2B71-4AD3-8A11-D7C2888DB6D2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{BED15137-2B71-4AD3-8A11-D7C2888DB6D2}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -55,6 +61,7 @@ Global
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{BED15137-2B71-4AD3-8A11-D7C2888DB6D2} = {1B01EA56-DD75-47E7-BCF0-FAAFE4564226}
+                {4EC8900C-077F-434E-84A5-878C18D0D12F} = {1B01EA56-DD75-47E7-BCF0-FAAFE4564226}
 		{FD9D35B1-918A-43E7-A5EC-6663C71852B1} = {FA2FB5A5-8369-47C7-8E73-BAA3B3F0814E}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
Problem:
- `Wrecept.Domain` lacked unit tests for core value objects.

Approach:
- Added `Wrecept.Domain.Tests` xUnit project targeting `net8.0`.
- Implemented tests for `Money` and `TaxRate` value objects.
- Registered the new test project in `wrecept.sln`.

Alternatives considered:
- Including domain tests in existing test projects, but a dedicated project mirrors solution structure.

Risk & mitigations:
- `dotnet build wrecept.sln` fails on Linux due to missing WindowsDesktop SDK; domain tests compile and run successfully.

Affected files:
- tests/Wrecept.Domain.Tests/Wrecept.Domain.Tests.csproj
- tests/Wrecept.Domain.Tests/ValueObjects/MoneyTests.cs
- tests/Wrecept.Domain.Tests/ValueObjects/TaxRateTests.cs
- wrecept.sln

Test results (from COMMANDS.sh):
- `dotnet build wrecept.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*
- `dotnet build tests/Wrecept.Domain.Tests/Wrecept.Domain.Tests.csproj`
- `dotnet test tests/Wrecept.Domain.Tests/Wrecept.Domain.Tests.csproj --logger "trx;LogFileName=test.trx"`

Refs: #000

------
https://chatgpt.com/codex/tasks/task_e_6899053494848322932f22d65d5fe276