### PR TITLE
docs/tests: add contribution guide and domain entity tests

### DIFF
--- a/docs/code-of-conduct.md
+++ b/docs/code-of-conduct.md
@@ -1,0 +1,11 @@
+# Code of Conduct
+
+---
+
+To foster an open and welcoming environment:
+
+- Be respectful and inclusive.
+- Avoid harassment or personal attacks.
+- Resolve conflicts constructively.
+
+Report issues to the project maintainers.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,19 @@
+# Contributing Guide
+
+---
+
+## Development Workflow
+
+1. Read `AGENTS.md` and `docs/styleguide.md` before making changes.
+2. Modify only files in `src/`, `tests/`, or `docs/` unless instructed otherwise.
+3. Run `dotnet build` and `dotnet test` to verify changes.
+
+## Commit and PR
+
+- Commit messages use `<scope>: <imperative summary>`
+- Reference relevant TODO items or milestones.
+- Use the pull request template defined in `AGENTS.md`.
+
+## Code of Conduct
+
+See [code-of-conduct.md](code-of-conduct.md).

--- a/tests/Wrecept.Domain.Tests/Entities/CustomerTests.cs
+++ b/tests/Wrecept.Domain.Tests/Entities/CustomerTests.cs
@@ -1,0 +1,34 @@
+using Wrecept.Domain;
+
+namespace Wrecept.Domain.Tests.Entities;
+
+public class CustomerTests
+{
+    [Fact]
+    public void Constructor_Sets_Properties()
+    {
+        // Arrange
+        var id = Guid.NewGuid();
+
+        // Act
+        var customer = new Customer(id, "Alice");
+
+        // Assert
+        Assert.Equal(id, customer.Id);
+        Assert.Equal("Alice", customer.Name);
+    }
+
+    [Fact]
+    public void Constructor_EmptyId_Throws()
+    {
+        // Act & Assert
+        Assert.Throws<ArgumentException>(() => new Customer(Guid.Empty, "Alice"));
+    }
+
+    [Fact]
+    public void Constructor_EmptyName_Throws()
+    {
+        // Act & Assert
+        Assert.Throws<ArgumentException>(() => new Customer(Guid.NewGuid(), ""));
+    }
+}

--- a/tests/Wrecept.Domain.Tests/Entities/InvoiceTests.cs
+++ b/tests/Wrecept.Domain.Tests/Entities/InvoiceTests.cs
@@ -1,0 +1,61 @@
+using Wrecept.Domain;
+
+namespace Wrecept.Domain.Tests.Entities;
+
+public class InvoiceTests
+{
+    private static InvoiceLine CreateLine(decimal amount = 100m, string currency = "HUF")
+    {
+        var product = new Product(Guid.NewGuid(), "Item", new Money(currency, amount), new TaxRate(0.27m));
+        return new InvoiceLine(product, 1, new Money(currency, amount));
+    }
+
+    [Fact]
+    public void Constructor_Sets_Total()
+    {
+        // Arrange
+        var line1 = CreateLine(100m);
+        var line2 = CreateLine(50m);
+        var customer = new Customer(Guid.NewGuid(), "Alice");
+
+        // Act
+        var invoice = new Invoice(Guid.NewGuid(), customer, new[] { line1, line2 });
+
+        // Assert
+        Assert.Equal(150m, invoice.Total.Amount);
+        Assert.Equal("HUF", invoice.Total.Currency);
+    }
+
+    [Fact]
+    public void Constructor_EmptyLines_Throws()
+    {
+        // Arrange
+        var customer = new Customer(Guid.NewGuid(), "Alice");
+
+        // Act & Assert
+        Assert.Throws<ArgumentException>(() => new Invoice(Guid.NewGuid(), customer, Array.Empty<InvoiceLine>()));
+    }
+
+    [Fact]
+    public void Constructor_MixedCurrencies_Throws()
+    {
+        // Arrange
+        var line1 = CreateLine(10m, "HUF");
+        var line2 = CreateLine(5m, "USD");
+        var customer = new Customer(Guid.NewGuid(), "Alice");
+
+        // Act & Assert
+        Assert.Throws<InvalidOperationException>(() => new Invoice(Guid.NewGuid(), customer, new[] { line1, line2 }));
+    }
+
+    [Fact]
+    public void InvoiceLine_InvalidQuantity_Throws()
+    {
+        // Arrange
+        var product = new Product(Guid.NewGuid(), "Item", new Money("HUF", 10m), new TaxRate(0.27m));
+        var unitPrice = new Money("HUF", 10m);
+
+        // Act & Assert
+        Assert.Throws<ArgumentOutOfRangeException>(() => new InvoiceLine(product, 0, unitPrice));
+    }
+}

--- a/tests/Wrecept.Domain.Tests/Entities/ProductTests.cs
+++ b/tests/Wrecept.Domain.Tests/Entities/ProductTests.cs
@@ -1,0 +1,45 @@
+using Wrecept.Domain;
+
+namespace Wrecept.Domain.Tests.Entities;
+
+public class ProductTests
+{
+    [Fact]
+    public void Constructor_Sets_Properties()
+    {
+        // Arrange
+        var id = Guid.NewGuid();
+        var price = new Money("HUF", 100m);
+        var tax = new TaxRate(0.27m);
+
+        // Act
+        var product = new Product(id, "Item", price, tax);
+
+        // Assert
+        Assert.Equal(id, product.Id);
+        Assert.Equal("Item", product.Name);
+        Assert.Equal(price, product.Price);
+        Assert.Equal(tax, product.TaxRate);
+    }
+
+    [Fact]
+    public void Constructor_EmptyName_Throws()
+    {
+        // Arrange
+        var price = new Money("HUF", 100m);
+        var tax = new TaxRate(0.27m);
+
+        // Act & Assert
+        Assert.Throws<ArgumentException>(() => new Product(Guid.NewGuid(), "", price, tax));
+    }
+
+    [Fact]
+    public void Constructor_NullPrice_Throws()
+    {
+        // Arrange
+        var tax = new TaxRate(0.27m);
+
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => new Product(Guid.NewGuid(), "Item", null!, tax));
+    }
+}


### PR DESCRIPTION
Problem:
Repository lacked contributor guidance and domain entity test coverage.

Approach:
Added contributing guide and code of conduct docs. Introduced unit tests for customer, product, and invoice entities.

Alternatives considered:
None.

Risk & mitigations:
Limited to basic scenarios; build scoped to domain project due to missing Windows desktop SDK.

Affected files:
- docs/contributing.md
- docs/code-of-conduct.md
- tests/Wrecept.Domain.Tests/Entities/CustomerTests.cs
- tests/Wrecept.Domain.Tests/Entities/ProductTests.cs
- tests/Wrecept.Domain.Tests/Entities/InvoiceTests.cs

Test results (from COMMANDS.sh):
- `dotnet build tests/Wrecept.Domain.Tests/Wrecept.Domain.Tests.csproj`
- `dotnet test tests/Wrecept.Domain.Tests/Wrecept.Domain.Tests.csproj --logger "trx;LogFileName=test.trx"`

Refs: stage-0

------
https://chatgpt.com/codex/tasks/task_e_68990ab03e108322a651a0738e57fa2a