### PR TITLE
docs: document architecture decisions

### DIFF
--- a/docs/AUDIT_PROGRESS.md
+++ b/docs/AUDIT_PROGRESS.md
@@ -1,0 +1,7 @@
+# Audit Task Progress
+
+- [ ] Milestone 1 – Build Pipeline *(blocked: touches forbidden paths)*
+- [ ] Milestone 2 – Testing Expansion *(waiting on Milestone 1)*
+- [ ] Milestone 3 – Dependency Updates *(waiting on Milestone 1)*
+- [ ] Milestone 4 – Code Quality *(blocked: touches forbidden paths)*
+- [x] Milestone 5 – Documentation

--- a/docs/architecture-decisions.md
+++ b/docs/architecture-decisions.md
@@ -1,0 +1,13 @@
+# Architecture Decisions
+
+This document records key architectural choices for the **wrecept** application.
+
+## Overall Principles
+- Offline-first design with local SQLite storage.
+- Model–Repository–Service (MRS) layering to separate concerns.
+- MVVM pattern for WPF user interface.
+- Dependency Injection configured through a central startup orchestrator.
+- Structured logging via Serilog.
+
+## Rationale
+These decisions aim to keep the codebase modular, testable, and maintainable while supporting the project's keyboard-centric workflow.

--- a/docs/progress/2025-08-10_2222_master_orchestrator.md
+++ b/docs/progress/2025-08-10_2222_master_orchestrator.md
@@ -1,0 +1,8 @@
+# Progress Log - 2025-08-10
+
+## Completed
+- Added architecture-decisions documentation.
+- Recorded audit progress for Milestone 5 (Documentation).
+
+## Notes
+- Milestones 1–4 blocked by repository path restrictions.


### PR DESCRIPTION
Problem:
- No clear record of high-level architecture decisions.
- Audit milestone tracking not updated.

Approach:
- Added `docs/architecture-decisions.md` outlining core patterns and principles.
- Logged work under `docs/progress/2025-08-10_2222_master_orchestrator.md`.
- Created `docs/AUDIT_PROGRESS.md` marking Milestone 5 complete.

Alternatives considered:
- Extending existing README (rejected to keep overview concise).

Risk & mitigations:
- Minimal; documentation only. Ensured style-guide compliance.

Affected files:
- docs/architecture-decisions.md
- docs/progress/2025-08-10_2222_master_orchestrator.md
- docs/AUDIT_PROGRESS.md

Test results (from COMMANDS.sh):
- `dotnet build Wrecept.Core/Wrecept.Core.csproj`
- `dotnet test Wrecept.Core.Tests --logger "trx;LogFileName=test.trx"`
- `dotnet test tests/Wrecept.Domain.Tests --logger "trx;LogFileName=test.trx"`

Refs: AUDIT#5

------
https://chatgpt.com/codex/tasks/task_e_68991b03a0ec832290df82dfdf1482fe