### PR TITLE
docs: expand architecture decisions and log milestone progress

### DIFF
--- a/docs/AUDIT_PROGRESS.md
+++ b/docs/AUDIT_PROGRESS.md
@@ -10,3 +10,4 @@
   Next Action: Enable code quality tooling then resolve flagged issues.
 - [x] Milestone 5 – Documentation
   Next Action: None – Completed
+  Notes: 2025-08-11 – architecture decisions expanded; progress log recorded.

--- a/docs/architecture-decisions.md
+++ b/docs/architecture-decisions.md
@@ -11,3 +11,16 @@ This document records key architectural choices for the **wrecept** application.
 
 ## Rationale
 These decisions aim to keep the codebase modular, testable, and maintainable while supporting the project's keyboard-centric workflow.
+
+## Domain Boundaries
+- `Wrecept.Domain` encapsulates shared entities and value objects.
+- `Wrecept.Core` implements services and repositories operating on those types.
+- `Wrecept.UI` provides view models and views that consume core services.
+
+## Data Persistence
+- Entity Framework Core with SQLite enables offline storage.
+- Migrations are versioned under `docs/migrations` to trace schema changes.
+
+## Testing Strategy
+- xUnit test projects mirror production modules.
+- Core and domain tests run cross-platform; UI tests require Windows.

--- a/docs/progress/2025-08-11_0001_master_orchestrator.md
+++ b/docs/progress/2025-08-11_0001_master_orchestrator.md
@@ -1,0 +1,9 @@
+# Progress Log - 2025-08-11
+
+## Completed
+- Expanded architecture-decisions document with domain layering and persistence details.
+- Recorded milestone completion in audit progress.
+- Verified core and domain tests succeed.
+
+## Notes
+- Documentation-only changes.


### PR DESCRIPTION
Problem:
- Architecture decisions lacked detail and recent documentation progress was untracked.

Approach:
- Added domain boundaries, data persistence, and testing strategy sections.
- Logged milestone completion and progress entry.
- Verified core and domain tests.

Alternatives considered:
- None.

Risk & mitigations:
- Documentation may drift from implementation; kept content concise and will update as architecture evolves.

Affected files:
- docs/architecture-decisions.md
- docs/AUDIT_PROGRESS.md
- docs/progress/2025-08-11_0001_master_orchestrator.md

Test results (from COMMANDS.sh):
- `dotnet test Wrecept.Core.Tests`
- `dotnet test tests/Wrecept.Domain.Tests`

Refs: AUDIT Milestone 5

------
https://chatgpt.com/codex/tasks/task_e_6899324fa0788322855ce728a88019b8