### PR TITLE
docs: document error handling strategy

### DIFF
--- a/LIMITS.txt
+++ b/LIMITS.txt
@@ -1,2 +1,2 @@
-token limit: assumed contract files exempt from 5-file cap; command run time ~60s
-intentionally not changed: src code, tests, existing docs/COMMANDS.sh
+token/time: ~2000 tokens processed; build and tests ~60s
+intentionally not changed: source code, prior progress logs, `COMMANDS.sh`

--- a/PR.txt
+++ b/PR.txt
@@ -1,23 +1,22 @@
-Title: docs: add documentation strategy and log entry
+Title: docs: document error handling strategy
 
 Body:
 
 Problem:
-Architecture decisions lacked a documentation strategy and the progress log required an update.
+New error handling documentation and progress log required style alignment.
 
 Approach:
-Appended a documentation strategy section, created a timestamped progress log, and verified build and tests.
+Added an "Error Handling Strategy" section with present-tense bullet points and logged the update.
 
 Alternatives considered:
 None.
 
 Risk & mitigations:
-Progress log naming could be inconsistent; timestamp verified before commit.
+Misinterpreting documentation style; cross-checked against `docs/styleguide.md`.
 
 Affected files:
 - docs/architecture-decisions.md
-- docs/progress/2025-08-11_00-31-27_master_orchestrator.md
-- COMMANDS.sh
+- docs/progress/2025-08-11_00-47-40_master_orchestrator.md
 - SUMMARY.md
 - PR.txt
 - LIMITS.txt

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -1,6 +1,6 @@
-- **Problem statement**: Architecture decisions lacked a documentation strategy and progress logs needed an entry for this update.
-- **Approach taken**: Added a "Documentation Strategy" section, created a timestamped progress log, and ran build and test commands.
-- **Files changed**: `docs/architecture-decisions.md`, `docs/progress/2025-08-11_00-31-27_master_orchestrator.md`, `COMMANDS.sh`, `SUMMARY.md`, `PR.txt`, `LIMITS.txt`.
+- **Problem statement**: Newly added documentation required style alignment.
+- **Approach taken**: Added an "Error Handling Strategy" section and recorded a matching progress log entry, then verified build and tests.
+- **Files changed**: `docs/architecture-decisions.md`, `docs/progress/2025-08-11_00-47-40_master_orchestrator.md`, `SUMMARY.md`, `PR.txt`, `LIMITS.txt`.
 - **Risks & mitigations**:
-  - Progress log naming mistakes could break chronology; verified timestamp format before commit.
-- **Assumptions made**: Output contract files are permitted at repository root and excluded from file-count limits.
+  - Misinterpreting style conventions → reviewed `docs/styleguide.md` before editing.
+- **Assumptions made**: Existing `COMMANDS.sh` remains valid and unchanged.

--- a/docs/architecture-decisions.md
+++ b/docs/architecture-decisions.md
@@ -25,6 +25,12 @@ These decisions aim to keep the codebase modular, testable, and maintainable whi
 - xUnit test projects mirror production modules.
 - Core and domain tests run cross-platform; UI tests require Windows.
 
+## Error Handling Strategy
+- Services validate inputs and throw domain-specific exceptions.
+- A central service captures unhandled exceptions and logs them via Serilog.
+- UI components display errors through `IMessageService` for consistency.
+- Background tasks return structured error results instead of throwing.
+
 ## Cross-platform Build Strategy
 To keep builds portable, only the core libraries and domain tests run on non-Windows hosts. WPF UI projects depend on the WindowsDesktop SDK and are skipped outside Windows environments.
 

--- a/docs/progress/2025-08-11_00-47-40_master_orchestrator.md
+++ b/docs/progress/2025-08-11_00-47-40_master_orchestrator.md
@@ -1,0 +1,9 @@
+# Progress Log - 2025-08-11
+
+## Completed
+- Added "Error Handling Strategy" section to `docs/architecture-decisions.md` (Milestone 5).
+- Logged this documentation change for traceability.
+
+## Notes
+- Section uses consistent terminology and present tense.
+


### PR DESCRIPTION
Problem:
New error handling documentation and progress log required style alignment.

Approach:
Added an "Error Handling Strategy" section with present-tense bullet points and logged the update.

Alternatives considered:
None.

Risk & mitigations:
Misinterpreting documentation style; cross-checked against `docs/styleguide.md`.

Affected files:
- docs/architecture-decisions.md
- docs/progress/2025-08-11_00-47-40_master_orchestrator.md
- SUMMARY.md
- PR.txt
- LIMITS.txt

Test results (from COMMANDS.sh):
- dotnet build Wrecept.Core.sln
- dotnet test Wrecept.Core.Tests
- dotnet test tests/Wrecept.Domain.Tests

Refs: Milestone 5

------
https://chatgpt.com/codex/tasks/task_e_68993d4b2bb8832295937ca343263713