### PR TITLE
docs: document progress log naming pattern

### DIFF
--- a/LIMITS.txt
+++ b/LIMITS.txt
@@ -1,2 +1,2 @@
-token/time: ~2000 tokens processed; build and tests ~60s
-intentionally not changed: source code, prior progress logs, `COMMANDS.sh`
+token/time: ~1500 tokens processed; build and tests ~30s
+intentionally not changed: application source code, existing progress logs, COMMANDS.sh

--- a/PR.txt
+++ b/PR.txt
@@ -1,29 +1,29 @@
-Title: docs: document error handling strategy
+Title: docs: document progress log naming pattern
 
 Body:
 
 Problem:
-New error handling documentation and progress log required style alignment.
+Progress logs lacked a documented naming convention and corresponding progress entry for Milestone 5.
 
 Approach:
-Added an "Error Handling Strategy" section with present-tense bullet points and logged the update.
+Added the naming pattern to `docs/architecture-decisions.md` and created a matching progress log.
 
 Alternatives considered:
 None.
 
 Risk & mitigations:
-Misinterpreting documentation style; cross-checked against `docs/styleguide.md`.
+Potential divergence from style guidelines; cross-checked with `docs/styleguide.md`.
 
 Affected files:
 - docs/architecture-decisions.md
-- docs/progress/2025-08-11_00-47-40_master_orchestrator.md
+- docs/progress/2025-08-11_01-00-00_master_orchestrator.md
 - SUMMARY.md
 - PR.txt
 - LIMITS.txt
 
 Test results (from COMMANDS.sh):
 - dotnet build Wrecept.Core.sln
-- dotnet test Wrecept.Core.Tests
-- dotnet test tests/Wrecept.Domain.Tests
+- dotnet test Wrecept.Core.Tests/Wrecept.Core.Tests.csproj
+- dotnet test tests/Wrecept.Domain.Tests/Wrecept.Domain.Tests.csproj
 
 Refs: Milestone 5

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -1,6 +1,6 @@
-- **Problem statement**: Newly added documentation required style alignment.
-- **Approach taken**: Added an "Error Handling Strategy" section and recorded a matching progress log entry, then verified build and tests.
-- **Files changed**: `docs/architecture-decisions.md`, `docs/progress/2025-08-11_00-47-40_master_orchestrator.md`, `SUMMARY.md`, `PR.txt`, `LIMITS.txt`.
+- **Problem statement**: Milestone 5 requires documenting progress log naming and recording the update.
+- **Approach taken**: Added the required naming pattern to `docs/architecture-decisions.md` and logged the change in a new progress entry. Verified build and tests.
+- **Files changed**: `docs/architecture-decisions.md`, `docs/progress/2025-08-11_01-00-00_master_orchestrator.md`, `SUMMARY.md`, `PR.txt`, `LIMITS.txt`.
 - **Risks & mitigations**:
-  - Misinterpreting style conventions → reviewed `docs/styleguide.md` before editing.
-- **Assumptions made**: Existing `COMMANDS.sh` remains valid and unchanged.
+  - Possible deviation from future naming policies → referenced style guide for consistency.
+- **Assumptions made**: Timestamp `01-00-00` chosen to satisfy naming convention.

--- a/docs/architecture-decisions.md
+++ b/docs/architecture-decisions.md
@@ -41,6 +41,6 @@ This approach relies on:
 - Conditional project configurations that ignore WPF projects when the `WindowsDesktop` SDK is unavailable.
 
 ## Documentation Strategy
-- Progress logs under `docs/progress/` capture timestamped updates for traceability.
+- Progress logs under `docs/progress/` capture timestamped updates for traceability and use the naming convention `YYYY-MM-DD_HH-MM-SS_agentname.md`.
 - Architecture decision records are revised alongside progress logs to preserve context.
 - Documentation updates are logged to help future contributors understand project history.

--- a/docs/progress/2025-08-11_01-00-00_master_orchestrator.md
+++ b/docs/progress/2025-08-11_01-00-00_master_orchestrator.md
@@ -1,0 +1,8 @@
+# Progress Log - 2025-08-11
+
+## Completed
+- Documented the naming pattern for progress logs in `docs/architecture-decisions.md` (Milestone 5).
+- Logged this update for traceability.
+
+## Notes
+- Files follow `YYYY-MM-DD_HH-MM-SS_agentname.md` to keep entries ordered.


### PR DESCRIPTION
Problem:
Progress logs lacked a documented naming convention and corresponding progress entry for Milestone 5.

Approach:
Added the naming pattern to `docs/architecture-decisions.md` and created a matching progress log.

Alternatives considered:
None.

Risk & mitigations:
Potential divergence from style guidelines; cross-checked with `docs/styleguide.md`.

Affected files:
- docs/architecture-decisions.md
- docs/progress/2025-08-11_01-00-00_master_orchestrator.md
- SUMMARY.md
- PR.txt
- LIMITS.txt

Test results (from COMMANDS.sh):
- dotnet build Wrecept.Core.sln
- dotnet test Wrecept.Core.Tests/Wrecept.Core.Tests.csproj
- dotnet test tests/Wrecept.Domain.Tests/Wrecept.Domain.Tests.csproj

Refs: Milestone 5

------
https://chatgpt.com/codex/tasks/task_e_68999eba3e80832282b2d263c0170ba3