### PR TITLE
docs: require task references in progress logs

### DIFF
--- a/LIMITS.txt
+++ b/LIMITS.txt
@@ -1,2 +1,2 @@
-token/time: ~1700 tokens processed; build and tests ~45s
-intentionally not changed: application source code, other docs, COMMANDS.sh
+token/time: ~1800 tokens processed; build and tests ~25s
+intentionally not changed: application source code, test projects, COMMANDS.sh

--- a/PR.txt
+++ b/PR.txt
@@ -1,29 +1,26 @@
-Title: docs: clarify cross-platform build strategy
-
-Body:
+Title: docs: require task references in progress logs
 
 Problem:
-Cross-platform build guidance did not clearly state how to build on non-Windows hosts.
+Progress logs did not explicitly link entries to their related tasks or milestones.
 
 Approach:
-Refined the build strategy in `docs/architecture-decisions.md` and recorded the update in a progress log.
+Added an architecture decision mandating task references in progress logs and recorded a corresponding progress entry.
 
 Alternatives considered:
 None.
 
 Risk & mitigations:
-Instructions may become outdated; review periodically as tooling evolves.
+Documentation practices may still be overlooked → treat missing references as bugs during review.
 
 Affected files:
 - docs/architecture-decisions.md
-- docs/progress/2025-08-11_13-15-14_master_orchestrator.md
+- docs/progress/2025-08-11_13-35-14_master_orchestrator.md
 - SUMMARY.md
 - PR.txt
 - LIMITS.txt
 
 Test results (from COMMANDS.sh):
-- dotnet build Wrecept.Core.sln
-- dotnet test Wrecept.Core.Tests/Wrecept.Core.Tests.csproj
-- dotnet test tests/Wrecept.Domain.Tests/Wrecept.Domain.Tests.csproj
-
-Refs: Milestone 5
+- `dotnet build Wrecept.Core.sln`
+- `dotnet test Wrecept.Core.Tests`
+- `dotnet test tests/Wrecept.Domain.Tests`
+Refs: AUDIT Milestone 5

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -1,6 +1,6 @@
-- **Problem statement**: Cross-platform build guidance lacked clear instructions for non-Windows hosts.
-- **Approach taken**: Expanded the build strategy in `docs/architecture-decisions.md` and logged the change in a new progress entry. Verified build and tests.
-- **Files changed**: `docs/architecture-decisions.md`, `docs/progress/2025-08-11_13-15-14_master_orchestrator.md`, `SUMMARY.md`, `PR.txt`, `LIMITS.txt`.
+- **Problem statement**: Progress logs lacked explicit references to their related tasks or milestones.
+- **Approach taken**: Added an architecture decision requiring task references in progress logs and logged the update.
+- **Files changed**: `docs/architecture-decisions.md`, `docs/progress/2025-08-11_13-35-14_master_orchestrator.md`, `SUMMARY.md`, `PR.txt`, `LIMITS.txt`.
 - **Risks & mitigations**:
-  - Guidance may become outdated as build tooling evolves → periodically review documentation.
-- **Assumptions made**: Existing build commands remain valid across environments.
+  - Future logs might omit task references → treat missing references as documentation bugs during review.
+- **Assumptions made**: Existing progress log format remains acceptable.

--- a/docs/architecture-decisions.md
+++ b/docs/architecture-decisions.md
@@ -49,5 +49,6 @@ This approach relies on:
 
 ## Documentation Strategy
 - Progress logs under `docs/progress/` capture timestamped updates for traceability and use the naming convention `YYYY-MM-DD_HH-MM-SS_agentname.md`.
+- Each progress log entry references its related task or milestone.
 - Architecture decision records are revised alongside progress logs to preserve context.
 - Documentation updates are logged to help future contributors understand project history.

--- a/docs/progress/2025-08-11_13-35-14_master_orchestrator.md
+++ b/docs/progress/2025-08-11_13-35-14_master_orchestrator.md
@@ -1,0 +1,5 @@
+# Progress Log 2025-08-11
+
+## master_orchestrator
+
+- Documented requirement for progress logs to reference related tasks or milestones. Ref: AUDIT Milestone 5.

--- a/docs/progress/2025-08-11_13-35-14_master_orchestrator.md
+++ b/docs/progress/2025-08-11_13-35-14_master_orchestrator.md
@@ -2,4 +2,4 @@
 
 ## master_orchestrator
 
-- Documented requirement for progress logs to reference related tasks or milestones. Ref: AUDIT Milestone 5.
+- Established architectural requirement: All progress logs must explicitly reference related tasks or milestones to ensure traceability and facilitate audit processes. This decision was made in alignment with AUDIT Milestone 5.


### PR DESCRIPTION
Problem:
Progress logs did not explicitly link entries to their related tasks or milestones.

Approach:
Added an architecture decision mandating task references in progress logs and recorded a corresponding progress entry.

Alternatives considered:
None.

Risk & mitigations:
Documentation practices may still be overlooked → treat missing references as bugs during review.

Affected files:
- docs/architecture-decisions.md
- docs/progress/2025-08-11_13-35-14_master_orchestrator.md
- SUMMARY.md
- PR.txt
- LIMITS.txt

Test results (from COMMANDS.sh):
- `dotnet build Wrecept.Core.sln`
- `dotnet test Wrecept.Core.Tests`
- `dotnet test tests/Wrecept.Domain.Tests`
Refs: AUDIT Milestone 5

------
https://chatgpt.com/codex/tasks/task_e_6899ef8cfcd48322a8bd0a8116fabd7c