### PR TITLE
core: handle invoice add failures

### DIFF
--- a/Wrecept.Core.Tests/Wrecept.Core.Tests.csproj
+++ b/Wrecept.Core.Tests/Wrecept.Core.Tests.csproj
@@ -20,6 +20,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Moq" Version="4.20.69" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
     <ProjectReference Include="../Wrecept.Core/Wrecept.Core.csproj" />
   </ItemGroup>
 

--- a/Wrecept.Core/Services/InvoiceService.cs
+++ b/Wrecept.Core/Services/InvoiceService.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Logging;
 using Wrecept.Core.Models;
 using Wrecept.Core.Repositories;
 
@@ -6,16 +7,29 @@ namespace Wrecept.Core.Services;
 public class InvoiceService : IInvoiceService
 {
     private readonly IRepository<Invoice> _invoiceRepository;
+    private readonly ILogger<InvoiceService> _logger;
 
-    public InvoiceService(IRepository<Invoice> invoiceRepository)
+    public InvoiceService(IRepository<Invoice> invoiceRepository, ILogger<InvoiceService> logger)
     {
         _invoiceRepository = invoiceRepository;
+        _logger = logger;
     }
 
     public async Task AddInvoiceAsync(Invoice invoice)
     {
+        ArgumentNullException.ThrowIfNull(invoice);
+
         invoice.RecalculateTotals();
-        await _invoiceRepository.AddAsync(invoice);
+
+        try
+        {
+            await _invoiceRepository.AddAsync(invoice);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to add invoice {InvoiceId}", invoice.Id);
+            throw new InvalidOperationException("Adding invoice failed.", ex);
+        }
     }
 
     public async Task<IEnumerable<Invoice>> GetInvoicesAsync() => await _invoiceRepository.GetAllAsync();


### PR DESCRIPTION
Problem:
- InvoiceService lacked argument validation and propagated repository exceptions without context.

Approach:
- Injected ILogger into InvoiceService and added null-argument check for invoices.
- Wrapped repository persistence in try/catch, logging failures and rethrowing as InvalidOperationException.
- Added Moq and logging packages to test project and expanded InvoiceServiceTests for null and failure scenarios.

Alternatives considered:
- Using custom logger implementation; rejected in favor of Microsoft.Extensions.Logging for DI alignment.

Risk & mitigations:
- DI configurations may need logger registrations; verified tests with NullLogger.

Affected files:
- Wrecept.Core/Services/InvoiceService.cs
- Wrecept.Core.Tests/Wrecept.Core.Tests.csproj
- Wrecept.Core.Tests/InvoiceServiceTests.cs

Test results (from COMMANDS.sh):
- `dotnet build Wrecept.Core.sln`
- `dotnet test Wrecept.Core.Tests/Wrecept.Core.Tests.csproj --logger "trx;LogFileName=test.trx"`

Refs: #123

------
https://chatgpt.com/codex/tasks/task_e_689a6ea108c48322811c42034d3635fc