### PR TITLE
docs: add CI strategy section

### DIFF
--- a/docs/architecture-decisions.md
+++ b/docs/architecture-decisions.md
@@ -46,6 +46,10 @@ This approach relies on:
 - A dedicated solution (`Wrecept.Core.sln`) and solution filter (`wrecept-core.slnf`) that contain only cross-platform projects.
 - CI and local scripts invoking `dotnet build Wrecept.Core.sln` on non-Windows hosts.
 - Conditional project configurations that ignore WPF projects when the `WindowsDesktop` SDK is unavailable.
+## Continuous Integration Strategy
+- CI pipelines build cross-platform components with `dotnet build Wrecept.Core.sln`.
+- Tests execute via `dotnet test Wrecept.Core.Tests` and `dotnet test tests/Wrecept.Domain.Tests`.
+- UI projects are skipped when the `WindowsDesktop` SDK is missing to ensure portable builds.
 ## Localization Strategy
 - The primary user interface language is **Hungarian**.
 - Text resources are stored in `.resx` files under `Resources/` to enable translation.

--- a/docs/progress/2025-08-12_06-33-09_master_orchestrator.md
+++ b/docs/progress/2025-08-12_06-33-09_master_orchestrator.md
@@ -1,0 +1,5 @@
+# Progress Log 2025-08-12
+
+## master_orchestrator
+
+- Documented CI strategy in `architecture-decisions.md`. Ref: AUDIT Milestone 5.


### PR DESCRIPTION
Problem:
Architecture decisions lacked guidance on how CI builds cross-platform components.

Approach:
Added a Continuous Integration Strategy section outlining build and test steps and recorded the change in progress logs.

Alternatives considered:
Leaving CI behavior undocumented.

Risk & mitigations:
CI instructions might drift from pipeline; kept scope to current build/test commands to limit mismatch.

Affected files:
- docs/architecture-decisions.md
- docs/progress/2025-08-12_06-33-09_master_orchestrator.md

Test results (from COMMANDS.sh):
- dotnet build Wrecept.Core.sln
- dotnet test Wrecept.Core.Tests
- dotnet test tests/Wrecept.Domain.Tests

Refs: Milestone 5

------
https://chatgpt.com/codex/tasks/task_e_689adf2710e88322a7550da305a975f9