### PR TITLE
docs: document validation strategy

### DIFF
--- a/LIMITS.txt
+++ b/LIMITS.txt
@@ -1,2 +1,3 @@
-- Assumed sufficient tokens (<5k) and time (<10m) to edit documentation and run tests.
+- Assumed <5k tokens and <10m runtime for documentation updates and tests.
 - Did not modify source or test code outside docs.
+- Left COMMANDS.sh unchanged to keep file count within limits.

--- a/PR.txt
+++ b/PR.txt
@@ -1,24 +1,24 @@
-Title: docs: add localization strategy
+Title: docs: document validation strategy
 
 Problem:
-Documentation missed localization guidance and progress log for Milestone 5.
+Architecture decisions lacked guidance on input validation and progress logs were outdated.
 
 Approach:
-Added localization strategy section and logged related progress.
+Added a validation strategy section and recorded milestone progress.
 
 Alternatives considered:
 None.
 
 Risk & mitigations:
-Documentation may fall out of sync with code; keep docs updated during feature work.
+Validation details could overlap with error handling; section kept concise and focused.
 
 Affected files:
 - docs/architecture-decisions.md
-- docs/progress/2025-08-11_13-42-06_master_orchestrator.md
+- docs/progress/2025-08-12_06-37-55_master-orchestrator.md
 
 Test results (from COMMANDS.sh):
 - `dotnet build Wrecept.Core.sln`
 - `dotnet test Wrecept.Core.Tests`
 - `dotnet test tests/Wrecept.Domain.Tests`
 
-Refs: AUDIT Milestone 5
+Refs: Milestone 5

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -1,9 +1,9 @@
-- Problem: Documentation lacked localization strategy and recent progress entry.
-- Approach: Added localization strategy section to architecture decisions and logged progress for Milestone 5.
-- Files changed:
+Problem: Architecture decisions lacked a validation strategy and progress logs were outdated.
+Approach: Added a dedicated validation strategy section and recorded a milestone progress entry.
+Files changed:
   - docs/architecture-decisions.md
-  - docs/progress/2025-08-11_13-42-06_master_orchestrator.md
-- Risks & mitigations:
-  - Localization guidelines may require refinement as implementation evolves; keep documentation synced with code.
-- Assumptions:
-  - Output contract files are exempt from file-count limits.
+  - docs/progress/2025-08-12_06-37-55_master-orchestrator.md
+Risks & mitigations:
+  - Potential overlap with error handling guidance; kept validation notes concise to avoid duplication.
+Assumptions:
+  - Existing validation mechanisms match documented strategy.

--- a/docs/architecture-decisions.md
+++ b/docs/architecture-decisions.md
@@ -25,6 +25,12 @@ These decisions aim to keep the codebase modular, testable, and maintainable whi
 - xUnit test projects mirror production modules.
 - Core and domain tests run cross-platform; UI tests require Windows.
 
+## Validation Strategy
+- Domain models and services enforce business rules through guard clauses and return structured validation results.
+- View models implement `INotifyDataErrorInfo` to surface property-level issues.
+- User-facing validation messages are delivered via `IMessageService`.
+- Commands remain disabled until associated property errors are resolved.
+
 ## Error Handling Strategy
 - Services validate inputs and throw domain-specific exceptions.
 - A central service captures unhandled exceptions and logs them via Serilog.

--- a/docs/progress/2025-08-12_06-37-55_master-orchestrator.md
+++ b/docs/progress/2025-08-12_06-37-55_master-orchestrator.md
@@ -1,0 +1,5 @@
+# Progress Log 2025-08-12
+
+## master-orchestrator
+
+- Documented validation strategy across services and view models. Ref: Milestone 5.


### PR DESCRIPTION
Problem:
Architecture decisions lacked guidance on input validation and progress logs were outdated.

Approach:
Added a validation strategy section and recorded milestone progress.

Alternatives considered:
None.

Risk & mitigations:
Validation details could overlap with error handling; section kept concise and focused.

Affected files:
- docs/architecture-decisions.md
- docs/progress/2025-08-12_06-37-55_master-orchestrator.md

Test results (from COMMANDS.sh):
- `dotnet build Wrecept.Core.sln`
- `dotnet test Wrecept.Core.Tests`
- `dotnet test tests/Wrecept.Domain.Tests`

Refs: Milestone 5

------
https://chatgpt.com/codex/tasks/task_e_689ae0f6d3f88322bfd816a32a3f251f