### PR TITLE
build: skip UI tests on non-Windows

### DIFF
--- a/Wrecept.UI.Tests/Wrecept.UI.Tests.csproj
+++ b/Wrecept.UI.Tests/Wrecept.UI.Tests.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
-    <IsTestProject>true</IsTestProject>
+    <IsTestProject Condition="'$(OS)' == 'Windows_NT'">true</IsTestProject>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
   <PropertyGroup Condition="'$(OS)' == 'Windows_NT'">

--- a/tests/Wrecept.UI.AutomatedTests/Wrecept.UI.AutomatedTests.csproj
+++ b/tests/Wrecept.UI.AutomatedTests/Wrecept.UI.AutomatedTests.csproj
@@ -1,12 +1,19 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework Condition="'$(OS)' == 'Windows_NT'">net8.0-windows</TargetFramework>
+    <TargetFramework Condition="'$(OS)' != 'Windows_NT'">net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
-    <IsTestProject>true</IsTestProject>
+    <IsTestProject Condition="'$(OS)' == 'Windows_NT'">true</IsTestProject>
+    <EnableDefaultItems>false</EnableDefaultItems>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(OS)' == 'Windows_NT'">
     <EnableWindowsTargeting>true</EnableWindowsTargeting>
   </PropertyGroup>
+  <ItemGroup Condition="'$(OS)' == 'Windows_NT'">
+    <Compile Include="**/*.cs" />
+  </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
     <!--


### PR DESCRIPTION
Problem:
UI test projects attempted to run on non-Windows hosts, hindering cross-platform builds.

Approach:
Conditionalized test project properties to disable UI tests on non-Windows environments.

Alternatives considered:
Removing projects from the solution or cross-targeting WPF packages.

Risk & mitigations:
UI tests no longer run on non-Windows; Windows CI must cover them.

Affected files:
- Wrecept.UI.Tests/Wrecept.UI.Tests.csproj
- tests/Wrecept.UI.AutomatedTests/Wrecept.UI.AutomatedTests.csproj

Test results (from COMMANDS.sh):
- `dotnet build wrecept.sln`
- `dotnet test Wrecept.Core.Tests/Wrecept.Core.Tests.csproj`
- `dotnet test tests/Wrecept.Domain.Tests/Wrecept.Domain.Tests.csproj`

Refs: Milestone 1

------
https://chatgpt.com/codex/tasks/task_e_689af8850c088322a4baaed051ec15cc