### PR TITLE
ui: add localized date input widget

### DIFF
--- a/COMMANDS.sh
+++ b/COMMANDS.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-dotnet build wrecept.sln
-dotnet test wrecept.sln
+ruff check src/facturon_py tests
+black src/facturon_py tests
+pytest

--- a/LIMITS.txt
+++ b/LIMITS.txt
@@ -1,3 +1,3 @@
 - Assumed <5k tokens and <10m runtime.
-- Focused on UI and model changes; no database migration generated.
-- Output contract files excluded from 5-file code limit assumption.
+- Only prompt_toolkit installed; no other dependencies added.
+- Locale coverage limited to en_US and de_DE.

--- a/PR.txt
+++ b/PR.txt
@@ -1,29 +1,27 @@
-Title: ui: add accessible status markers
+Title: ui: add localized date input widget
 
 Body:
 
 Problem:
-- Invoice status relied on color alone, excluding screen readers and color-blind users.
+Date editors accepted free-form strings without locale awareness.
 
 Approach:
-- Added InvoiceStatus enum with marker/description helpers.
-- Bound status markers in list and detail views with accessible text.
+Added `DateField` with locale-based masks, validation, and ISO normalization.
 
 Alternatives considered:
-- Dedicated value converters (deferred).
+Using external libraries like Babel was deemed unnecessary for MVP.
 
 Risk & mitigations:
-- Colors are hard-coded; future theming may require refactor.
+Limited locale support; ISO fallback ensures consistent storage.
 
 Affected files:
-- Wrecept.Core/Models/Invoice.cs
-- Wrecept.UI/ViewModels/InvoiceViewModel.cs
-- Wrecept.UI/Views/ListsView.xaml
-- Wrecept.UI/Views/InvoiceView.xaml
-- Wrecept.Core.Tests/InvoiceTests.cs
+- src/facturon_py/ui_tui/widgets/date_field.py
+- src/facturon_py/ui_tui/widgets/__init__.py
+- tests/test_date_field.py
 
 Test results (from COMMANDS.sh):
-- dotnet build wrecept.sln
-- dotnet test wrecept.sln
+- `ruff check src/facturon_py tests`
+- `black src/facturon_py tests`
+- `pytest`
 
 Refs: #3

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -1,12 +1,22 @@
-Problem: Invoice status relied solely on color, leaving color-blind and screen-reader users without context.
-Approach: Introduced InvoiceStatus with marker/description helpers and bound them in list and detail views.
-Files changed:
-  - Wrecept.Core/Models/Invoice.cs
-  - Wrecept.UI/ViewModels/InvoiceViewModel.cs
-  - Wrecept.UI/Views/ListsView.xaml
-  - Wrecept.UI/Views/InvoiceView.xaml
-  - Wrecept.Core.Tests/InvoiceTests.cs
-Risks & mitigations:
-  - Marker text hard-coded; localization may be needed later.
-Assumptions:
-  - Only Active and Inactive statuses are required.
+## Problem
+Date inputs lacked validation and locale-aware prompts, allowing invalid or ambiguous entries.
+
+## Approach
+- Added `DateField` widget with locale-based masks and normalization.
+- Provided validator for prompt_toolkit editors.
+- Covered parsing and prompts in unit tests.
+
+## Files Changed
+- `src/facturon_py/ui_tui/widgets/date_field.py`
+- `src/facturon_py/ui_tui/widgets/__init__.py`
+- `tests/test_date_field.py`
+- `COMMANDS.sh`
+- `PR.txt`
+- `LIMITS.txt`
+- `SUMMARY.md`
+
+## Risks & Mitigations
+- **Locale coverage** limited to few locales → fallback to ISO format.
+
+## Assumptions
+- Using regex + strptime is sufficient for mask enforcement.

--- a/src/facturon_py/ui_tui/widgets/__init__.py
+++ b/src/facturon_py/ui_tui/widgets/__init__.py
@@ -1,0 +1,1 @@
+"""Widgets for Facturon TUI."""

--- a/src/facturon_py/ui_tui/widgets/date_field.py
+++ b/src/facturon_py/ui_tui/widgets/date_field.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import datetime as dt
+import locale
+import re
+from dataclasses import dataclass
+from typing import Tuple
+
+from prompt_toolkit.validation import ValidationError, Validator
+
+# Mapping of locale codes to (strftime format, regex pattern, display mask)
+LOCALE_FORMATS: dict[str, Tuple[str, str, str]] = {
+    "en_US": ("%m/%d/%Y", r"\d{2}/\d{2}/\d{4}", "MM/DD/YYYY"),
+    "de_DE": ("%d.%m.%Y", r"\d{2}\.\d{2}\.\d{4}", "DD.MM.YYYY"),
+}
+DEFAULT_FORMAT = ("%Y-%m-%d", r"\d{4}-\d{2}-\d{2}", "YYYY-MM-DD")
+
+
+def _locale_spec(locale_code: str | None) -> Tuple[str, str, str]:
+    """Return format, regex, and mask for the given locale."""
+    if not locale_code:
+        locale_code = locale.getlocale(locale.LC_TIME)[0] or ""
+    return LOCALE_FORMATS.get(locale_code, DEFAULT_FORMAT)
+
+
+@dataclass
+class DateField:
+    """Utility for localized date input and normalization."""
+
+    locale_code: str | None = None
+
+    def prompt(self) -> str:
+        """Return localized prompt hint."""
+        _fmt, _pattern, mask = _locale_spec(self.locale_code)
+        return f"Enter date ({mask}):"
+
+    def normalize(self, text: str) -> str:
+        """Validate and normalize the input to ISO format."""
+        fmt, pattern, mask = _locale_spec(self.locale_code)
+        if not re.fullmatch(pattern, text):
+            raise ValueError(f"Expected {mask}")
+        try:
+            parsed = dt.datetime.strptime(text, fmt).date()
+        except ValueError as exc:  # pragma: no cover - strptime detail
+            raise ValueError(f"Invalid date: {text}") from exc
+        return parsed.isoformat()
+
+    def validator(self) -> Validator:
+        fmt, pattern, mask = _locale_spec(self.locale_code)
+
+        class _V(Validator):
+            def validate(self, document) -> None:  # type: ignore[override]
+                text = document.text
+                if not re.fullmatch(pattern, text):
+                    raise ValidationError(message=f"Expected {mask}")
+                try:
+                    dt.datetime.strptime(text, fmt)
+                except ValueError:
+                    raise ValidationError(message="Invalid date")
+
+        return _V()
+
+
+__all__ = ["DateField"]

--- a/tests/test_date_field.py
+++ b/tests/test_date_field.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import pytest
+from prompt_toolkit.document import Document
+from prompt_toolkit.validation import ValidationError
+
+from facturon_py.ui_tui.widgets.date_field import DateField
+
+
+def test_normalize_en_us():
+    field = DateField("en_US")
+    assert field.normalize("12/31/2024") == "2024-12-31"
+
+
+def test_normalize_de_de():
+    field = DateField("de_DE")
+    assert field.normalize("31.12.2024") == "2024-12-31"
+
+
+def test_validator_rejects_bad_format():
+    field = DateField("en_US")
+    validator = field.validator()
+    with pytest.raises(ValidationError):
+        validator.validate(Document("31/12/2024"))
+
+
+def test_prompt_localized():
+    assert DateField("de_DE").prompt().startswith("Enter date (DD.MM.YYYY)")


### PR DESCRIPTION
## Problem
Date editors accepted free-form strings without locale awareness.

## Approach
Added `DateField` with locale-based masks, validation, and ISO normalization.

## Alternatives considered
Using external libraries like Babel was deemed unnecessary for MVP.

## Risk & mitigations
Limited locale support; ISO fallback ensures consistent storage.

## Affected files
- src/facturon_py/ui_tui/widgets/date_field.py
- src/facturon_py/ui_tui/widgets/__init__.py
- tests/test_date_field.py

## Test results
- `ruff check src/facturon_py tests`
- `black src/facturon_py tests`
- `pytest`

Refs: #3

------
https://chatgpt.com/codex/tasks/task_e_68a3b01a59fc8322aef25584bce1c29e