### PR TITLE
ui: add F1 help popup and shortcut registry

### DIFF
--- a/LIMITS.txt
+++ b/LIMITS.txt
@@ -1,3 +1,3 @@
 - Assumed <5k tokens and <10m runtime.
-- Only prompt_toolkit installed; no other dependencies added.
-- Locale coverage limited to en_US and de_DE.
+- No interactive TUI tests; dialog rendering mocked.
+- Shortcuts text fixed in Hungarian only.

--- a/PR.txt
+++ b/PR.txt
@@ -1,23 +1,24 @@
-Title: ui: add localized date input widget
+Title: ui: add F1 help popup and shortcut registry
 
 Body:
 
 Problem:
-Date editors accepted free-form strings without locale awareness.
+No global shortcut registry and F1 didn't provide help dialogs, leading to inconsistent key hints.
 
 Approach:
-Added `DateField` with locale-based masks, validation, and ISO normalization.
+Created central `shortcuts` module and registered edit-form keys. Mapped F1 to display them in a dialog.
 
 Alternatives considered:
-Using external libraries like Babel was deemed unnecessary for MVP.
+Keeping per-view definitions risked duplicated descriptions.
 
 Risk & mitigations:
-Limited locale support; ISO fallback ensures consistent storage.
+Hungarian text is hardcoded; future localization might require registry updates.
 
 Affected files:
-- src/facturon_py/ui_tui/widgets/date_field.py
-- src/facturon_py/ui_tui/widgets/__init__.py
-- tests/test_date_field.py
+- src/facturon_py/ui_tui/shortcuts.py
+- src/facturon_py/ui_tui/edit_views/edit_form.py
+- tests/test_edit_form_controller.py
+- tests/test_shortcuts.py
 
 Test results (from COMMANDS.sh):
 - `ruff check src/facturon_py tests`

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -1,22 +1,22 @@
 ## Problem
-Date inputs lacked validation and locale-aware prompts, allowing invalid or ambiguous entries.
+No centralized shortcut registry and F1 key lacked help popup, making keyboard hints inconsistent.
 
 ## Approach
-- Added `DateField` widget with locale-based masks and normalization.
-- Provided validator for prompt_toolkit editors.
-- Covered parsing and prompts in unit tests.
+- Introduced `shortcuts` registry with dialog helper.
+- Registered edit-form shortcuts and mapped F1 to show them.
+- Covered registry and F1 handler with tests.
 
 ## Files Changed
-- `src/facturon_py/ui_tui/widgets/date_field.py`
-- `src/facturon_py/ui_tui/widgets/__init__.py`
-- `tests/test_date_field.py`
-- `COMMANDS.sh`
+- `src/facturon_py/ui_tui/shortcuts.py`
+- `src/facturon_py/ui_tui/edit_views/edit_form.py`
+- `tests/test_edit_form_controller.py`
+- `tests/test_shortcuts.py`
 - `PR.txt`
 - `LIMITS.txt`
 - `SUMMARY.md`
 
 ## Risks & Mitigations
-- **Locale coverage** limited to few locales → fallback to ISO format.
+- Dialog text hardcoded in Hungarian → adjust in registry if localization changes.
 
 ## Assumptions
-- Using regex + strptime is sufficient for mask enforcement.
+- Displayed key names (e.g., "Esc") are sufficient for user understanding.

--- a/src/facturon_py/ui_tui/edit_views/edit_form.py
+++ b/src/facturon_py/ui_tui/edit_views/edit_form.py
@@ -5,6 +5,17 @@ from typing import Any, Callable, Dict, List, Tuple
 from prompt_toolkit.shortcuts import confirm
 
 from facturon_py.repo import audit_log
+from facturon_py.ui_tui import shortcuts
+
+
+shortcuts.register(
+    "edit_form",
+    [
+        ("Esc", "Kilépés"),
+        ("Ctrl+Z", "Visszavonás"),
+        ("F1", "Gyorsbillentyűk"),
+    ],
+)
 
 
 class EditFormController:
@@ -55,6 +66,9 @@ class EditFormController:
         """
         if key == "c-z":
             self.undo_last()
+            return False
+        if key == "f1":
+            shortcuts.show("edit_form")
             return False
         if key != "escape":
             return False

--- a/src/facturon_py/ui_tui/shortcuts.py
+++ b/src/facturon_py/ui_tui/shortcuts.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from typing import Dict, List, Tuple
+
+from prompt_toolkit.shortcuts import message_dialog
+
+# Registry mapping view identifiers to lists of (key, description)
+_registry: Dict[str, List[Tuple[str, str]]] = {}
+
+
+def register(view: str, shortcuts: List[Tuple[str, str]]) -> None:
+    """Register shortcuts for a view."""
+    _registry[view] = list(shortcuts)
+
+
+def get(view: str) -> List[Tuple[str, str]]:
+    """Return shortcuts registered for a view."""
+    return list(_registry.get(view, []))
+
+
+def clear() -> None:
+    """Clear all registered shortcuts (useful for tests)."""
+    _registry.clear()
+
+
+def show(view: str) -> None:
+    """Show shortcuts for the given view in a dialog."""
+    lines = [f"{key} - {desc}" for key, desc in get(view)]
+    text = "\n".join(lines) if lines else "Nincs gyorsbillentyű."
+    message_dialog(title="Gyorsbillentyűk", text=text).run()

--- a/tests/test_edit_form_controller.py
+++ b/tests/test_edit_form_controller.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from facturon_py.repo import audit_log
+from facturon_py.ui_tui import shortcuts
 from facturon_py.ui_tui.edit_views.edit_form import EditFormController
 
 
@@ -60,3 +61,16 @@ def test_toggle_active_decline_does_nothing():
     controller.toggle_active()
     assert controller.data["active"] is False
     assert audit_log.get_log() == []
+
+
+def test_f1_shows_shortcuts(monkeypatch):
+    shown: dict[str, str] = {}
+
+    def fake_show(view: str) -> None:
+        shown["view"] = view
+
+    monkeypatch.setattr(shortcuts, "show", fake_show)
+
+    controller = EditFormController({})
+    assert controller.handle_key("f1") is False
+    assert shown["view"] == "edit_form"

--- a/tests/test_shortcuts.py
+++ b/tests/test_shortcuts.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from facturon_py.ui_tui import shortcuts
+
+
+def test_register_and_get():
+    shortcuts.clear()
+    shortcuts.register("view", [("A", "Valami")])
+    assert shortcuts.get("view") == [("A", "Valami")]
+
+
+def test_show_uses_message_dialog(monkeypatch):
+    shortcuts.clear()
+    shortcuts.register("view", [("A", "Valami")])
+
+    recorded: dict[str, str] = {}
+
+    class DummyDialog:
+        def __init__(self, title: str, text: str) -> None:  # noqa: D401 - simple
+            recorded["title"] = title
+            recorded["text"] = text
+
+        def run(self) -> None:  # pragma: no cover - no behavior needed
+            recorded["run"] = "yes"
+
+    monkeypatch.setattr(shortcuts, "message_dialog", DummyDialog)
+
+    shortcuts.show("view")
+
+    assert recorded["title"] == "Gyorsbillentyűk"
+    assert "A - Valami" in recorded["text"]
+    assert recorded["run"] == "yes"


### PR DESCRIPTION
## Problem
No global shortcut registry and F1 didn't provide help dialogs, leading to inconsistent key hints.

## Approach
Created central `shortcuts` module and registered edit-form keys. Mapped F1 to display them in a dialog.

## Alternatives considered
Keeping per-view definitions risked duplicated descriptions.

## Risk & mitigations
Hungarian text is hardcoded; future localization might require registry updates.

## Affected files
- src/facturon_py/ui_tui/shortcuts.py
- src/facturon_py/ui_tui/edit_views/edit_form.py
- tests/test_edit_form_controller.py
- tests/test_shortcuts.py

## Test results
- `ruff check src/facturon_py tests`
- `black src/facturon_py tests`
- `pytest`

## Refs
- #3

------
https://chatgpt.com/codex/tasks/task_e_68a3c5c58d78832292f2b5d5f1e0b964