### PR TITLE
ui: add detail view controller

### DIFF
--- a/src/facturon_py/ui_tui/__init__.py
+++ b/src/facturon_py/ui_tui/__init__.py
@@ -1,4 +1,5 @@
 from .main_menu import run_main_menu
+from .detail_view import DetailView
 from . import shortcuts
 
-__all__ = ["run_main_menu", "shortcuts"]
+__all__ = ["run_main_menu", "DetailView", "shortcuts"]

--- a/src/facturon_py/ui_tui/detail_view.py
+++ b/src/facturon_py/ui_tui/detail_view.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+from typing import Callable, Sequence
+
+from prompt_toolkit.application import Application
+from prompt_toolkit.input import Input
+from prompt_toolkit.input.defaults import DummyInput
+from prompt_toolkit.key_binding import KeyBindings
+from prompt_toolkit.layout import Layout
+from prompt_toolkit.layout.containers import Window
+from prompt_toolkit.layout.controls import FormattedTextControl
+from prompt_toolkit.output import Output
+from prompt_toolkit.output.defaults import DummyOutput
+
+from . import shortcuts
+from .edit_views.edit_form import EditFormController
+
+
+class DetailView:
+    """Simple detail view with section navigation and edit support.
+
+    Parameters
+    ----------
+    header:
+        Lines shown in the *Header* section.
+    body:
+        Lines shown in the *Body* section.
+    related_provider:
+        Callable returning lines for the *Related records* section. This allows
+        embedding tables such as invoice line items.
+    meta:
+        Lines shown in the *Meta* section.
+    controller:
+        Optional :class:`EditFormController` used for dirty checks when leaving
+        the view.
+    view_id:
+        Identifier used for shortcut registration.
+    """
+
+    _SECTION_NAMES = ["Fejléc", "Törzs", "Kapcsolódó", "Meta"]
+
+    def __init__(
+        self,
+        header: Sequence[str],
+        body: Sequence[str],
+        related_provider: Callable[[], Sequence[str]],
+        meta: Sequence[str],
+        *,
+        controller: EditFormController | None = None,
+        view_id: str = "detail_view",
+    ) -> None:
+        self._sections = [
+            list(header),
+            list(body),
+            list(related_provider()),
+            list(meta),
+        ]
+        self._related_provider = related_provider
+        self.section_index = 0
+        self.line_index = 0
+        self.controller = controller
+        shortcuts.register(
+            view_id,
+            [
+                ("Tab", "Szakasz váltás"),
+                ("↑/↓", "Mozgás"),
+                ("F2", "Szerkeszt"),
+                ("Esc", "Vissza"),
+            ],
+        )
+
+    # ------------------------------------------------------------------
+    def _current_lines(self) -> list[str]:
+        if self.section_index == 2:  # refresh related records
+            self._sections[2] = list(self._related_provider())
+        return self._sections[self.section_index]
+
+    def _render(self) -> str:
+        lines = self._current_lines()
+        header = f"[{self._SECTION_NAMES[self.section_index]}]"
+        if not lines:
+            return header + "\nNincs adat."
+        rendered = [
+            f"{'>' if i == self.line_index else ' '} {line}"
+            for i, line in enumerate(lines)
+        ]
+        return "\n".join([header] + rendered)
+
+    # ------------------------------------------------------------------
+    def _build_app(
+        self, *, input: Input | None = None, output: Output | None = None
+    ) -> Application:
+        kb = KeyBindings()
+
+        @kb.add("tab")
+        def _next_section(event) -> None:  # pragma: no cover - simple
+            self.section_index = (self.section_index + 1) % len(self._sections)
+            self.line_index = 0
+            event.app.invalidate()
+
+        @kb.add("up")
+        def _up(event) -> None:  # pragma: no cover - simple
+            if self.line_index > 0:
+                self.line_index -= 1
+                event.app.invalidate()
+
+        @kb.add("down")
+        def _down(event) -> None:  # pragma: no cover - simple
+            if self.line_index < len(self._current_lines()) - 1:
+                self.line_index += 1
+                event.app.invalidate()
+
+        @kb.add("f2")
+        def _edit(event) -> None:
+            event.app.exit(result="edit")
+
+        @kb.add("escape")
+        def _back(event) -> None:
+            if self.controller and not self.controller.handle_key("escape"):
+                return
+            event.app.exit(result="back")
+
+        body = Window(
+            FormattedTextControl(lambda: self._render()), always_hide_cursor=True
+        )
+
+        return Application(
+            layout=Layout(body),
+            key_bindings=kb,
+            mouse_support=False,
+            full_screen=False,
+            input=input or DummyInput(),
+            output=output or DummyOutput(),
+        )
+
+    # ------------------------------------------------------------------
+    def run(self, *, input: Input | None = None, output: Output | None = None) -> str:
+        """Run the detail view and return the action."""
+        app = self._build_app(input=input, output=output)
+        return app.run()
+
+
+__all__ = ["DetailView"]

--- a/tests/test_detail_view.py
+++ b/tests/test_detail_view.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from prompt_toolkit.input import create_pipe_input
+from prompt_toolkit.output.defaults import DummyOutput
+
+from facturon_py.ui_tui.detail_view import DetailView
+from facturon_py.ui_tui.edit_views.edit_form import EditFormController
+
+
+def _make_view(controller: EditFormController | None = None) -> DetailView:
+    header = ["H1", "H2"]
+    body = ["B1", "B2", "B3"]
+    related_lines = ["R1", "R2"]
+    meta = ["M1"]
+
+    def related_provider() -> list[str]:
+        return list(related_lines)
+
+    return DetailView(
+        header,
+        body,
+        related_provider,
+        meta,
+        controller=controller,
+    )
+
+
+def test_tab_and_arrow_navigation():
+    view = _make_view()
+    with create_pipe_input() as pipe:
+        pipe.send_text("\t")  # to body
+        pipe.send_text("\x1b[B")  # down -> index 1
+        pipe.send_text("\t")  # to related
+        pipe.send_text("\x1b[B")  # down -> index 1
+        pipe.send_text("\t")  # to meta
+        pipe.send_text("\x1b[A")  # up -> stays 0
+        pipe.send_text("\x1b")  # exit
+        action = view.run(input=pipe, output=DummyOutput())
+    assert action == "back"
+    assert view.section_index == 3
+    assert view.line_index == 0
+
+
+def test_escape_dirty_uses_edit_controller():
+    responses = [False, True]
+
+    def confirm(_msg: str) -> bool:
+        return responses.pop(0)
+
+    controller = EditFormController({"name": "Alice"}, confirm_discard=confirm)
+    controller.update_field("name", "Bob")
+    view = _make_view(controller)
+
+    with create_pipe_input() as pipe:
+        pipe.send_text("\x1b")  # first attempt, decline
+        pipe.send_text("\x1b")  # second attempt, confirm
+        action = view.run(input=pipe, output=DummyOutput())
+    assert action == "back"
+    assert responses == []
+    assert controller.data == {"name": "Alice"}


### PR DESCRIPTION
Problem:
Detail screens lacked a controller for section navigation and edit handling.

Approach:
Implemented a DetailView controller with Tab/arrow navigation, F2 editing hook, Esc back with dirty-check, and related-record embedding. Added unit tests.

Alternatives considered:
A more complex multi-pane layout was deferred.

Risk & mitigations:
Navigation or edit logic may require expansion; covered core flows with tests.

Affected files:
- src/facturon_py/ui_tui/__init__.py
- src/facturon_py/ui_tui/detail_view.py
- tests/test_detail_view.py

Test results (from COMMANDS.sh):
- black src/facturon_py tests
- ruff check src/facturon_py tests
- pytest

Refs: #123

------
https://chatgpt.com/codex/tasks/task_e_68a3e457036883228d7aabf309d50bd3