### PR TITLE
services: add invoice creation and TUI flow

### DIFF
--- a/COMMANDS.sh
+++ b/COMMANDS.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Commands for invoice service feature
 pip install -r src/facturon_py/requirements.txt
 ruff check src/facturon_py tests
 black src/facturon_py tests

--- a/LIMITS.txt
+++ b/LIMITS.txt
@@ -1,3 +1,3 @@
-- Assumed <5k tokens and <10m runtime.
-- Alt+digit navigation implemented for 8 options only.
-- Hungarian labels fixed; no localization yet.
+- Assumed <5k tokens and <15m runtime.
+- TUI flow uses simple prompts without advanced navigation.
+- VAT rates provided via in-memory mapping only.

--- a/PR.txt
+++ b/PR.txt
@@ -1,23 +1,25 @@
-Title: ui: implement main menu navigation
+Title: services: add invoice creation and TUI flow
 
 Body:
 
 Problem:
-No TUI main menu existed; users lacked keyboard navigation and help for available keys.
+No invoice creation logic or wizard existed, so VAT totals couldn't be computed.
 
 Approach:
-Implemented prompt_toolkit main menu with Alt+digit shortcuts and F1 help via shortcut registry. Added tests for navigation and exit.
+Implemented `InvoiceService` for VAT snapshot and totals, added `new_invoice` wizard leveraging `DateField` and `EditFormController`, and covered totals with a unit test.
 
 Alternatives considered:
-A simple text prompt without key bindings was rejected due to poor UX.
+Deferring the TUI until full persistence was rejected to keep vertical slice progress.
 
 Risk & mitigations:
-Hardcoded Hungarian labels may require localization later.
+Wizard currently lacks advanced validation; future iterations will refine UX.
 
 Affected files:
-- src/facturon_py/ui_tui/main_menu.py
+- src/facturon_py/services/__init__.py
+- src/facturon_py/services/invoice_service.py
+- src/facturon_py/ui_tui/invoice_flow.py
 - src/facturon_py/ui_tui/__init__.py
-- tests/test_main_menu.py
+- tests/test_invoice_service.py
 
 Test results (from COMMANDS.sh):
 - `pip install -r src/facturon_py/requirements.txt`
@@ -26,3 +28,4 @@ Test results (from COMMANDS.sh):
 - `pytest`
 
 Refs: #0
+

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -1,22 +1,26 @@
 ## Problem
-No main menu existed, so users couldn't navigate via keyboard or view shortcut hints.
+No service existed to create invoices and compute VAT totals, and the TUI lacked a flow for entering new invoices.
 
 ## Approach
-- Added prompt_toolkit main menu with Alt+number navigation.
-- Registered F1 in shortcut registry to display available keys.
-- Exposed `run_main_menu()` and covered selection/exit via simulated key presses.
+- Added `InvoiceService` with VAT snapshot and total calculations.
+- Introduced `new_invoice` wizard using `DateField` and `EditFormController`.
+- Exported the wizard from the TUI package.
+- Verified totals for a single invoice line with a unit test.
 
 ## Files Changed
-- `src/facturon_py/ui_tui/main_menu.py`
+- `src/facturon_py/services/__init__.py`
+- `src/facturon_py/services/invoice_service.py`
+- `src/facturon_py/ui_tui/invoice_flow.py`
 - `src/facturon_py/ui_tui/__init__.py`
-- `tests/test_main_menu.py`
+- `tests/test_invoice_service.py`
 - `COMMANDS.sh`
 - `PR.txt`
 - `LIMITS.txt`
 - `SUMMARY.md`
 
 ## Risks & Mitigations
-- Menu texts hardcoded in Hungarian → refactor for localization later.
+- Wizard uses simple text prompts; richer UI will come later.
 
 ## Assumptions
-- Alt+digit mapping is adequate for initial navigation.
+- VAT rates supplied via an in-memory table; persistence postponed.
+

--- a/src/facturon_py/services/__init__.py
+++ b/src/facturon_py/services/__init__.py
@@ -1,0 +1,5 @@
+"""Business service layer for Facturon-Py."""
+
+from .invoice_service import InvoiceService, Invoice, InvoiceItem
+
+__all__ = ["InvoiceService", "Invoice", "InvoiceItem"]

--- a/src/facturon_py/services/invoice_service.py
+++ b/src/facturon_py/services/invoice_service.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from decimal import Decimal, ROUND_HALF_EVEN
+from typing import Iterable, Mapping
+
+
+TWOPLACES = Decimal("0.01")
+
+
+def _q(value: Decimal) -> Decimal:
+    return value.quantize(TWOPLACES, ROUND_HALF_EVEN)
+
+
+@dataclass
+class InvoiceItem:
+    description: str
+    quantity: Decimal
+    unit_price: Decimal
+    vat_rate: Decimal  # percent
+
+    @property
+    def net(self) -> Decimal:
+        return _q(self.quantity * self.unit_price)
+
+    @property
+    def vat(self) -> Decimal:
+        return _q(self.net * self.vat_rate / Decimal("100"))
+
+    @property
+    def gross(self) -> Decimal:
+        return self.net + self.vat
+
+
+@dataclass
+class Invoice:
+    customer: str
+    supplier: str
+    issue_date: str
+    due_date: str
+    items: list[InvoiceItem] = field(default_factory=list)
+    net_total: Decimal = Decimal("0")
+    vat_total: Decimal = Decimal("0")
+    gross_total: Decimal = Decimal("0")
+
+
+class InvoiceService:
+    """Create invoices with VAT snapshot and totals."""
+
+    def __init__(self, tax_rates: Mapping[str, Decimal]):
+        self._tax_rates = tax_rates
+
+    def create_invoice(
+        self,
+        *,
+        customer: str,
+        supplier: str,
+        issue_date: str,
+        due_date: str,
+        items: Iterable[Mapping[str, Decimal | str]],
+    ) -> Invoice:
+        line_items: list[InvoiceItem] = []
+        for data in items:
+            vat_code = str(data["vat_code"])
+            vat_rate = self._tax_rates[vat_code]
+            item = InvoiceItem(
+                description=str(data["description"]),
+                quantity=Decimal(str(data["quantity"])),
+                unit_price=Decimal(str(data["unit_price"])),
+                vat_rate=vat_rate,
+            )
+            line_items.append(item)
+
+        net_total = _q(sum((item.net for item in line_items), Decimal("0")))
+        vat_total = _q(sum((item.vat for item in line_items), Decimal("0")))
+        gross_total = _q(sum((item.gross for item in line_items), Decimal("0")))
+
+        return Invoice(
+            customer=customer,
+            supplier=supplier,
+            issue_date=issue_date,
+            due_date=due_date,
+            items=line_items,
+            net_total=net_total,
+            vat_total=vat_total,
+            gross_total=gross_total,
+        )
+
+
+__all__ = ["InvoiceService", "Invoice", "InvoiceItem"]

--- a/src/facturon_py/ui_tui/__init__.py
+++ b/src/facturon_py/ui_tui/__init__.py
@@ -1,5 +1,6 @@
 from .main_menu import run_main_menu
 from .detail_view import DetailView
+from .invoice_flow import new_invoice
 from . import shortcuts
 
-__all__ = ["run_main_menu", "DetailView", "shortcuts"]
+__all__ = ["run_main_menu", "DetailView", "shortcuts", "new_invoice"]

--- a/src/facturon_py/ui_tui/invoice_flow.py
+++ b/src/facturon_py/ui_tui/invoice_flow.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Mapping, Sequence
+
+from prompt_toolkit import prompt
+
+from facturon_py.services.invoice_service import Invoice, InvoiceService
+from .edit_views.edit_form import EditFormController
+from .widgets.date_field import DateField
+
+
+def new_invoice(
+    customers: Sequence[str],
+    *,
+    supplier: str,
+    tax_rates: Mapping[str, Decimal],
+) -> Invoice:
+    for idx, name in enumerate(customers, 1):
+        print(f"{idx}. {name}")
+    selected = int(prompt("Select customer: ")) - 1
+    customer = customers[selected]
+
+    issue_field = DateField()
+    issue_date = issue_field.normalize(prompt(issue_field.prompt()))
+
+    due_field = DateField()
+    due_date = due_field.normalize(prompt(due_field.prompt()))
+
+    items = []
+    while True:
+        controller = EditFormController(
+            {
+                "description": "",
+                "quantity": Decimal("1"),
+                "unit_price": Decimal("0"),
+                "vat_code": "27",
+            }
+        )
+        controller.update_field("description", prompt("Item description: "))
+        controller.update_field("quantity", Decimal(prompt("Quantity: ")))
+        controller.update_field("unit_price", Decimal(prompt("Unit price: ")))
+        controller.update_field("vat_code", prompt("VAT code: "))
+        items.append(controller.data)
+        if prompt("Add another item? (y/N): ").lower() != "y":
+            break
+
+    service = InvoiceService(tax_rates)
+    return service.create_invoice(
+        customer=customer,
+        supplier=supplier,
+        issue_date=issue_date,
+        due_date=due_date,
+        items=items,
+    )
+
+
+__all__ = ["new_invoice"]

--- a/tests/test_invoice_service.py
+++ b/tests/test_invoice_service.py
@@ -1,0 +1,25 @@
+from decimal import Decimal
+
+from facturon_py.services.invoice_service import InvoiceService
+
+
+def test_single_item_totals() -> None:
+    service = InvoiceService({"27": Decimal("27")})
+    invoice = service.create_invoice(
+        customer="Alice",
+        supplier="ACME",
+        issue_date="2025-08-19",
+        due_date="2025-08-20",
+        items=[
+            {
+                "description": "Service",
+                "quantity": Decimal("1"),
+                "unit_price": Decimal("1000"),
+                "vat_code": "27",
+            }
+        ],
+    )
+    assert invoice.net_total == Decimal("1000.00")
+    assert invoice.vat_total == Decimal("270.00")
+    assert invoice.gross_total == Decimal("1270.00")
+    assert invoice.items[0].vat_rate == Decimal("27")


### PR DESCRIPTION
## Problem
No invoice creation logic or wizard existed, so VAT totals couldn't be computed.

## Approach
Implemented `InvoiceService` for VAT snapshot and totals, added `new_invoice` wizard leveraging `DateField` and `EditFormController`, and covered totals with a unit test.

## Alternatives considered
Deferring the TUI until full persistence was rejected to keep vertical slice progress.

## Risk & mitigations
Wizard currently lacks advanced validation; future iterations will refine UX.

## Affected files
- src/facturon_py/services/__init__.py
- src/facturon_py/services/invoice_service.py
- src/facturon_py/ui_tui/invoice_flow.py
- src/facturon_py/ui_tui/__init__.py
- tests/test_invoice_service.py

## Test results (from COMMANDS.sh)
- `pip install -r src/facturon_py/requirements.txt`
- `ruff check src/facturon_py tests`
- `black src/facturon_py tests`
- `pytest` *(terminated early; see notes)*

Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68a436206c54832297ad0102740b7ba5